### PR TITLE
Enable enclosing window to request map details be posted to it.

### DIFF
--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -51,7 +51,7 @@ window.addEventListener('message', NgChm.UHM.processMessage, false);
 
 /* Format the pixel information for display in the helpContents table.
  */
-NgChm.UHM.displayMapDetails = function (helpContents, pixelInfo) {
+NgChm.UHM.formatMapDetails = function (helpContents, pixelInfo) {
 	helpContents.insertRow().innerHTML = NgChm.UHM.formatBlankRow();
 	NgChm.UHM.setTableRow(helpContents, ["<u>"+"Data Details"+"</u>", "&nbsp;"], 2);
 	NgChm.UHM.setTableRow(helpContents,["&nbsp;Value:", pixelInfo.value]);


### PR DESCRIPTION
This feature is intended for use by a document that includes
the NGCHM in an iframe:
- The enclosing window includes a secret nonce as an extra parameter
  in the NGCHM URL  ....?nonce=value&...  Any random value will suffice.
- The enclosing window posts a message to the iframe including the nonce:
  { nonce: value, override: 'ShowMapDetails' }
- Instead of displaying map details itself, the NgChm will post messages
  to the enclosing window.  The message will include the nonce as well
  as details about the current pixel.