### PR TITLE
Add a variety of linkouts for metabolite and compound identifiers

### DIFF
--- a/NGCHM/WebContent/javascript/custom/custom.js
+++ b/NGCHM/WebContent/javascript/custom/custom.js
@@ -959,3 +959,138 @@ linkouts.addPlugin({
 
     });
 }) (linkouts);
+
+//==============================================//
+// Metabolomic plugins                          //
+//==============================================//
+(function() {
+
+    linkouts.describeTypes([{
+            typeName: "bio.metabolite.MW.name",
+            displayName: "Metabolomics Workbench Metabolite name",
+            description: "Latin letters and Arabic numerals"
+        },
+        {
+            typeName: "bio.metabolite.MW.regno",
+            displayName: "Metabolomics Workbench Regno id",
+            description: "Numeric Id"
+
+        },
+        {
+            typeName: "bio.metabolite.refmet",
+            displayName: "refmet name",
+            description: "Latin letters and Arabic numerals"
+
+        },
+        {
+            typeName: "bio.metabolite.hmdb",
+            displayName: "HMDB Metabolite Id",
+            description: "An ID starting with HMDB"
+
+        },
+        {
+            typeName: "bio.compound.pubchem",
+            displayName: "Pubchem id",
+            description: "Numeric Id"
+
+        },
+        {
+            typeName: "bio.compound.kegg",
+            displayName: "KEGG Compound Id",
+            description: "An ID"
+
+        },
+        {
+            typeName: "bio.compound.chebi",
+            displayName: "ChEBI Compound Id",
+            description: "Numeric ID"
+
+        },
+        {
+            typeName: "bio.compound.metacyc",
+            displayName: "MetaCyc Compound Id",
+            description: "Latin letters, Arabic numerals, hyphens (e.g. CPD-6989)"
+
+        },
+    ]);
+
+    function openMW(names) {
+        var mname = names[0];
+        linkouts.openUrl("https://www.metabolomicsworkbench.org/search/sitesearch.php?Name=" + mname, "Metabolomics Workbench");
+    }
+
+    function openRegno(names) {
+        var regno = names[0];
+        if (regno == '') {
+             alert('No RegNo available for this metabolite')
+        } else {
+             linkouts.openUrl("https://www.metabolomicsworkbench.org/data/StructureData.php?RegNo=" + regno, "Regno");
+        }
+    }
+
+    function openPubchem(names) {
+        var pubchemid = names[0];
+        if (pubchemid == '') {
+            alert("No pubchemID available for this metabolite.")
+        } else {
+            linkouts.openUrl("https://pubchem.ncbi.nlm.nih.gov/compound/" + pubchemid, "PubChem");
+        }
+    }
+
+    function openRefmet(names) {
+        var refmetname = names[0];
+        linkouts.openUrl("https://www.metabolomicsworkbench.org/search/sitesearch.php?Name=" + refmetname, "Refmet");
+    }
+
+    function openHMDB(names) {
+        var hmdbName = names[0];
+        if (hmdbName == '') {
+            alert('No HMDB ID available for this metabolite')
+        } else {
+            linkouts.openUrl("https://hmdb.ca/metabolites/" + hmdbName, "HMDB");
+        }
+    }
+
+    function openKEGG(names) {
+        var keggName = names[0];
+        if (keggName == '') {
+            alert("No KEGG ID available for this metabolite.")
+        } else {
+            linkouts.openUrl("https://www.genome.jp/dbget-bin/www_bget?compound+" + keggName, "KEGG");
+        }
+    }
+
+    function openChebi(names) {
+        var chebiName = names[0];
+        if (chebiName == '') {
+            alert("No ChEBI name available for this metabolite.")
+        } else {
+            linkouts.openUrl("https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:" + chebiName, "CheBI");
+        }
+    }
+
+    function openMetacyc(names) {
+        var metaCycName = names[0];
+        if (metaCycName == '') {
+            alert("No MetaCyc name available for this metabolite.")
+        } else {
+            linkouts.openUrl("https://metacyc.org/compound?orgid=META&id=" + metaCycName, "Metacyc");
+        }
+    }
+
+    linkouts.addPlugin({
+        name: "MWannotation",
+        description: "Adds linkouts to Metabolomics name",
+        version: "0.1.0",
+        linkouts: [{ menuEntry: "View Metabolomics workbench", typeName: "bio.metabolite.MW.name", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openMW },
+            { menuEntry: "View PubChem", typeName: "bio.compound.pubchem", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openPubchem },
+            { menuEntry: "View RefMet", typeName: "bio.metabolite.refmet", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openRefmet },
+            { menuEntry: "View Regno", typeName: "bio.metabolite.MW.regno", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openRegno },
+            { menuEntry: "View HMDB", typeName: "bio.metabolite.hmdb", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openHMDB },
+            { menuEntry: "View KEGG", typeName: "bio.compound.kegg", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openKEGG },
+            { menuEntry: "View ChEBI", typeName: "bio.compound.chebi", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openChebi },
+            { menuEntry: "View MetaCyc", typeName: "bio.compound.metacyc", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openMetacyc }
+        ]
+    });
+})(linkouts);
+


### PR DESCRIPTION

Add the metabolite and compound link outs to the default link outs.

For the type codes, I changed the "bio" category (the second field) to either "metabolite" or "compound".