### PR TITLE
Use closure compiler instead of yui to compress javascript.

### DIFF
--- a/NGCHM/WebContent/WEB-INF/lib/closure-compiler/COPYING
+++ b/NGCHM/WebContent/WEB-INF/lib/closure-compiler/COPYING
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NGCHM/WebContent/WEB-INF/lib/closure-compiler/README.md
+++ b/NGCHM/WebContent/WEB-INF/lib/closure-compiler/README.md
@@ -1,0 +1,501 @@
+# [Google Closure Compiler](https://developers.google.com/closure/compiler/)
+
+[![Build Status](https://travis-ci.org/google/closure-compiler.svg?branch=master)](https://travis-ci.org/google/closure-compiler)
+[![Open Source Helpers](https://www.codetriage.com/google/closure-compiler/badges/users.svg)](https://www.codetriage.com/google/closure-compiler)
+
+The [Closure Compiler](https://developers.google.com/closure/compiler/) is a tool for making JavaScript download and run faster. It is a true compiler for JavaScript. Instead of compiling from a source language to machine code, it compiles from JavaScript to better JavaScript. It parses your JavaScript, analyzes it, removes dead code and rewrites and minimizes what's left. It also checks syntax, variable references, and types, and warns about common JavaScript pitfalls.
+
+## Getting Started
+ * [Download the latest version](https://dl.google.com/closure-compiler/compiler-latest.zip) ([Release details here](https://github.com/google/closure-compiler/wiki/Releases))
+ * [Download a specific version](https://github.com/google/closure-compiler/wiki/Binary-Downloads). Also available via:
+   - [Maven](https://github.com/google/closure-compiler/wiki/Maven)
+   - [NPM](https://www.npmjs.com/package/google-closure-compiler) - includes java, native and javascript versions.
+ * See the [Google Developers Site](https://developers.google.com/closure/compiler/docs/gettingstarted_app) for documentation including instructions for running the compiler from the command line.
+
+## Options for Getting Help
+1. Post in the [Closure Compiler Discuss Group](https://groups.google.com/forum/#!forum/closure-compiler-discuss).
+2. Ask a question on [Stack Overflow](https://stackoverflow.com/questions/tagged/google-closure-compiler).
+3. Consult the [FAQ](https://github.com/google/closure-compiler/wiki/FAQ).
+
+## Building it Yourself
+
+Note: The Closure Compiler requires [Java 8 or higher](https://www.java.com/).
+
+### Using [Maven](https://maven.apache.org/)
+
+1. Download [Maven](https://maven.apache.org/download.cgi).
+
+2. Add sonatype snapshots repository to `~/.m2/settings.xml`:
+   ```xml
+   <profile>
+     <id>allow-snapshots</id>
+        <activation><activeByDefault>true</activeByDefault></activation>
+     <repositories>
+       <repository>
+         <id>snapshots-repo</id>
+         <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+         <releases><enabled>false</enabled></releases>
+         <snapshots><enabled>true</enabled></snapshots>
+       </repository>
+     </repositories>
+   </profile>
+   ```
+
+3. On the command line, at the root of this project, run `mvn -DskipTests` (omit the `-DskipTests` if you want to run all the
+unit tests too).
+
+    This will produce a jar file called `target/closure-compiler-1.0-SNAPSHOT.jar`. You can run this jar
+    as per the [Running section](#running) of this Readme. If you want to depend on the compiler via
+    Maven in another Java project, use the `com.google.javascript/closure-compiler-unshaded` artifact.
+
+    Running `mvn -DskipTests -pl externs/pom.xml,pom-main.xml,pom-main-shaded.xml`
+    will skip building the GWT version of the compiler. This can speed up the build process significantly.
+
+### Using [Eclipse](https://www.eclipse.org/)
+
+1. Download and open [Eclipse IDE](https://www.eclipse.org/). Disable `Project > Build automatically` during this process.
+2. On the command line, at the root of this project, run `mvn eclipse:eclipse -DdownloadSources=true` to download JARs and build Eclipse project configuration.
+3. Run `mvn clean` and `mvn -DskipTests` to ensure AutoValues are generated and updated.
+4. In Eclipse, navigate to `File > Import > Maven > Existing Maven Projects` and browse to closure-compiler.
+5. Import both closure-compiler and the nested externs project.
+6. Disregard the warnings about maven-antrun-plugin and build errors.
+7. Configure the project to use the [Google Eclipse style guide](https://github.com/google/styleguide/blob/gh-pages/eclipse-java-google-style.xml)
+8. Edit `.classpath` in closure-compiler-parent. Delete the `<classpathentry ... kind="src" path="src" ... />` line, then add:
+   ```xml
+   <classpathentry excluding="com/google/debugging/sourcemap/super/**|com/google/javascript/jscomp/debugger/gwt/DebuggerGwtMain.java|com/google/javascript/jscomp/gwt/|com/google/javascript/jscomp/resources/super-gwt/**" kind="src" path="src"/>
+   <classpathentry kind="src" path="target/generated-sources/annotations"/>
+   ```
+9. Ensure the Eclipse project settings specify 1.8 compliance level in "Java Compiler".
+10. Build project in Eclipse (right click on the project `closure-compiler-parent` and select `Build Project`).
+11. See *Using Maven* above to build the JAR.
+
+## Running
+
+On the command line, at the root of this project, type
+
+```
+java -jar target/closure-compiler-1.0-SNAPSHOT.jar
+```
+
+This starts the compiler in interactive mode. Type
+
+```javascript
+var x = 17 + 25;
+```
+
+then hit "Enter", then hit "Ctrl-Z" (on Windows) or "Ctrl-D" (on Mac or Linux)
+and "Enter" again. The Compiler will respond:
+
+```javascript
+var x=42;
+```
+
+The Closure Compiler has many options for reading input from a file, writing
+output to a file, checking your code, and running optimizations. To learn more,
+type
+
+```
+java -jar compiler.jar --help
+```
+
+More detailed information about running the Closure Compiler is available in the
+[documentation](https://developers.google.com/closure/compiler/docs/gettingstarted_app).
+
+
+### Run using Eclipse
+
+1. Open the class `src/com/google/javascript/jscomp/CommandLineRunner.java` or create your own extended version of the class.
+2. Run the class in Eclipse.
+3. See the instructions above on how to use the interactive mode - but beware of the [bug](https://stackoverflow.com/questions/4711098/passing-end-of-transmission-ctrl-d-character-in-eclipse-cdt-console) regarding passing "End of Transmission" in the Eclipse console.
+
+
+## Compiling Multiple Scripts
+
+If you have multiple scripts, you should compile them all together with one
+compile command.
+
+```bash
+java -jar compiler.jar --js_output_file=out.js in1.js in2.js in3.js ...
+```
+
+You can also use minimatch-style globs.
+
+```bash
+# Recursively include all js files in subdirs
+java -jar compiler.jar --js_output_file=out.js 'src/**.js'
+
+# Recursively include all js files in subdirs, excluding test files.
+# Use single-quotes, so that bash doesn't try to expand the '!'
+java -jar compiler.jar --js_output_file=out.js 'src/**.js' '!**_test.js'
+```
+
+The Closure Compiler will concatenate the files in the order they're passed at
+the command line.
+
+If you're using globs or many files, you may start to run into
+problems with managing dependencies between scripts. In this case, you should
+use the [Closure Library](https://developers.google.com/closure/library/). It
+contains functions for enforcing dependencies between scripts, and Closure Compiler
+will re-order the inputs automatically.
+
+## How to Contribute
+### Reporting a bug
+1. First make sure that it is really a bug and not simply the way that Closure Compiler works (especially true for ADVANCED_OPTIMIZATIONS).
+ * Check the [official documentation](https://developers.google.com/closure/compiler/)
+ * Consult the [FAQ](https://github.com/google/closure-compiler/wiki/FAQ)
+ * Search on [Stack Overflow](https://stackoverflow.com/questions/tagged/google-closure-compiler) and in the [Closure Compiler Discuss Group](https://groups.google.com/forum/#!forum/closure-compiler-discuss)
+ * Look through the list of [compiler assumptions](https://github.com/google/closure-compiler/wiki/Compiler-Assumptions).
+2. If you still think you have found a bug, make sure someone hasn't already reported it. See the list of [known issues](https://github.com/google/closure-compiler/issues).
+3. If it hasn't been reported yet, post a new issue. Make sure to add enough detail so that the bug can be recreated. The smaller the reproduction code, the better.
+
+### Suggesting a Feature
+1. Consult the [FAQ](https://github.com/google/closure-compiler/wiki/FAQ) to make sure that the behaviour you would like isn't specifically excluded (such as string inlining).
+2. Make sure someone hasn't requested the same thing. See the list of [known issues](https://github.com/google/closure-compiler/issues).
+3. Read up on [what type of feature requests are accepted](https://github.com/google/closure-compiler/wiki/FAQ#how-do-i-submit-a-feature-request-for-a-new-type-of-optimization).
+4. Submit your request as an issue.
+
+### Submitting patches
+1. All contributors must sign a contributor license agreement (CLA).
+   A CLA basically says that you own the rights to any code you contribute,
+   and that you give us permission to use that code in Closure Compiler.
+   You maintain the copyright on that code.
+   If you own all the rights to your code, you can fill out an
+   [individual CLA](https://code.google.com/legal/individual-cla-v1.0.html).
+   If your employer has any rights to your code, then they also need to fill out
+   a [corporate CLA](https://code.google.com/legal/corporate-cla-v1.0.html).
+   If you don't know if your employer has any rights to your code, you should
+   ask before signing anything.
+   By default, anyone with an @google.com email address already has a CLA
+   signed for them.
+2. To make sure your changes are of the type that will be accepted, ask about your patch on the [Closure Compiler Discuss Group](https://groups.google.com/forum/#!forum/closure-compiler-discuss)
+3. Fork the repository.
+4. Make your changes. Check out our
+   [coding conventions](https://github.com/google/closure-compiler/wiki/Contributors#coding-conventions)
+   for details on making sure your code is in correct style.
+5. Submit a pull request for your changes. A project developer will review your work and then merge your request into the project.
+
+## Closure Compiler License
+
+Copyright 2009 The Closure Compiler Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+## Dependency Licenses
+
+### Rhino
+
+<table>
+  <tr>
+    <td>Code Path</td>
+    <td>
+      <code>src/com/google/javascript/rhino</code>, <code>test/com/google/javascript/rhino</code>
+    </td>
+  </tr>
+
+  <tr>
+    <td>URL</td>
+    <td>https://developer.mozilla.org/en-US/docs/Mozilla/Projects/Rhino</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>1.5R3, with heavy modifications</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>Netscape Public License and MPL / GPL dual license</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>A partial copy of Mozilla Rhino. Mozilla Rhino is an
+implementation of JavaScript for the JVM.  The JavaScript
+parse tree data structures were extracted and modified
+significantly for use by Google's JavaScript compiler.</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>The packages have been renamespaced. All code not
+relevant to the parse tree has been removed. A JsDoc parser and static typing
+system have been added.</td>
+  </tr>
+</table>
+
+### Args4j
+
+<table>
+  <tr>
+    <td>URL</td>
+    <td>http://args4j.kohsuke.org/</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>2.33</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>MIT</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>args4j is a small Java class library that makes it easy to parse command line
+options/arguments in your CUI application.</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### Guava Libraries
+
+<table>
+  <tr>
+    <td>URL</td>
+    <td>https://github.com/google/guava</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>20.0</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>Apache License 2.0</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>Google's core Java libraries.</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### JSR 305
+
+<table>
+  <tr>
+    <td>URL</td>
+    <td>https://github.com/findbugsproject/findbugs</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>3.0.1</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>BSD License</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>Annotations for software defect detection.</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### JUnit
+
+<table>
+  <tr>
+    <td>URL</td>
+    <td>http://junit.org/junit4/</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>4.12</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>Common Public License 1.0</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>A framework for writing and running automated tests in Java.</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### Protocol Buffers
+
+<table>
+  <tr>
+    <td>URL</td>
+    <td>https://github.com/google/protobuf</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>3.0.2</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>New BSD License</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>Supporting libraries for protocol buffers,
+an encoding of structured data.</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### Truth
+
+<table>
+  <tr>
+    <td>URL</td>
+    <td>https://github.com/google/truth</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>0.32</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>Apache License 2.0</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>Assertion/Proposition framework for Java unit tests</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### Ant
+
+<table>
+  <tr>
+    <td>URL</td>
+    <td>https://ant.apache.org/bindownload.cgi</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>1.9.7</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>Apache License 2.0</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>Ant is a Java based build tool. In theory it is kind of like "make"
+without make's wrinkles and with the full portability of pure java code.</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### GSON
+
+<table>
+  <tr>
+    <td>URL</td>
+    <td>https://github.com/google/gson</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>2.7</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>Apache license 2.0</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>A Java library to convert JSON to Java objects and vice-versa</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>None</td>
+  </tr>
+</table>
+
+### Node.js Closure Compiler Externs
+
+<table>
+  <tr>
+    <td>Code Path</td>
+    <td><code>contrib/nodejs</code></td>
+  </tr>
+
+  <tr>
+    <td>URL</td>
+    <td>https://github.com/dcodeIO/node.js-closure-compiler-externs</td>
+  </tr>
+
+  <tr>
+    <td>Version</td>
+    <td>e891b4fbcf5f466cc4307b0fa842a7d8163a073a</td>
+  </tr>
+
+  <tr>
+    <td>License</td>
+    <td>Apache 2.0 license</td>
+  </tr>
+
+  <tr>
+    <td>Description</td>
+    <td>Type contracts for NodeJS APIs</td>
+  </tr>
+
+  <tr>
+    <td>Local Modifications</td>
+    <td>Substantial changes to make them compatible with NpmCommandLineRunner.</td>
+  </tr>
+</table>

--- a/NGCHM/build_ngchmApp.xml
+++ b/NGCHM/build_ngchmApp.xml
@@ -6,14 +6,15 @@
     <property name="js.dir" value="${web.dir}javascript/"/>
     <property name="dir.jarfile" value="./WebContent/WEB-INF/lib"/>
     <property name="java.dir" value="./src/mda/ngchm/util/"/>
-
+    <property name="closure.compiler.jar" value="${dir.jarfile}/closure-compiler/closure-compiler-v20190528.jar"/>
     <target name="minimize_custom_js">
 	<apply executable="java" parallel="false">
 	    <fileset dir="${js.dir}" includes="custom/custom.js"/>
 	    <arg line="-jar"/>
-	    <arg path="${dir.jarfile}/yuicompressor-2.4.2.jar"/>
+	    <arg path="${closure.compiler.jar}"/>
+	    <arg line="--js"/>
 	    <srcfile/>
-	    <arg line="-o"/>
+	    <arg line="--js_output_file"/>
 	    <mapper type="glob" from="*.js" to="${js.dir}*-min.js"/>
 	    <targetfile/>
 	</apply>
@@ -38,9 +39,10 @@
         <apply executable="java" parallel="false">
             <fileset dir="${js.dir}" includes="ngchm.js"/>
             <arg line="-jar"/>
-            <arg path="${dir.jarfile}/yuicompressor-2.4.2.jar"/>
+            <arg path="${closure.compiler.jar}"/>
+            <arg line="--js"/>
             <srcfile/>
-            <arg line="-o"/>
+            <arg line="--js_output_file"/>
             <mapper type="glob" from="*.js" to="${js.dir}*-min.js"/>
             <targetfile/>
         </apply>


### PR DESCRIPTION
Closure compiler outputs some warnings, at least some of which
look like real bugs.  I haven't addressed them in this patch.

The compiled/minified javascript appears to work, but I haven't done
extensive checks yet.