### PR TITLE
2.17.6 Viewer ready for testing

### DIFF
--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,7 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.17.5";
+NgChm.CM.version = "2.17.6";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/src/mda/ngchm/datagenerator/GalaxyMapGen.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/GalaxyMapGen.java
@@ -24,7 +24,7 @@ import org.json.simple.parser.ParseException;
 public class GalaxyMapGen {
 	
 public static boolean debugOutput = false;
-private static String BUILDER_VERSION = "2.11.2";
+private static String BUILDER_VERSION = "2.11.3";
 
 
 	public static void main(String[] args){


### PR DESCRIPTION
This is the 2.17.6 Viewer ready for testing.  The only changes from Mary's #37 pull request are changes to set the version number for the Viewer (2.17.6) and Galaxy (2.11.3).  The Master can be tagged 2.17.6 as soon as it is merged.