### PR TITLE
Potential bug fix for missing color always set to black in PDF

### DIFF
--- a/NGCHM/src/mda/ngchm/datagenerator/HeatmapDataGenerator.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/HeatmapDataGenerator.java
@@ -1429,6 +1429,7 @@ public class HeatmapDataGenerator {
 	        int numBreaks = cMap.breaks.size();
 	        Color lowExCol = cMap.colors.get(0);
 	        Color hiExCol = cMap.colors.get(numBreaks-1);
+	        Color missingCol = cMap.missingColor;
 	        float lowEx = Float.parseFloat(cMap.breaks.get(0));
 	        float hiEx = Float.parseFloat(cMap.breaks.get(numBreaks-1));
 	        
@@ -1443,7 +1444,7 @@ public class HeatmapDataGenerator {
 	                if (val == MIN_VALUES) {
 	                	rgb = RGB_WHITE;
 	                } else if (val == MAX_VALUES) {
-	                	rgb = RGB_BLACK;
+	                	rgb = missingCol.getRGB();
 	                } else {
 		                if (val > hiEx){
 		                    rgb = hiExCol.getRGB();
@@ -1487,6 +1488,7 @@ public class HeatmapDataGenerator {
 	        int numBreaks = cMap.breaks.size();
 	        Color lowExCol = cMap.colors.get(0);
 	        Color hiExCol = cMap.colors.get(numBreaks-1);
+	        Color missingCol = cMap.missingColor;
 	        float lowEx = Float.parseFloat(cMap.breaks.get(0));
 	        float hiEx = Float.parseFloat(cMap.breaks.get(numBreaks-1));
 	        
@@ -1501,7 +1503,7 @@ public class HeatmapDataGenerator {
 	                if (val == MIN_VALUES) {
 	                	rgb = RGB_WHITE;
 	                } else if (val == MAX_VALUES) {
-	                	rgb = RGB_BLACK;
+	                	rgb = missingCol.getRGB();
 	                } else {
 		                if (val > hiEx){
 		                    rgb = hiExCol.getRGB();
@@ -1896,6 +1898,7 @@ public class HeatmapDataGenerator {
 			        int numBreaks = cMap.breaks.size();
 			        Color lowExCol = cMap.colors.get(0);
 			        Color hiExCol = cMap.colors.get(numBreaks-1);
+			        Color missingCol = cMap.missingColor;
 			        float lowEx = Float.parseFloat(cMap.breaks.get(0));
 			        float hiEx = Float.parseFloat(cMap.breaks.get(numBreaks-1));
 			        
@@ -1910,7 +1913,7 @@ public class HeatmapDataGenerator {
 			                if (val == MIN_VALUES) {
 			                	rgb = RGB_WHITE;
 			                } else if (val == MAX_VALUES) {
-			                	rgb = RGB_BLACK;
+			                	rgb = missingCol.getRGB();
 			                } else {
 				                if (val > hiEx){
 				                    rgb = hiExCol.getRGB();


### PR DESCRIPTION
This attempts to fix a bug in which when the -FULLPDF flag is given to GalaxyMapGen.jar, the missing data values are set to RGB_BLACK instead of being set to the 'missing' value specified in heatmapProperties.json.

Specifically, the command 

```bash
java -cp GalaxyMapGen.jar mda.ngchm.datagenerator.HeatmapDataGenerator ./heatmapProperties.json -FULLPDF
```

would produce a PDF file in which the missing values were always black, instead of the value specified as 'missing' in the color map. Here is a snippet of the heatmapProperties.json file for reference:

```json
      "color_map": {
        "type": "linear",
        "colors": ["#0000ff","#ffffff","#ff0000"],
        "thresholds": [0,1,2],
        "missing": "#b3b3b3"
      }
```

These missing values are set to MAX_VALUES in InputFile.java (I think). For reference here's one example:

```java
258                         if (NA_VALUES.contains(toks[i])) {
259                           fVal = MAX_VALUES;
260                         } else {
261                           fVal = (float) Float.parseFloat(toks[i]);
262                         }
263                       }
```

One thing I tried that **did not work**: setting fVal = Float.NaN in InputFile.java, with the following in HeatmapDataGenerator.java:

```java
  } else if (Float.isNaN(val)) {
     rgb = missingCol.getRGB();
```

While this produced the desired PDF just fine, when I used the resulting GalaxyMapGen.jar in Galaxy, the NGCHM was all white in the Galaxy viewer.

Maybe someone has a suggestion about a better way to address the issue?
