### PR TITLE
Add covariate selection & mean test to gear dialog

### DIFF
--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -260,6 +260,7 @@ div.paneHeader img {
 
 .optionsBox .nodeSelector,
 .optionsBox .userLabel,
+.optionsBox .thresholdDropdownDIV,
 .optionsBox input,
 .optionsBox select {
 	grid-column-start: contents;
@@ -301,6 +302,11 @@ div.paneHeader img {
 	font-size: 0.7rem;
 }
 
+.gearPanel div.thresholdDropdownDIV{
+	margin: 0;
+	font-size: 0.7rem;
+}
+
 .gearPanel div.nodeSelector {
 	margin: 0.2em 0 0.5em 0;
 	font-size: 0.7rem;
@@ -326,6 +332,7 @@ span.button.negative {
 
 
 .gearPanel div.userLabel .leftLabel::after,
+.gearPanel div.thresholdDropdownDIV .leftLabel::after,
 .gearPanel div.nodeSelector .leftLabel::after {
 	margin-right: 0.5em;
 }
@@ -1068,5 +1075,22 @@ iframe.nopointer {
     width: 140px;
   }  
   
-  
- 
+.gear-menu-covariate-checkbox {
+	margin-left: 5%;
+}
+.gear-menu-covariate-range{
+	margin-left: 5%;
+	width: 150px;
+}
+.gear-menu-spacing{
+	margin-left: 5%;
+}
+
+/* Help Question marks. These are anchors in the HTML, and when
+   a user hovers over them, a help message is diplayed */
+.helpQuestionMark {
+	content: url('../images/questionMark.png'); 
+	height: 15px;
+	width: 15px;
+}
+

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -2177,6 +2177,9 @@ NgChm.DET.labelClick = function (e) {
 		NgChm.SEL.searchItems[axis][index] = 1;
 		NgChm.DET.labelLastClicked[axis] = index;
 	}
+	var clickType = (e.ctrlKey || e.metaKey) ? 'ctrlClick' : 'standardClick';
+	var lastClickedIndex = (typeof index == 'undefined') ? focusIndex : index;
+	NgChm.LNK.postSelectionToLinkouts(this.dataset.axis, clickType, index, null);
 	var searchElement = document.getElementById('search_text');
 	searchElement.value = "";
 	document.getElementById('prev_btn').style.display='';
@@ -2795,7 +2798,10 @@ NgChm.DET.detailDrawRowClassBarLabels = function () {
 					if (!document.getElementById("missingSumRowClassBars") && NgChm.SUM.canvas){
 						var x = NgChm.SUM.canvas.offsetLeft;
 						var y = NgChm.SUM.canvas.offsetTop + NgChm.SUM.canvas.clientHeight + 2;
-						NgChm.DET.addLabelDiv(document.getElementById('sumlabelDiv'), "missingSumRowClassBars", "ClassBar MarkLabel", "...", "...", x, y, 10, "T", null,"Row");
+						var sumlabelDiv = document.getElementById('sumlabelDiv')
+						if (sumlabelDiv !== null) {
+							NgChm.DET.addLabelDiv(document.getElementById('sumlabelDiv'), "missingSumRowClassBars", "ClassBar MarkLabel", "...", "...", x, y, 10, "T", null,"Row");
+						}
 					}
 				}
 				prevClassBarHeight = currentClassBar.height;

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -1196,3 +1196,18 @@ NgChm.UTIL.embedExpandableMap = function (options) {
 /**********************************************************************************
  * END: EMBEDDED MAP FUNCTIONS AND GLOBALS
  **********************************************************************************/
+
+/**
+*  Function to show selected items when the 'SHOW' button in the Gear Dialog is clicked
+* 
+*  @function redrawSearchResults
+*/
+NgChm.UTIL.redrawSearchResults = function () {
+	NgChm.DET.updateDisplayedLabels();
+	NgChm.SUM.redrawSelectionMarks();
+	NgChm.SEL.updateSelection();
+	NgChm.DET.showSearchResults();
+};
+
+
+

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -397,7 +397,7 @@ NgChm.UHM.locateHelpBox = function(helptext) {
  * pop-up help panel for the tool buttons at the top of the detail pane. It receives
  * text from chm.html. 
  **********************************************************************************/
-NgChm.UHM.hlp = function(e, text, width, reverse) {
+NgChm.UHM.hlp = function(e, text, width, reverse, delay=1500) {
 	NgChm.UHM.hlpC();
 	const helptext = document.createElement('div');
 	helptext.id = 'bubbleHelp';
@@ -417,7 +417,7 @@ NgChm.UHM.hlp = function(e, text, width, reverse) {
 		helptext.style.width = width + 'px';
 		helptext.innerHTML = "<b><font size='2' color='#0843c1'>"+text+"</font></b>";
 		helptext.style.display = "inherit";
-	}, 1500);
+	}, delay);
 }
 
 /**********************************************************************************


### PR DESCRIPTION
Added several features to the gear dialog for plugins. These changes
are in Linkouts.js:

- Checkboxes for selection of discrete covariates
- Range input boxes for selection of continuous covariates
- Help tooltips
- Statistical test for mean

Also made other changes that are not quite part of the gear dialog UI:

- Color map sent to plugins (Linkouts.js)
- System alert if groups have < 2 members (Linkouts.js)
  - statistical tests will crash if < 2 members
- Show labels in NGCHM when sent from plugins (NGCHM_Util.js)
  - bug fix
- Send labels to plugins when clicked on (DetailHeatMapDisplay.js)
  - bug fix
- Optional delay for showing tooltip (UserHelpManager.js)
  - so that when user hovers over '?', the tooltip can show up
    right away