### PR TITLE
NgChm Viewer Release 2.17.2

### DIFF
--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,7 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.17.1";
+NgChm.CM.version = "2.17.2";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -177,7 +177,8 @@ NgChm.CUST.verbose = false;
 	    linkoutFn = (function(lofn) {
 		return function(labels) {
 		    if (labels.length===0 || labels[0]==="-") {
-			alert("No information known for the selected label");
+			//console.log("No information known for the selected label"); //alert
+			NgChm.UHM.systemMessage("NG-CHM Plug-in", "No information known for the selected label.")
 		    } else {
 			lofn(labels);
 		    }
@@ -189,14 +190,15 @@ NgChm.CUST.verbose = false;
 		    var idx = labels.indexOf("-");
 		    if (idx >= 0) labels.splice(idx,1);
 		    if (labels.length===0) {
-			alert("No information known for any selected label");
+		    	//console.log("No information known for any selected label"); //alert
+				NgChm.UHM.systemMessage("NG-CHM Plug-in", "No information known for any selected label.")
 		    } else {
 			lofn(labels);
 		    }
 		};
 	    })(linkoutFn);
 	} else {
-	    alert('Unknown selectMode: ' + selectMode);
+		console.log('Unknown selectMode: ' + selectMode); //alert
 	}
 
 	if (NgChm.CUST.allTypes.indexOf( typeName ) >= 0) {

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -3158,7 +3158,7 @@ NgChm.DET.getDetVertexShader = function (theGL) {
 	theGL.shaderSource(shader, source);
 	theGL.compileShader(shader);
 	if (!theGL.getShaderParameter(shader, theGL.COMPILE_STATUS)) {
-        alert(theGL.getShaderInfoLog(shader));
+		console.log(theGL.getShaderInfoLog(shader)); //alert
     }
 
 	return shader;
@@ -3178,7 +3178,7 @@ NgChm.DET.getDetFragmentShader = function (theGL) {
 	theGL.shaderSource(shader, source);
 	theGL.compileShader(shader);
 	if (!theGL.getShaderParameter(shader, theGL.COMPILE_STATUS)) {
-        alert(theGL.getShaderInfoLog(shader));
+		console.log(theGL.getShaderInfoLog(shader)); //alert
     }
 
 	return shader;

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -798,7 +798,7 @@ NgChm.createNS('NgChm.LNK');
 		};
 
 		NgChm.LNK.getPanePlugins = function() {
-			return panePlugins;
+			return Array.from(new Set(panePlugins.map(a => a.name))).map(name => { return panePlugins.find(a => a.name === name)})
 		};
 	})();
 
@@ -1136,7 +1136,7 @@ NgChm.createNS('NgChm.LNK');
 				pluginLabels.push(msg.axisLabels[i]);
 			}
 		}
-		if (axisIdx.length < 1) {console.warn('Heatmap and pathway have no genes in common.')}
+		if (axisIdx.length < 1) {NgChm.UHM.systemMessage("NG-CHM Pathway Mapper", "Heatmap and pathway have no genes in common."); return;}
 		var idx1 = [];
 		var idx2 = [];
 		if (msg.group2 == null || msg.group2.length == 0) {
@@ -1288,7 +1288,7 @@ NgChm.createNS('NgChm.LNK');
 		const debug = false;
 		const loc = NgChm.Pane.findPaneLocation (icon);
 		if (!loc || !loc.pane || loc.pane.getElementsByTagName('IFRAME').length == 0) {
-			alert ('No options');
+			console.log('No options');  //alert
 			return;
 		}
 
@@ -1906,7 +1906,7 @@ NgChm.createNS('NgChm.LNK');
 			(source||iframe.contentWindow).postMessage({ vanodi: { nonce, op: 'none' }}, '*');  // Let plugin know we heard it.
 			NgChm.Pane.switchToPlugin (loc, plugin.name);
 		} else {
-			alert ('Params has length > 0');
+			console.log('Params has length > 0');  //alert
 			loc.paneTitle.innerText = plugin.name;
 			NgChm.LNK.initializePanePlugin (nonce, params);
 		}

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -327,7 +327,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	}
 	
 	this.setRowClassificationOrder = function() {
-		mapConfig.row_configuration.classifications_order = this.getRowClassificationOrder();
+		if (mapConfig !== null) {mapConfig.row_configuration.classifications_order = this.getRowClassificationOrder();}
 	}
 	
 	this.getColClassificationOrder = function(showOnly){
@@ -356,7 +356,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	}
 	
 	this.setColClassificationOrder = function() {
-		mapConfig.col_configuration.classifications_order = this.getColClassificationOrder();
+		if (mapConfig !== null) {mapConfig.col_configuration.classifications_order = this.getColClassificationOrder();}
 	}
 	
 	this.getRowClassificationData = function() {
@@ -942,9 +942,9 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 			NgChm.SEL.currentCol = Number(NgChm.UTIL.getURLParameter("column"))
 		}
 
+		NgChm.UTIL.configurePanelInterface();
 		NgChm.SUM.initSummaryDisplay();
 		NgChm.DET.initDetailDisplay();
-		NgChm.UTIL.configurePanelInterface();
 		document.addEventListener("keydown", NgChm.SEL.keyNavigate);
 
 		addDataLayers(mc);

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -402,6 +402,9 @@ NgChm.UTIL.showDetailPane = true;
 	var firstTime = true;
 
 	NgChm.UTIL.configurePanelInterface = function configurePanelInterface () {
+		if (NgChm.MMGR.source === NgChm.MMGR.FILE_SOURCE) {
+			firstTime = true;
+		}
 		// Split the initial pane horizontally and insert the
 		// summary and detail NGCHMs into the children.
 		if (firstTime) {

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -531,7 +531,7 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 						NgChm.LNK.switchPaneToPlugin (loc, plugin);
 					});
 				}
-			});
+			});  
 			menuSeparator();
 		}
 
@@ -622,6 +622,8 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 		}
 		if (parentC !== null) {
 			if (getExpandedSibling(paneLoc) == null) {
+				menuItemDisabled ('Close');
+			} else if ((NgChm.MMGR.source === NgChm.MMGR.FILE_SOURCE) && (document.getElementsByClassName("pane").length < 3)) {
 				menuItemDisabled ('Close');
 			} else {
 				menuItem ('Close', () => {

--- a/NGCHM/WebContent/javascript/PdfGenerator.js
+++ b/NGCHM/WebContent/javascript/PdfGenerator.js
@@ -21,6 +21,7 @@ NgChm.PDF.openPdfPrefs = function(e) {
 	NgChm.UHM.closeMenu();
 	NgChm.UHM.hlpC();
 	if (e.classList.contains('disabled')) {
+		NgChm.UHM.systemMessage("NG-CHM PDF Generator", "Cannot generate the PDF when both the Summary and Detail heat map panels are closed.");
 		return;
 	}
 
@@ -45,7 +46,7 @@ NgChm.PDF.openPdfPrefs = function(e) {
 		bothButton.disabled = false;
 	} else {
 		// Should not happen.
-		alert('Cannot generate PDF when no heatmap panels are open');
+		NgChm.UHM.systemMessage("NG-CHM PDF", "Cannot generate PDF when the Summary or Detail heat map panels are closed.");
 		return;
 	}
 	var prefspanel = document.getElementById('pdfPrefs');

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -1896,6 +1896,7 @@ NgChm.SUM.drawAxisSelectionMarks = function(axis) {
 	const isRow = NgChm.MMGR.isRow (axis);
 	const selection = NgChm.DET.getSearchItemsForAxis(axis);
 	const canvas = document.getElementById (isRow ? "summary_row_select_canvas" : "summary_col_select_canvas");
+	if (canvas === null) { return;}
 	const limit = isRow ? canvas.height : canvas.width;
 	const scale = limit / NgChm.heatMap.getTotalElementsForAxis(axis);
 

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -654,6 +654,18 @@ NgChm.UHM.hamburgerLinkMissing = function() {
 }
 
 /**********************************************************************************
+ * FUNCTION - systemMessage: This function handles all of the tasks necessary 
+ * display a modal window whenever a given notification condition occurs. 
+ **********************************************************************************/
+NgChm.UHM.systemMessage = function(header, message) {
+	NgChm.UHM.initMessageBox();
+	NgChm.UHM.setMessageBoxHeader(header);
+	NgChm.UHM.setMessageBoxText("<br>" + message);
+	NgChm.UHM.setMessageBoxButton(1, "images/closeButton.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	document.getElementById('msgBox').style.display = '';
+}
+
+/**********************************************************************************
  * FUNCTION - zipAppDownload: This function calls the Matrix Manager to initiate
  * the download of the NG-CHM File Viewer application. 
  **********************************************************************************/

--- a/NGCHM/build_ngchmApp.xml
+++ b/NGCHM/build_ngchmApp.xml
@@ -42,6 +42,8 @@
             <srcfile/>
             <arg line="--compilation_level"/>
             <arg line="SIMPLE_OPTIMIZATIONS"/>
+            <arg line="--jscomp_off"/>
+            <arg line="uselessCode"/>
             <arg line="--js_output_file"/>
             <mapper type="glob" from="*.js" to="${js.dir}*-min.js"/>
             <targetfile/>

--- a/NGCHM/src/mda/ngchm/datagenerator/HeatmapDataGenerator.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/HeatmapDataGenerator.java
@@ -953,7 +953,7 @@ public class HeatmapDataGenerator {
 	        for (int row = 1; row < classData.length; row++) {
 	        	int adjustedPos = row - 1;
 	    		float remainder = ((float)adjustedPos/interval)%1;
-	    		String dataItem = classData[row];
+	    		String dataItem = classData[row] == null ? "NA" : classData[row];
 	    		if (currFile.map.type.equals(COLORTYPE_CONTINUOUS)) {
 	    			if (dataItem.equals(CUT_VALUE) || NA_VALUES.contains(dataItem)) {
 	    				cutCtr++;


### PR DESCRIPTION
New NGCHM Project items fixed in this branch:
PT #171882807: Eliminate warning messages in ngchmApp widget builder process.
PT #171882807: Eliminate warning messages in ngchmApp widget builder process.
PT #171937256: Scatterplot throws errors on drawing selections on summary panel when panel not present
PT #171937316:  Replace alert popups in panels code with error message boxes OR console messages
PT #171997994: sValues summation error for large maps with continuous covariates that are missing labels.
PT #172058160: Viewer PDF -  Give user indication when PDF creation is halted due to lack of open summary and detail panels
PT #171976784:  Standalone Viewer - Loading a new heat map in the standalone or other viewers should reset view to standard view of Summary panel on the left and Detail panel on right. 
PT #172079820: Stand-alone viewer will not load a second map if summary and detail panels are not 
PT #172111739: Stand-alone viewer fails to load second map if user removes all but one panel
PT #172115438: stand-alone viewer duplicates scatterplot and pathway mapper menu items as each new map is opened