### PR TITLE
Include software version in URLs for style and javascript files.

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -4,36 +4,52 @@
 		<title>NG-CHM</title>
 		<meta charset="utf-8"/>
 		<link rel="shortcut icon" href="ngChmIcon.ico">
-		<link rel="stylesheet" href="css/NGCHM.css">
-		<script src="javascript/lib/zip.js"></script>
-		<script src="javascript/lib/deflate.js"></script>
-		<script src="javascript/lib/inflate.js"></script>
-		<script src="javascript/Config.js"></script>
-		<script src="javascript/MatrixManager.js"></script>
-		<script src="javascript/NGCHM_Util.js"></script>
-		<script src="javascript/PaneControl.js"></script>
-		<script src="javascript/SelectionManager.js"></script>
-		<script src="javascript/ColorMapManager.js"></script>
-		<script src="javascript/Drawing.js"></script>
-		<script src="javascript/SummaryHeatMapDisplay.js"></script>
-		<script src="javascript/DetailHeatMapDisplay.js"></script>
-		<script src="javascript/Dendrogram.js"></script>
-		<script src="javascript/UserHelpManager.js"></script>
-		<script src="javascript/UserPreferenceManager.js"></script>
-		<script src="javascript/PdfGenerator.js"></script>
-		<script src="javascript/Linkout.js"></script>
-		<script src="javascript/Customization.js"></script>
-		<script src="javascript/CompatibilityManager.js"></script>
-		<script src="javascript/SearchManager.js"></script>
-		<script src="javascript/lib/jspdf.min.js"></script>
-		<script src="javascript/lib/jstat.min.js"></script>
-		<script src="javascript/use_jstat.js"></script>
-	
 		<meta id='viewport' name ="viewport" content="width=device-width,user-scalable=no">
 	
 		<script type="text/Javascript">
-			NgChm.heatMap = null;  //global - heatmap object.
-			NgChm.UTIL.containerElement = document.getElementById('ngChmContainer');
+		    //Define Namespace for NgChm Application
+		    var NgChm = NgChm || {};
+		    NgChm.version = "2.18.1.bmbdev.0";
+		    NgChm.heatMap = null;  //global - heatmap object.
+		    (function() {
+			// Include style and javascript files in a way that
+			// overrides client and proxy caching when and only
+			// when the software version changes.
+			//
+			// The software version is included in the URLs for
+			// these files after the css and javascript path
+			// components (e.g. .../javascript-v1/... ).
+			//
+			// The system serving these files can just ignore the
+			// version numbers.  The following pair of NGINX
+			// rewrite rules is one way:
+			//     rewrite ^(.*)/javascript-[^/]*/(.*)$ $1/javascript/$2 last;
+			//     rewrite ^(.*)/css-[^/]*/(.*)$ $1/css/$2 last;
+		        const styles = [ "NGCHM.css" ];
+			const scripts = [
+			    "lib/zip.js", "lib/deflate.js", "lib/inflate.js",
+			    "Config.js", "MatrixManager.js", "NGCHM_Util.js",
+			    "PaneControl.js", "SelectionManager.js",
+			    "ColorMapManager.js", "Drawing.js",
+			    "SummaryHeatMapDisplay.js", "DetailHeatMapDisplay.js",
+			    "Dendrogram.js", "UserHelpManager.js",
+			    "UserPreferenceManager.js", "PdfGenerator.js",
+			    "Linkout.js", "Customization.js",
+			    "CompatibilityManager.js", "SearchManager.js",
+			    "lib/jspdf.min.js", "lib/jstat.min.js", "use_jstat.js"
+			];
+			styles.forEach(style => {
+			    const link = document.createElement('link');
+			    link.rel = 'stylesheet';
+			    link.href = "css-" + NgChm.version + "/" + style;
+			    document.head.appendChild(link);
+			});
+			scripts.forEach(script => {
+			    const el = document.createElement('script');
+			    el.async = false; el.defer = true;
+			    el.src = "javascript-" + NgChm.version + "/" + script;
+			    document.head.appendChild(el);
+			});
 			window.onload = function() {
 				// Line intentionally left blank
 				// Line intentionally left blank
@@ -41,6 +57,7 @@
 				document.body.addEventListener('click', NgChm.UHM.closeMenu,true);
 				document.getElementById('barMenu_btn').mouseIsOver = "";
 			};
+		    })();
 		</script>
 	</head>
 	<body class="NgChmViewer" style="font-family: sans-serif; font-size: 100%">

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,6 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.18.1";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -10,10 +10,6 @@
 // the tile is retrieved.
 //
 
-//Define Namespace for NgChm Application
-var NgChm = NgChm || {
-};
-
 // Function: createNS
 // This function is called from other JS files to define their individual namespaces.
 NgChm.createNS = function (namespace) {
@@ -1286,16 +1282,16 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	//Specify which file to get and what function to call when it arrives.
 	function fileModeFetchVersion() {
 		var req = new XMLHttpRequest();
-		req.open("GET", NgChm.CM.versionCheckUrl+NgChm.CM.version , true);
+		req.open("GET", NgChm.CM.versionCheckUrl+NgChm.version , true);
 		req.onreadystatechange = function () {
 			if (req.readyState == req.DONE) {
 		        if (req.status != 200) {
 		        	//Log failure, otherwise, do nothing.
 		            console.log('Failed to get software version: ' + req.status);
 		        } else {
-		        	var latestVersion = req.response;
-		        	if ((latestVersion > NgChm.CM.version) && (typeof NgChm.galaxy === 'undefined') && (NgChm.MMGR.embeddedMapName === null) && (fileSrc == NgChm.MMGR.WEB_SOURCE)) {
-		        		NgChm.UHM.viewerAppVersionExpiredNotification(NgChm.CM.version, latestVersion);   
+				var latestVersion = req.response;
+				if ((latestVersion > NgChm.version) && (typeof NgChm.galaxy === 'undefined') && (NgChm.MMGR.embeddedMapName === null) && (fileSrc == NgChm.MMGR.WEB_SOURCE)) {
+					NgChm.UHM.viewerAppVersionExpiredNotification(NgChm.version, latestVersion);
 		        	}
 			    } 
 			}

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -79,6 +79,10 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 		return "ngChmContainer" + nextUniqueContainerId++;
 	}
 
+	function getContainerElement() {
+	    return document.getElementById('ngChmContainer');
+	}
+
 	// The panel user interface is a DOM tree:
 	// - Leaf nodes are panels. They are implemented as DIV elements with class pane.
 	// - Internal tree nodes are containers.  They are implemented as DIV elements with class container.
@@ -883,13 +887,14 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 	// Exported function.
 	// Also used internally to reposition the popup after changes to the icon position.
 	function insertPopupNearIcon (popup, icon) {
-		if (popup.parentElement !== NgChm.UTIL.containerElement) {
+		const containerElement = getContainerElement();
+		if (popup.parentElement !== containerElement) {
 			// Test lets us reuse this function to reposition popup after moving the icon.
-			NgChm.UTIL.containerElement.appendChild(popup);
+			containerElement.appendChild(popup);
 			neighborPopups.push (popup);
 			neighborIcons.push (icon);
 		}
-		const contBB = NgChm.UTIL.containerElement.getBoundingClientRect();
+		const contBB = containerElement.getBoundingClientRect();
 		const iconBB = icon.getBoundingClientRect();
 		let topPosn = iconBB.bottom - contBB.top;
 		let leftPosn = iconBB.left - contBB.left;
@@ -927,7 +932,7 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 
 	// Exported function.
 	function removePopupNearIcon (popup, icon) {
-		NgChm.UTIL.containerElement.removeChild (popup);
+		getContainerElement().removeChild (popup);
 		for (let idx = 0; idx < neighborPopups.length; idx++) {
 			if (popup === neighborPopups[idx] && icon === neighborIcons[idx]) {
 				neighborPopups.splice(idx,1);
@@ -1111,7 +1116,7 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 		document.addEventListener('touchmove', this.moveListener, NgChm.UTIL.passiveCompat({passive: false}));
 		document.addEventListener('mouseup', this.endListener);
 		document.addEventListener('touchend', this.endListener);
-		NgChm.UTIL.containerElement.addEventListener('mouseleave', this.endListener);
+		getContainerElement().addEventListener('mouseleave', this.endListener);
 	};
 
 	// This method is called for each pointer movement while moving the divider.
@@ -1296,7 +1301,7 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 		// Set the heatmap's DividerPref iff the Pane configuation matches the standard configuration.
 		const { summary, detail } = getStandardConfiguration();
 		if (summary) {
-			const sumPercent = Math.ceil(100 * summary.pane.clientWidth / NgChm.UTIL.containerElement.clientWidth);
+			const sumPercent = Math.ceil(100 * summary.pane.clientWidth / getContainerElement().clientWidth);
 			if (debug) console.log ('Setting DividerPref to ' + sumPercent);
 			NgChm.heatMap.setDividerPref(sumPercent);
 		}
@@ -1316,7 +1321,7 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 
 	// Exported function.
 	function setPanePropWidths (percent, left, right, divider) {
-		const w = NgChm.UTIL.containerElement.clientWidth - divider.offsetWidth - verticalDividerMargins;
+		const w = getContainerElement().clientWidth - divider.offsetWidth - verticalDividerMargins;
 		const w1 = (w * percent) / 100;
 		left.style.width = w1 + 'px';
 		right.style.width = (w - w1) + 'px';
@@ -1336,7 +1341,7 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 	// this function returns an object containing the PaneLocations of the summary and detail NG-CHMs.
 	// Otherwise, it returns an empty object.
 	function getStandardConfiguration() {
-		const c1 = NgChm.UTIL.containerElement.children;
+		const c1 = getContainerElement().children;
 		// Stop if top-level container does not contain exactly one container.
 		if (c1.length !== 1 || !c1[0].classList.contains('ngChmContainer')) return {};
 		// Stop if subcontainer is not horizontal.

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -595,7 +595,7 @@ NgChm.UHM.widgetHelp = function() {
     var mapVersion = ((NgChm.heatMap !== null) && NgChm.heatMap.isMapLoaded()) === true ? NgChm.heatMap.getMapInformation().version_id : "N/A";
 	var text = "<p>The NG-CHM Heat Map Viewer is a dynamic, graphical environment for exploration of clustered or non-clustered heat map data in a web browser. It supports zooming, panning, searching, covariate bars, and link-outs that enable deep exploration of patterns and associations in heat maps.</p>";
 	text = text + "<p><a href='https://bioinformatics.mdanderson.org/public-software/ngchm/' target='_blank'>Additional NG-CHM Information and Help</a></p>";
-	text = text + "<p><b>Software Version: </b>" + NgChm.CM.version+"</p>";
+	text = text + "<p><b>Software Version: </b>" + NgChm.version+"</p>";
 	text = text + "<p><b>Linkouts Version: </b>" + linkouts.getVersion()+"</p>";
 	text = text + "<p><b>Map Version: </b>" +mapVersion+"</p>";
 	text = text + "<p><b>Citation:</b> Bradley M. Broom, Michael C. Ryan, Robert E. Brown, Futa Ikeda, Mark Stucky, David W. Kane, James Melott, Chris Wakefield, Tod D. Casasent, Rehan Akbani and John N. Weinstein, A Galaxy Implementation of Next-Generation Clustered Heatmaps for Interactive Exploration of Molecular Profiling Data. Cancer Research 77(21): e23-e26 (2017): <a href='http://cancerres.aacrjournals.org/content/77/21/e23' target='_blank'>http://cancerres.aacrjournals.org/content/77/21/e23</a></p>";

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -1734,7 +1734,7 @@ NgChm.UPM.setupRowColPrefs = function(e, prefprefs) {
 	var prefContents = document.createElement("TABLE");
 	NgChm.UHM.addBlankRow(prefContents);
 	NgChm.UHM.setTableRow(prefContents,["MAP INFORMATION:"], 2);
-	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Viewer Version:", NgChm.CM.version]);
+	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Viewer Version:", NgChm.version]);
 	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Map Version:", NgChm.heatMap.getMapInformation().version_id]);
 	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Builder Version:", NgChm.heatMap.getMapInformation().builder_version]);
 	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Read Only:", NgChm.heatMap.getMapInformation().read_only]);


### PR DESCRIPTION
This is a start on a possible way to address the client caching problem on version changes.

The intention is to override client and proxy caching when **and only when**
the software version changes.  Basically, the version number is included
in the URLs for style and javascript files. It requires the web server to ignore those
version numbers.  Example rewrite rules for NGINX are included.

This commit breaks compilation of source files into widget or standalone
artifacts.  If this seems a reasonable way forward, we can address those
issues in future commits.