### PR TITLE
Implement RESET button & fix bugs

### DIFF
--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -260,7 +260,8 @@ div.paneHeader img {
 
 .optionsBox .nodeSelector,
 .optionsBox .userLabel,
-.optionsBox .thresholdDropdownDIV,
+.optionsBox .rangeSelector,
+.optionsBox .discreteSelector,
 .optionsBox input,
 .optionsBox select {
 	grid-column-start: contents;
@@ -297,12 +298,9 @@ div.paneHeader img {
 	content: ":";
 }
 
+.gearPanel div.rangeSelector,
+.gearPanel div.discreteSelector,
 .gearPanel div.userLabel {
-	margin: 0;
-	font-size: 0.7rem;
-}
-
-.gearPanel div.thresholdDropdownDIV{
 	margin: 0;
 	font-size: 0.7rem;
 }
@@ -332,7 +330,8 @@ span.button.negative {
 
 
 .gearPanel div.userLabel .leftLabel::after,
-.gearPanel div.thresholdDropdownDIV .leftLabel::after,
+.gearPanel div.rangeSelector.leftLabel::after,
+.gearPanel div.discreteSelector.leftLabel::after,
 .gearPanel div.nodeSelector .leftLabel::after {
 	margin-right: 0.5em;
 }
@@ -1074,14 +1073,9 @@ iframe.nopointer {
   	font-size: 12px;
     width: 140px;
   }  
-  
-.gear-menu-covariate-checkbox {
-	margin-left: 5%;
-}
-.gear-menu-covariate-range{
-	margin-left: 5%;
-	width: 150px;
-}
+ 
+/* Used to add a little space in SPANs 
+   for prettier format of gear dialog*/ 
 .gear-menu-spacing{
 	margin-left: 5%;
 }
@@ -1093,4 +1087,26 @@ iframe.nopointer {
 	height: 15px;
 	width: 15px;
 }
+
+
+/* For the checkboxes for choosing discrete covariates in Gear Dialog */
+.gear-dialog-dropDownCheckBoxes-inline {
+	margin-top: 0em !important;
+	border: 1px #DADADA solid;
+	background-color: white;
+	height: 100px;
+	overflow: scroll;
+}
+
+.gear-dialog-dropDownCheckBoxes-inline label {
+	display: block;
+	position: relative;
+	overscroll-behavior: contain;
+	z-index: 11000;
+}
+
+.gear-dialog-dropDownCheckBoxes-inline label:hover {
+	background-color: #CBDBF6;
+}
+
 

--- a/NGCHM/WebContent/javascript/Dendrogram.js
+++ b/NGCHM/WebContent/javascript/Dendrogram.js
@@ -961,6 +961,8 @@ NgChm.DDR.DetailDendrogram = function(summaryDendrogram) {
 			NgChm.SEL.updateSelection();
 			NgChm.SUM.drawSelectionMarks();
 			NgChm.SUM.drawTopItems();
+			let clickType = (e.ctrlKey || e.metaKey) ? 'ctrlClick' : 'standardClick';
+			NgChm.LNK.postSelectionToLinkouts(this.axis, clickType, 0, null);
 			this.draw();
 		});
 	};

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -543,7 +543,8 @@ NgChm.UTIL.onLoadCHM = function (sizeBuilderView) {
 			NgChm.heatMap.addEventListener(NgChm.DET.processDetailMapUpdate);
 		}
  	} 
-	document.getElementById("container").addEventListener('wheel', NgChm.SEL.handleScroll, NgChm.UTIL.passiveCompat({capture: false, passive: false}));
+	document.getElementById("detail_canvas").addEventListener('wheel', NgChm.SEL.handleScroll, NgChm.UTIL.passiveCompat({capture: false, passive: false}));
+	document.getElementById("summary_canvas").addEventListener('wheel', NgChm.SEL.handleScroll, NgChm.UTIL.passiveCompat({capture: false, passive: false}));
 	document.getElementById("detail_canvas").focus();
 };
 


### PR DESCRIPTION
This commit implements the RESET button on the Gear Dialog, fixes
some bugs, and makes code and UI improvements on the Gear Dialog.
Most of the changes are in Linkouts.js, with two exceptions in
Dendogram.js and NGCHM_Util.js noted below, and some changes to
the css in NGCHM.css.

Bug fixes:

- Selection of Scatter Plot points by clicking dendograms
  - this is the change in Dendogram.js
- Disallows selection of non-numeric covariates for Coordinates in
  Gear Dialog
- Selection of points between two Scatter Plots

Gear Dialog UI improvements

- In choosing groups from discrete covariates, limit the height of
  the selection box and allow for scrolling (sometimes the list of
  discrete covariates is very long).
  - part of this is the change in NGCHM_Util.js. This change of
    the wheel event listener was made to allow for the wheel
    action to scroll in the Gear Dialong and NOT cause zooming of
    the heat maps.
- The RESET button works now

Gear Dialog code improvements

- Refactor of existiong code from my Pull Request #33 to better fit
  into the existing code structure