### PR TITLE
2.18.2 Release - PT items: #74070556 and #173967975

### DIFF
--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,7 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.18.1";
+NgChm.CM.version = "2.18.2";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -778,8 +778,8 @@ NgChm.UTIL.downloadSummaryMapPng = function () {
 }
 
 NgChm.UTIL.downloadSummaryPng = function (e) { 
-	if (e.classList.contains('disabled')) {
-		return;
+	if (typeof e !== 'undefined') {
+		if (e.classList.contains('disabled')) return;
 	}
     var mapName = NgChm.heatMap.getMapInformation().name;
     var colDCanvas = document.getElementById("column_dendro_canvas");

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -180,10 +180,10 @@ NgChm.SUM.summaryInit = function() {
 	NgChm.SUM.canvas.height = NgChm.SUM.totalHeight;
 	NgChm.SUM.boxCanvas.width =  NgChm.SUM.totalWidth;
 	NgChm.SUM.boxCanvas.height = NgChm.SUM.totalHeight;
-	NgChm.SUM.rCCanvas.width =  NgChm.SUM.rowClassBarWidth*NgChm.SUM.widthScale;
+	NgChm.SUM.rCCanvas.width =  NgChm.SUM.rowClassBarWidth;
 	NgChm.SUM.rCCanvas.height = NgChm.SUM.totalHeight;
 	NgChm.SUM.cCCanvas.width =  NgChm.SUM.totalWidth;
-	NgChm.SUM.cCCanvas.height = NgChm.SUM.colClassBarHeight*NgChm.SUM.heightScale;
+	NgChm.SUM.cCCanvas.height = NgChm.SUM.colClassBarHeight;
 	
 	var nameDiv = document.getElementById("mapName");  
 	var mapName = NgChm.heatMap.getMapInformation().name;

--- a/NGCHM/src/mda/ngchm/datagenerator/GalaxyMapGen.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/GalaxyMapGen.java
@@ -24,7 +24,7 @@ import org.json.simple.parser.ParseException;
 public class GalaxyMapGen {
 	
 public static boolean debugOutput = false;
-private static String BUILDER_VERSION = "2.12.0";
+private static String BUILDER_VERSION = "2.12.1";
 
 
 	public static void main(String[] args){


### PR DESCRIPTION
This production release branch contains 2 fixes for items for a new 2.18.2 release that were discussed at last Thursday's meeting: 

#173967975: REFLECT site having issues with covariate bar display on maps with just 2 columns
#174070556: GUI Builder - Get Thumbnail Image button not working in Chrome or Firefox