### PR TITLE
Big fixes and drawing speed ups

### DIFF
--- a/NGCHM/WebContent/javascript/ColorMapManager.js
+++ b/NGCHM/WebContent/javascript/ColorMapManager.js
@@ -192,6 +192,9 @@ NgChm.CMM.ColorMap = function(colorMapObj) {
 		var lowerColor = rgbaColors[bounds["lower"]];
 		var upperColor = rgbaColors[bounds["upper"]];
 		// lowerColor and upperColor should be in { r:###, g:###, b:### } format
+                if (!lowerColor || !upperColor) {
+                    console.log ('Color limit missing');
+                }
 		var color = {};
 		color["r"] = Math.round(lowerColor["r"] * (1.0 - ratio) + upperColor["r"] * ratio);
 	    color["g"] = Math.round(lowerColor["g"] * (1.0 - ratio) + upperColor["g"] * ratio);

--- a/NGCHM/WebContent/javascript/Dendrogram.js
+++ b/NGCHM/WebContent/javascript/Dendrogram.js
@@ -47,17 +47,18 @@ NgChm.DDR.DendroMatrix = function(numRows, numCols,isRow){
 	//For performance on large maps, it is faster to reduce the matrix and draw than it is to
 	//draw with scaling.  This function creates a reduced size representation of the matrix
 	this.scaleMatrix =  function(newRows, newCols) {
-		var newMatrix = new NgChm.DDR.DendroMatrix(newRows, newCols, isRow);
+		const newMatrix = new NgChm.DDR.DendroMatrix(newRows, newCols, isRow);
 		
-		var yRatio = newRows/numRows;
-		var xRatio = newCols/numCols;
-		var position = 0;
+		const yRatio = newRows/numRows;
+		const xRatio = newCols/numCols;
+		let position = 0;
 		
-		for (var y=0; y<numRows; y++){
-			for (var x=0; x<numCols; x++){
-				val = matrixData[position];
+		for (let y=0; y<numRows; y++){
+                        const yPosn = Math.floor(y*yRatio);
+			for (let x=0; x<numCols; x++){
+				const val = matrixData[position];
 				if (val > 0){
-					newMatrix.setTrue(Math.floor(y*yRatio),Math.floor(x*xRatio),val==2)
+					newMatrix.setTrue(yPosn,Math.floor(x*xRatio),val==2)
 				}
 				position++;
 			}
@@ -72,13 +73,13 @@ NgChm.DDR.DendroMatrix = function(numRows, numCols,isRow){
 	//When a matrix is scaled up, sometimes the horizontal lines get holes. This routine
 	//patches up the holes in the dendro matrix.
 	this.fillHoles = function() {
-		for (var y=numRows; y>0; y--){
-			for (var x=0; x<numCols; x++){
-				val = this.get(y, x);
+		for (let y=numRows; y>0; y--){
+			for (let x=0; x<numCols; x++){
+				const val = this.get(y, x);
 				if (val > 0 && y > 1){
-					below = this.get(y-1,x);
-					above = this.get(y+1,x);
-					left = this.get(y,x-1);
+					const below = this.get(y-1,x);
+					const above = this.get(y+1,x);
+					const left = this.get(y,x-1);
 					if (below == 0 && this.get(y, x+1) == 0 && this.getNumCols()%(x+1) !==0){ // check to see if this is a gap in a cross bar
 						this.setTrue(y, x+1, val==2);
 					} else if (below > 0 && above == 0 && left ==0 && this.get(y,x+1)==0){ // check to see if this is a gap in a left branch

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -552,12 +552,11 @@ NgChm.DET.getDetCanvasXFromCol = function (col) {
  * 2 arrays is empty, lines will be drawn otherwise boxes.  
  *********************************************************************************************/
 NgChm.DET.drawSelections = function () {
-	var ctx=NgChm.DET.boxCanvas.getContext("2d");
+	const ctx=NgChm.DET.boxCanvas.getContext("2d");
 	ctx.clearRect(0, 0, NgChm.DET.boxCanvas.width, NgChm.DET.boxCanvas.height);
 
 	//Draw the border
 	if (NgChm.heatMap.getMapInformation().map_cut_rows+NgChm.heatMap.getMapInformation().map_cut_cols == 0) {
-		var ctx=NgChm.DET.boxCanvas.getContext("2d");
 		var boxX = (NgChm.DET.calculateTotalClassBarHeight("row") / NgChm.DET.canvas.width) * NgChm.DET.boxCanvas.width;
 		var boxY = (NgChm.DET.calculateTotalClassBarHeight("column") / NgChm.DET.canvas.height) * NgChm.DET.boxCanvas.height;
 		var boxW = NgChm.DET.boxCanvas.width-boxX;
@@ -581,7 +580,7 @@ NgChm.DET.drawSelections = function () {
 				var range = colRanges[i];
 				var colStart = range[0];
 				var colEnd = range[1];
-				NgChm.DET.drawSearchBox(0,NgChm.heatMap.getNumRows('d'),colStart,colEnd);
+				NgChm.DET.drawSearchBox(ctx, 0,NgChm.heatMap.getNumRows('d'),colStart,colEnd);
 			}
 		} else if (colRanges.length === 0) {
 			//Draw vertical lines across entire heatMap
@@ -589,7 +588,7 @@ NgChm.DET.drawSelections = function () {
 				var range = rowRanges[i];
 				var rowStart = range[0];
 				var rowEnd = range[1];
-				NgChm.DET.drawSearchBox(rowStart,rowEnd,0,NgChm.heatMap.getNumColumns('d'));
+				NgChm.DET.drawSearchBox(ctx, rowStart,rowEnd,0,NgChm.heatMap.getNumColumns('d'));
 			}
 		} else {
 			for (var i=0;i<rowRanges.length;i++) {
@@ -601,8 +600,8 @@ NgChm.DET.drawSelections = function () {
 					var colRange = colRanges[j];
 					var colStart = colRange[0];
 					var colEnd = colRange[1];
-					NgChm.DET.drawSearchBox(rowStart,rowEnd,colStart,colEnd);
-				}				
+					NgChm.DET.drawSearchBox(ctx, rowStart,rowEnd,colStart,colEnd);
+				}
 			}
 		}
 	}
@@ -649,7 +648,7 @@ NgChm.DET.getContigSearchRanges = function (searchArr) {
  * This function draws lines on the heatMap detail box canvas for each contiguous search 
  * range that the user has specified (by click dragging, label selecting, or dendro clicking).
  *********************************************************************************************/
-NgChm.DET.drawSearchBox = function (csRowStart, csRowEnd, csColStart, csColEnd) {
+NgChm.DET.drawSearchBox = function (ctx, csRowStart, csRowEnd, csColStart, csColEnd) {
 
 	//top-left corner of visible area
 	var topX = ((NgChm.DET.calculateTotalClassBarHeight("row") / NgChm.DET.canvas.width) * NgChm.DET.boxCanvas.width);
@@ -690,19 +689,19 @@ NgChm.DET.drawSearchBox = function (csRowStart, csRowEnd, csColStart, csColEnd) 
 
 	// draw top horizontal line
 	if (NgChm.DET.isHorizLineVisible(topY, boxY)) {
-		NgChm.DET.drawHorizLine(topX,boxX, boxX2, boxY);
+		NgChm.DET.drawHorizLine(ctx, topX,boxX, boxX2, boxY);
 	}
 	// draw left side line
 	if (NgChm.DET.isVertLineVisible(topX, boxX)) {
-		NgChm.DET.drawVertLine(topY, boxY, boxY2, boxX);
+		NgChm.DET.drawVertLine(ctx, topY, boxY, boxY2, boxX);
 	}
 	// draw bottom line
 	if (NgChm.DET.isHorizLineVisible(topY, boxY2)) {
-		NgChm.DET.drawHorizLine(topX,boxX, boxX2, boxY2);
+		NgChm.DET.drawHorizLine(ctx, topX,boxX, boxX2, boxY2);
 	}
 	// draw right side line
 	if (NgChm.DET.isVertLineVisible(topX, boxX2)) {
-		NgChm.DET.drawVertLine(topY, boxY, boxY2, boxX2);
+		NgChm.DET.drawVertLine(ctx, topY, boxY, boxY2, boxX2);
 	}
 }
 
@@ -727,19 +726,19 @@ NgChm.DET.isVertLineVisible = function (topX, boxX) {
  * viewport.   If only a portion of the line is visible on the top or left border, the length 
  * of the line will be amended to stop at the border.
  *********************************************************************************************/
-NgChm.DET.drawHorizLine = function (topX, boxX, boxX2, boxY) {
+NgChm.DET.drawHorizLine = function (ctx, topX, boxX, boxX2, boxY) {
 	var lineStart = boxX >= topX ? boxX : topX;
 	var lineEnd = boxX2 >= topX ? boxX2 : topX;
 	if (lineStart !== lineEnd) {
-		NgChm.DET.strokeLine(lineStart,boxY,lineEnd, boxY);
+		NgChm.DET.strokeLine(ctx, lineStart,boxY,lineEnd, boxY);
 	}
 }
 
-NgChm.DET.drawVertLine = function (topY, boxY, boxY2, boxX) {
+NgChm.DET.drawVertLine = function (ctx, topY, boxY, boxY2, boxX) {
 	var lineStart = boxY >= topY ? boxY : topY;
 	var lineEnd = boxY2 >= topY ? boxY2 : topY;
 	if (lineStart !== lineEnd) {
-		NgChm.DET.strokeLine(boxX,lineStart,boxX, lineEnd);
+		NgChm.DET.strokeLine(ctx,boxX,lineStart,boxX, lineEnd);
 	}
 }
 
@@ -749,8 +748,7 @@ NgChm.DET.drawVertLine = function (topY, boxY, boxY2, boxX) {
  * This function draws lines on the heatMap detail box canvas for each contiguous search 
  * range that the user has specified (by click dragging, label selecting, or dendro clicking).
  *********************************************************************************************/
-NgChm.DET.strokeLine = function (fromX, fromY, toX,toY) {
-	var ctx=NgChm.DET.boxCanvas.getContext("2d");
+NgChm.DET.strokeLine = function (ctx, fromX, fromY, toX,toY) {
 	ctx.beginPath();
 	ctx.moveTo(fromX,fromY);
 	ctx.lineTo(toX, toY); 

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -1000,16 +1000,21 @@ NgChm.MMGR.HeatMapData = function(heatMapName, level, jsonData, datalayers, lowe
 		arrayData = tileCache[NgChm.SEL.currentDl+"."+level+"."+tileRow+"."+tileCol];   
 
 		//If we have the tile, use it.  Otherwise, use a lower resolution tile to provide a value.
+            let retval;
 	    if (arrayData != undefined) {
 	    	//for end tiles, the # of columns can be less than the colsPerTile - figure out the correct num columns.
 			var thisTileColsPerRow = tileCol == numTileColumns ? ((this.totalColumns % colsPerTile) == 0 ? colsPerTile : this.totalColumns % colsPerTile) : colsPerTile; 
 			//Tile data is in one long list of numbers.  Calculate which position maps to the row/column we want.
-	    	return arrayData[(row-1)%rowsPerTile * thisTileColsPerRow + (column-1)%colsPerTile];
+		retval = arrayData[(row-1)%rowsPerTile * thisTileColsPerRow + (column-1)%colsPerTile];
 	    } else if (lowerLevel != null) {
-	    	return lowerLevel.getValue(Math.floor(row/rowToLower) + 1, Math.floor(column/colToLower) + 1);
+		retval = lowerLevel.getValue(Math.floor((row-1)/rowToLower) + 1, Math.floor((column-1)/colToLower) + 1);
 	    } else {
-	    	return 0;
+		retval = 0;
 	    }	
+            if (retval === undefined) {
+                console.log ('getValue undefined');
+            }
+            return retval;
 	};
 
 	// External user of the matix data lets us know where they plan to read.

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -84,6 +84,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	//This holds the various zoom levels of data.
 	var mapConfig = null;
 	var mapData = null;
+        var mapDataComputed = {};
 	var datalevels = {};
 	var tileCache = {};
 	var zipFiles = {};
@@ -354,13 +355,43 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	}
 	
 	this.getRowDendroData = function() {
-		return mapData.row_data.dendrogram ? mapData.row_data.dendrogram : [];
+		if (!mapDataComputed.hasOwnProperty('row_dendrogram_data')) {
+		    mapDataComputed.row_dendrogram_data = (mapData.row_data.dendrogram || [])
+                    .map(entry => {
+			const tokes = entry.split(",");
+                        // index is the location of the bar in the clustered data
+                        return { left: Number(tokes[0]), right: Number(tokes[1]), height: Number(tokes[2]) };
+                    });
+                }
+		return mapDataComputed.row_dendrogram_data;
 	}
 	
 	this.getColDendroData = function() {
-		return mapData.col_data.dendrogram ? mapData.col_data.dendrogram : [];
+		if (!mapDataComputed.hasOwnProperty('col_dendrogram_data')) {
+		    mapDataComputed.col_dendrogram_data = (mapData.col_data.dendrogram || [])
+                    .map(entry => {
+			const tokes = entry.split(",");
+                        // index is the location of the bar in the clustered data
+                        return { left: Number(tokes[0]), right: Number(tokes[1]), height: Number(tokes[2]) };
+                    });
+                }
+		return mapDataComputed.col_dendrogram_data;
 	}
-	
+
+        this.getRowDendroMaxHeight = function() {
+		if (!mapDataComputed.hasOwnProperty('row_dendrogram_max_height')) {
+			mapDataComputed.row_dendrogram_max_height = this.getRowDendroData().reduce((max,entry) => entry.height > max ? entry.height : max, 0);
+                }
+                return mapDataComputed.row_dendrogram_max_height;
+        }
+
+        this.getColDendroMaxHeight = function() {
+		if (!mapDataComputed.hasOwnProperty('col_dendrogram_max_height')) {
+			mapDataComputed.col_dendrogram_max_height = this.getColDendroData().reduce((max,entry) => entry.height > max ? entry.height : max, 0);
+                }
+                return mapDataComputed.col_dendrogram_max_height;
+        }
+
 	this.setRowDendrogramShow = function(value) {
 		mapConfig.row_configuration.dendrogram.show = value;
 	}
@@ -816,6 +847,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	
 	function addMapData(md) {
 		mapData = md;
+                mapDataComputed = {};
 		NgChm.CM.mapDataCompatibility(mapData);
 		sendCallBack(NgChm.MMGR.Event_JSON);
 	}


### PR DESCRIPTION
This pull request includes:
- some fixes to illegal data accesses in vertical ribbon mode
- fixes to undeclared local variables
- various changes to enhance drawing speed, including:
- label width memoization
- label blanking during redraw
- parsing dendrogram data once
- using a single context for drawing selections.

Depending on the particular circumstances, drawing can be a factor of 2-3 times faster based on my tests with Chrome.
