### PR TITLE
Bugfix: don't try to access color/break -1 if colorVal < firstbreak

### DIFF
--- a/NGCHM/src/mda/ngchm/datagenerator/InputClass.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/InputClass.java
@@ -479,13 +479,17 @@ public class InputClass {
             while (Float.parseFloat(classBreaks.get(i)) <= eVal && i < classBreaks.size()-1){
             	i++;
             };
-            Color lowCol = classColors.get(i-1);
-            Color hiCol = classColors.get(i);
-            float low = Float.parseFloat(classBreaks.get(i-1));
-            float hi = Float.parseFloat(classBreaks.get(i));
-            float ratio = (hi-eVal)/(hi-low);
-            Color breakColor = ColorMapGenerator.blendColors(hiCol,lowCol,ratio);
-            rgb = breakColor.getRGB();
+	    if (i == 0) {
+		rgb = classColors.get(i).getRGB();
+	    } else {
+                Color lowCol = classColors.get(i-1);
+                Color hiCol = classColors.get(i);
+                float low = Float.parseFloat(classBreaks.get(i-1));
+                float hi = Float.parseFloat(classBreaks.get(i));
+                float ratio = (hi-eVal)/(hi-low);
+                Color breakColor = ColorMapGenerator.blendColors(hiCol,lowCol,ratio);
+                rgb = breakColor.getRGB();
+	    }
     	}
     	return rgb;
 	}


### PR DESCRIPTION
This prevents ShaidyMapGen from dying if eVal is less than the first break.

This loop was terminating with i == 0 and the attempt to access element -1 was causing an access error.