### PR TITLE
Don't crash on bad meta data.

### DIFF
--- a/NGCHM/src/mda/ngchm/datagenerator/ShaidyRMapGen.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/ShaidyRMapGen.java
@@ -317,7 +317,12 @@ public class ShaidyRMapGen {
 					String k = metadata[0].trim();
 					if (labelPosition.containsKey(k)) {
 						int idx = labelPosition.get(k);
-						values[idx] = metadata[1].trim();
+                                                if (metadata.length < 2) {
+                                                    // Don't crash here on bad meta data.  Errors will cause a halt later.
+						    values[idx] = "";
+                                                } else {
+						    values[idx] = metadata[1].trim();
+                                                }
 						if (keys[idx].equals(EmptyString)) { keys[idx] = k; }
 					}
 					line = br.readLine();


### PR DESCRIPTION
ShaidyMapGen was crashing before it could output error messages.  This prevents the crash so the
error messages can be output.