### PR TITLE
Tileio

### DIFF
--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -263,7 +263,22 @@ NgChm.UTIL.convertToArray = function(value) {
 	var valArr = [];
 	valArr.push(value);
 	return valArr;
-}
+};
+
+/**********************************************************************************
+ * Perform Early Initializations.
+ *
+ * Perform latency sensitive initializations.  Note that the complete sources
+ * have not loaded yet.
+ **********************************************************************************/
+(function () {
+	//Call functions that enable viewing in IE.
+	NgChm.UTIL.iESupport();
+
+	if (NgChm.MMGR.embeddedMapName === null && NgChm.UTIL.getURLParameter('map') !== '') {
+		NgChm.MMGR.createWebTileLoader();
+	}
+})();
 
 /**********************************************************************************
  * FUNCTION - onLoadCHM: This function performs "on load" processing for the NG_CHM
@@ -271,8 +286,6 @@ NgChm.UTIL.convertToArray = function(value) {
  * viewer.  
  **********************************************************************************/
 NgChm.UTIL.onLoadCHM = function (sizeBuilderView) {
-	//Call functions that enable viewing in IE.
-	NgChm.UTIL.iESupport();
 	NgChm.UTIL.setBrowserMinFontSize();
 	//Run startup checks that enable startup warnings button.
 	NgChm.UTIL.startupChecks();


### PR DESCRIPTION
Changes to tile I/O and caching:
- Use a worker for fetching tiles to overlap I/O and script execution
- Don't issue multiple requests for the same tile (because new fetch request occurs before tile has been received)
- Prefetch initial tiles in a slightly different order so that detail view can render earlier.