### PR TITLE
PTs: #172607456, #172609983, #172672555, #172672580, #172672598,

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -70,12 +70,12 @@
 					<img id='fileOpen_btn' style="display: none;vertical-align: bottom;" src='images/openMap.png' alt='Open .NG-CHM' onmouseout='this.setAttribute("src", "images/openMap.png");NgChm.UHM.hlpC();' onmouseover='this.setAttribute("src", "images/openMapHover.png");NgChm.UHM.hlp(this,"Open .NG-CHM Heat Map",130);' onclick='NgChm.SEL.openFileToggle();'/>
 					<img id="back_btn" style="display: none;vertical-align: bottom;" src="images/returnArrow.png" alt="Return to previous screen" /> 
 					<strong>Search:</strong>&nbsp;
-					<select name="search_on" id="search_on" style="vertical-align:bottom;font-size: 13px;" onchange="NgChm.SRCH.searchOnSel();">
+					<select name="search_on" id="search_on" class='srchSelect' onchange="NgChm.SRCH.searchOnSel();">
 						<option value="labels">Labels</option>
 					</select>
-					<input id="search_text" name="search" type="text" style="vertical-align:bottom;font-size: 12px;" onmouseout='NgChm.UHM.hlpC();' onmouseover='NgChm.UHM.hlp(this,"Search row and column labels.  Enter search term and click Go. The search will find labels that partially match the search text. To find exact matches only, put double-quote characters around the search term.  Multiple search terms can be separated by spaces.  If the search box turns red, none of the search terms were found.  If it turns yellow, only some of the search terms were found.",300);' />
-					<input id="search_cov_cont" name="search_cont" type="text" style="display:none;vertical-align:bottom;font-size: 12px;" onmouseout='NgChm.UHM.hlpC();' onmouseover='NgChm.UHM.hlp(this,"Search row and column covariate values.  Enter search term and click Go. The search will find rows/cols with continuous covariate values that fall within the search expressions entered. Search expressions should be entered in the form of a comma-delimited string with each segment representing an expression. Valid expressions would include individual values and/or values preceded by one of the following operators: >, >=< <, <=. If the search box turns red, no rows/cols containing the selected covariate values were found.",300);' />
-					<div id="search_cov_disc" style="display:none;padding-top:2px;vertical-align:bottom;">
+					<input id="search_text" name="search" type="text" class='srchText' onmouseout='NgChm.UHM.hlpC();' onmouseover='NgChm.UHM.hlp(this,"Search row and column labels.  Enter search term and click Go. The search will find labels that partially match the search text. To find exact matches only, put double-quote characters around the search term.  Multiple search terms can be separated by spaces.  If the search box turns red, none of the search terms were found.  If it turns yellow, only some of the search terms were found.",300);' />
+					<input id="search_cov_cont" name="search_cont" type="text" class='srchText' style='display:none;' onmouseout='NgChm.UHM.hlpC();' onmouseover='NgChm.UHM.hlp(this,"Search row/column covariate values.  Enter search term and click Go. The search will find rows/cols with continuous covariate values that fall within the search expressions entered. Search expressions should be entered in the form of a comma-delimited string with each segment representing an expression. Valid expressions would include individual numeric values, values preceded by one of the following operators: >, >=< <, <= (e.g. >10), and/or range expressions with 2 operators creating a range of values (e.g.>10<=20). Expressions that do not match these patterns will be ignored. If the search box turns red, no rows/cols containing the selected covariate values were found.",300);' />
+					<div id="search_cov_disc" style="display:none;"> 
 						<div class="dropDownMultiSelect">
 					        <div id="srchCovSelectBox" class="dropDownSelectBox" onclick="NgChm.UTIL.showCheckBoxDropDown('srchCovCheckBoxes');">   
 					        </div>
@@ -83,7 +83,7 @@
 					        </div>
 						</div>
 					</div>
-					<select name="search_target" id="search_target" style='vertical-align:bottom;font-size: 13px;"'>
+					<select name="search_target" id="search_target" class='srchSelect'>
 						<option value="Both">Both</option>
 						<option value="Column">Column</option>
 						<option value="Row">Row</option>
@@ -132,9 +132,9 @@
 			<canvas id='col_class_canvas' class='summary_canvas'></canvas>
 			<canvas id='summary_canvas' class='summary_canvas'></canvas>
 			<canvas id='summary_box_canvas' ></canvas>
-			<canvas id=summary_col_top_items_canvas class='selection_canvas' style='padding-top:2px;'></canvas>
+			<canvas id=summary_col_top_items_canvas class='selection_canvas' style='padding-top:2px;z-index:1;'></canvas>
 			<canvas id='summary_row_top_items_canvas' class='selection_canvas' style='padding-left:2px;'></canvas>
-			<canvas id='summary_col_select_canvas' class='selection_canvas' style='padding-top:2px;'></canvas>
+			<canvas id='summary_col_select_canvas' class='selection_canvas' style='padding-top:2px;z-index:0;'></canvas>
 			<canvas id='summary_row_select_canvas' class='selection_canvas' style='padding-left:2px;'></canvas>
 			<div id='sumlabelDiv' style="display: inline-block"></div>
 		</div>

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -1017,7 +1017,7 @@ iframe.nopointer {
       border: 1px #DADADA solid;
       font-size:13px;
   	overflow-y:auto; 
-  	z-index:1;
+  	z-index:100;
   	position:absolute;
   	background-color: white;
   }
@@ -1031,21 +1031,42 @@ iframe.nopointer {
   .dropDownMultiSelect {
       width: 140px;
       float: left;
-      padding: 1px;
+      vertical-align: bottom;
   }
+  
   .dropDownSelectBox {
       position: relative;
   }
+  
   .dropDownSelectBox select {
       width: 100%;
+      font-size:11px;
+      height:21px;
+      padding-top:2px;
+      padding-bottom:4px;
   }
 
   .dropDownOverSelect {
       position: absolute;
       left: 0; right: 0; top: 0; bottom: 0;
   }
+  
   .srchCovCheckBox {
   	margin: 2px;
   	font-size: 8px;
   }
-    
+  
+  .srchSelect {
+  	vertical-align:bottom;
+  	font-size: 12px;
+  	height:20px;
+  }  
+
+  .srchText {
+ 	vertical-align:bottom;
+  	font-size: 12px;
+    width: 140px;
+  }  
+  
+  
+ 

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,7 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.17.4";
+NgChm.CM.version = "2.17.5";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -2182,7 +2182,7 @@ NgChm.DET.labelClick = function (e) {
 	document.getElementById('prev_btn').style.display='';
 	document.getElementById('next_btn').style.display='';
 	document.getElementById('cancel_btn').style.display='';
-//	NgChm.SUM.clearSelectionMarks();
+	NgChm.SUM.clearSelectionMarks();
 	NgChm.DET.updateDisplayedLabels();
 	NgChm.SEL.updateSelection();
 	NgChm.SUM.drawSelectionMarks();
@@ -2222,7 +2222,6 @@ NgChm.DET.labelDrag = function(e){
 	document.getElementById('next_btn').style.display='';
 	document.getElementById('cancel_btn').style.display='';
 	NgChm.DET.updateDisplayedLabels();
-//	NgChm.SUM.clearSelectionMarks();
 	NgChm.SRCH.showSearchResults();	
 	NgChm.SEL.updateSelection();
 	NgChm.SUM.drawSelectionMarks();

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -197,6 +197,28 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 		return datalevels[NgChm.MMGR.DETAIL_LEVEL].totalRows;
 	}
 	
+	//Return the summary row ratio
+	this.getSummaryRowRatio = function(){
+		if (datalevels[NgChm.MMGR.SUMMARY_LEVEL] !== null) {
+			return datalevels[NgChm.MMGR.SUMMARY_LEVEL].rowSummaryRatio;
+		} else {
+			return datalevels[NgChm.MMGR_THUMBNAIL_LEVEL].rowSummaryRatio;
+		}
+	}
+	
+	//Return the summary row ratio
+	this.getSummaryColRatio = function(){
+		if (datalevels[NgChm.MMGR.SUMMARY_LEVEL] !== null) {
+			return datalevels[NgChm.MMGR.SUMMARY_LEVEL].colSummaryRatio;
+		} else {
+			return datalevels[NgChm.MMGR_THUMBNAIL_LEVEL].col_summaryRatio;
+		}
+	}
+	//Return the total number of detail rows
+	this.getTotalRows = function(){
+		return datalevels[NgChm.MMGR.DETAIL_LEVEL].totalRows;
+	}
+	
 	this.setFlickInitialized = function(value){
 		flickInitialized = value;
 	}
@@ -638,7 +660,8 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 			var currentClassBar = classBarsConfig[key];
 			// create new option element
 			var opt = document.createElement('option');
-			opt.appendChild( document.createTextNode(key) );
+			let covname = key.length > 20 ? key.substring(0,20) + "..." : key;
+			opt.appendChild( document.createTextNode(covname) );
 			opt.value = "col|" + key; 
 			// add opt to end of select box (sel)
 			searchOn.appendChild(opt); 
@@ -648,7 +671,8 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 		for (var i = 0; i < classBarConfigOrder.length; i++) {
 			var key = classBarConfigOrder[i];
 			var opt = document.createElement('option');
-			opt.appendChild( document.createTextNode(key) );
+			let covname = key.length > 20 ? key.substring(0,20) + "..." : key;
+			opt.appendChild( document.createTextNode(covname) );
 			opt.value = "row|" + key; 
 			searchOn.appendChild(opt); 
 		}

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -906,6 +906,14 @@ NgChm.UTIL.setDragPanels = function () {
 }
 
 /**********************************************************************************
+ * FUNCTION - isNaN: This function checks for a numeric (float or integer) value
+ * and returns true/false.
+ **********************************************************************************/
+NgChm.UTIL.isNaN = function (n) {
+    return isNaN(n);
+}
+
+/**********************************************************************************
  * FUNCTION - dragElement: This function adds drag/move functionality to the DIV
  * passed in.
  **********************************************************************************/


### PR DESCRIPTION
Pivotal Tracker items covered by this pull request"
#172607456: Search dialog DOM elements drawing differently in Firefox and Builder.
#172609983: State tracking on search drop down check boxes needs to be able to handle 2 searches (row and col)
#172672555: Covariate search dropdown checkboxes showing behind divider bar
#172672580: Shorten covariate label length displayed in search covariate dropdown checkbox
#172672598: Modify search to allow for user-constructed expressions with two operators.
#172687319: Selection marks on summary side being drawn too wide
#172717454: Selection mark and top item line canvases being placed off the viewable area for small maps
#172717472: Summary selection marks drawn on top of top items arrows