### PR TITLE
Speed up calculation of many label widths by reducing forced reflows

### DIFF
--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -1166,8 +1166,8 @@ NgChm.DET.setButtons = function () {
 }
 
 NgChm.DET.setDetCanvasBoxSize = function () {
-	NgChm.DET.boxCanvas.width =  NgChm.DET.canvas.clientWidth + 'px';
-	NgChm.DET.boxCanvas.height = NgChm.DET.canvas.clientHeight + 'px';
+	NgChm.DET.boxCanvas.width =  NgChm.DET.canvas.clientWidth;
+	NgChm.DET.boxCanvas.height = NgChm.DET.canvas.clientHeight;
 	NgChm.DET.boxCanvas.style.left=NgChm.DET.canvas.style.left;
 	NgChm.DET.boxCanvas.style.top=NgChm.DET.canvas.style.top;
 }

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -805,6 +805,8 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 		var name = "";
 		if (fileSrc === NgChm.MMGR.FILE_SOURCE){
 			name += NgChm.CM.viewerAppUrl;
+		} else {
+			name = NgChm.CFG.api;
 		}
 		name += "ZipAppDownload"; 
 		callServlet("POST", name, false);


### PR DESCRIPTION
This is a small patch to improve the performance of label width calculations when a large number are
needed.  This includes startup to a modest degree and panning when zoomed out far enough for many labels to be displayed.

I've added the commit after the stdhtml merge request since that should happen first.