### PR TITLE
Create unpredictable nonces

### DIFF
--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -918,11 +918,10 @@ NgChm.createNS('NgChm.LNK');
 	};
 
 	(function() {
-		var nextNonce = 1234543;
 		NgChm.LNK.getNewNonce = function() {
-			const nonce = '' + nextNonce;
-			nextNonce += 3353;
-			return nonce;
+			const ta = new Uint8Array(16);
+			window.crypto.getRandomValues(ta);
+			return Array.from(ta).map(x => x.toString(16)).join("");
 		};
 	})();
 


### PR DESCRIPTION
Initial implementation used predictable nonces to simplify
development.  However, that's a huge security problem that
effectively defeats their purpose.  This patch uses crypt.getRandomValues
to generate unpredictable values.