### PR TITLE
Enable easy configuration of server API location

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -8,6 +8,7 @@
 	<script src="javascript/lib/zip.js"></script>
 	<script src="javascript/lib/deflate.js"></script>
 	<script src="javascript/lib/inflate.js"></script>
+ 	<script src="javascript/Config.js"></script>
  	<script src="javascript/MatrixManager.js"></script>
   	<script src="javascript/NGCHM_Util.js"></script>
 	<script src="javascript/SelectionManager.js"></script>

--- a/NGCHM/WebContent/javascript/Config.js
+++ b/NGCHM/WebContent/javascript/Config.js
@@ -1,0 +1,11 @@
+
+// Define/use Namespace for NgChm Application
+var NgChm = NgChm || { };
+NgChm.CFG = NgChm.CFG || {};
+
+// Location at which NGCHM server can be contacted.
+// Must end with a /.
+NgChm.CFG.api = 'api/';
+
+// Location of script for defining custom link outs etc.
+NgChm.CFG.custom_script = 'javascript/custom/custom.js';

--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -266,7 +266,7 @@ NgChm.CUST.verbose = false;
 	    var script = document.createElement('script');
 	    head.appendChild(script);
 	    script.type = 'text/javascript';
-	    script.src = 'javascript/custom/custom.js';
+	    script.src = NgChm.CFG.custom_script;
         // Most browsers:   NOTE: The next 2 lines of code are replaced when building ngchmApp.html and ngchmWidget-min.js (the "file mode" and "widget" versions of the application)
         script.onload = NgChm.CUST.definePluginLinkouts;
         // Internet explorer:

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -680,7 +680,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	
 	function webSaveMapProperties(jsonData) {
 		var success = "false";
-		var name = "SaveMapProperties?map=" + heatMapName;
+		var name = NgChm.CFG.api + "SaveMapProperties?map=" + heatMapName;
 		var req = new XMLHttpRequest();
 		req.open("POST", name, false);
 		req.setRequestHeader("Content-Type", "application/json");
@@ -879,7 +879,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 			var req = new XMLHttpRequest();
 			var name = "GetTile?map=" + heatMapName + "&datalayer=" + layer + "&level=" + level + "&tile=" + tileName;
 			if (fileSrc == NgChm.MMGR.WEB_SOURCE) {
-				req.open("GET", "GetTile?map=" + heatMapName + "&datalayer=" + layer + "&level=" + level + "&tile=" + tileName, true);
+				req.open("GET", NgChm.CFG.api + "GetTile?map=" + heatMapName + "&datalayer=" + layer + "&level=" + level + "&tile=" + tileName, true);
 			} else {
 				req.open("GET", NgChm.MMGR.localRepository+"/"+NgChm.MMGR.embeddedMapName+"/"+layer+"/"+level+"/"+tileName+".bin");
 				
@@ -929,7 +929,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 		if (fileSrc !== NgChm.MMGR.WEB_SOURCE) {
 			req.open("GET", NgChm.MMGR.localRepository+"/"+NgChm.MMGR.embeddedMapName+"/"+jsonFile+".json");
 		} else {
-			req.open("GET", "GetDescriptor?map=" + heatMapName + "&type=" + jsonFile, true);
+			req.open("GET", NgChm.CFG.api + "GetDescriptor?map=" + heatMapName + "&type=" + jsonFile, true);
 		}
 		req.onreadystatechange = function () {
 			if (req.readyState == req.DONE) {

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -711,7 +711,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	
 	function zipMapProperties(jsonData) {
 		var success = "";
-		var name = "ZippedMap?map=" + heatMapName; 
+		var name = NgChm.CFG.api + "ZippedMap?map=" + heatMapName; 
 		callServlet("POST", name, jsonData);
 		return true;
 	}


### PR DESCRIPTION
Moves API location to a location separate from NGCHM viewer, so
that it simplifies writing rules for front-end proxies etc.

Define that location in this small static file so that it can be
changed easily.  (e.g. by having proxy redirect to a customized file.)

Also include location of linkout customization script here as well.