### PR TITLE
Fix issue with Plugin Help not appearing

### DIFF
--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -1232,6 +1232,7 @@ NgChm.UHM.linkBoxSizing = function() {
 	}
 	var linkBoxTxt = document.getElementById('linkBoxTxt');
 	var linkBoxAllTxt = document.getElementById('linkBoxAllTxt');
+	var container = document.getElementById('ngChmContainer');
 	var contHeight = container.offsetHeight;
 	if (pluginCtr === 0) {
 		var boxHeight = contHeight *.30;


### PR DESCRIPTION
Recent changes renamed the "container" lelement to "ngchmContainer"
and somehow the reference to "container" in UserHelpManager.js was lost.
This patch simply gets a reference to the "ngchmContainer" element.