### PR TITLE
Insilico prefs sizing fix

### DIFF
--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -700,14 +700,11 @@ th.breakpointContainer {
 }
 
 #prefs {
-	height: 100%;
 	width: 420px;
 	overflow: hidden;
 	position: absolute;
-	top: 0px;
 	background-color: #CBDBF6; 
-	border-left: 1px solid black; 
-	border-right: 1px solid black; 
+	border: 1px solid black; 
 	z-index: 10000;
 }
 

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,7 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.18.2";
+NgChm.CM.version = "2.18.3";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -74,8 +74,20 @@ NgChm.UPM.editPreferences = function(e,errorMsg) {
 	NgChm.UPM.resetVal = NgChm.UPM.getResetVals();
 	
 	var prefspanel = document.getElementById("prefs");
+	var barMenu_btn = document.getElementById("barMenu_btn");
+	const contBB = NgChm.UTIL.containerElement.getBoundingClientRect();
+	const iconBB = barMenu_btn.getBoundingClientRect();
 	prefspanel.style.right = "0px";
 	prefspanel.style.left = "";
+	prefspanel.style.top = iconBB.top + 'px';
+	//done for builder panel sizing ONLY
+	var screenNotes  = document.getElementById('screenNotesDisplay')
+	if (screenNotes !== null) {
+		notesBB = screenNotes.getBoundingClientRect();
+		prefspanel.style.top = (iconBB.top - notesBB.height) + 'px';
+	}
+
+	prefspanel.style.height = (contBB.height + (iconBB.height*2)) + 'px';
 	var prefprefs = document.getElementById("prefPrefs");
 
 	if (errorMsg !== null) {

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -79,7 +79,7 @@ NgChm.UPM.editPreferences = function(e,errorMsg) {
 	const iconBB = barMenu_btn.getBoundingClientRect();
 	prefspanel.style.right = "0px";
 	prefspanel.style.left = "";
-	prefspanel.style.top = iconBB.top + 'px';
+	prefspanel.style.top=NgChm.UTIL.containerElement.parentElement.offsetTop + 30 + 'px';
 	//done for builder panel sizing ONLY
 	var screenNotes  = document.getElementById('screenNotesDisplay')
 	if (screenNotes !== null) {

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -74,20 +74,6 @@ NgChm.UPM.editPreferences = function(e,errorMsg) {
 	NgChm.UPM.resetVal = NgChm.UPM.getResetVals();
 	
 	var prefspanel = document.getElementById("prefs");
-	var barMenu_btn = document.getElementById("barMenu_btn");
-	const contBB = NgChm.UTIL.containerElement.getBoundingClientRect();
-	const iconBB = barMenu_btn.getBoundingClientRect();
-	prefspanel.style.right = "0px";
-	prefspanel.style.left = "";
-	prefspanel.style.top=NgChm.UTIL.containerElement.parentElement.offsetTop + 30 + 'px';
-	//done for builder panel sizing ONLY
-	var screenNotes  = document.getElementById('screenNotesDisplay')
-	if (screenNotes !== null) {
-		notesBB = screenNotes.getBoundingClientRect();
-		prefspanel.style.top = (iconBB.top - notesBB.height) + 'px';
-	}
-
-	prefspanel.style.height = (contBB.height + (iconBB.height*2)) + 'px';
 	var prefprefs = document.getElementById("prefPrefs");
 
 	if (errorMsg !== null) {
@@ -114,7 +100,6 @@ NgChm.UPM.editPreferences = function(e,errorMsg) {
 		prefspanel.appendChild(prefBtnsDiv);
 		NgChm.UPM.setMessage("");
 	}
-	prefspanel.style.display= '';
 	NgChm.UPM.prefsResize();
 
 	//If errors exist and they are NOT on the currently visible DIV (dataLayer1),
@@ -140,7 +125,31 @@ NgChm.UPM.editPreferences = function(e,errorMsg) {
 		NgChm.UPM.showLayerPrefs();
 	}
 	errorMsg = null;
-    NgChm.UTIL.redrawCanvases();
+	prefspanel.style.display= '';	
+	NgChm.UPM.locatePrefsPanel();
+	NgChm.UTIL.redrawCanvases();
+}
+
+/**********************************************************************************
+ * FUNCTION - locatePrefsPanel: The purpose of this function is to place the prefs 
+ * panel on the screen.
+ **********************************************************************************/
+NgChm.UPM.locatePrefsPanel = function() {
+	var prefspanel = document.getElementById("prefs");
+	var barMenu_btn = document.getElementById("barMenu_btn");
+	const contBB = NgChm.UTIL.containerElement.getBoundingClientRect();
+	const iconBB = barMenu_btn.getBoundingClientRect();
+	prefspanel.style.top=NgChm.UTIL.containerElement.parentElement.offsetTop + 30 + 'px';
+	//done for builder panel sizing ONLY
+	var screenNotes  = document.getElementById('screenNotesDisplay')
+	if (screenNotes !== null) {
+		notesBB = screenNotes.getBoundingClientRect();
+		prefspanel.style.top = (iconBB.top - notesBB.height) + 'px';
+	}
+	
+	prefspanel.style.height = (contBB.height + iconBB.height) + 'px';
+	document.getElementById("prefsMove_btn").dataset.state = 'moveLeft';
+	prefspanel.style.left = (NgChm.UTIL.containerElement.getBoundingClientRect().right - (prefspanel.offsetWidth)) + 'px';
 }
 
 /**********************************************************************************
@@ -270,12 +279,12 @@ NgChm.UPM.prefsMoveButton = function() {
 		moveBtn.setAttribute('src', 'images/prefsRight.png');
 		moveBtn.dataset.state = 'moveRight';
 		prefspanel.style.right = "";
-		prefspanel.style.left = "0px";
+		prefspanel.style.left = NgChm.UTIL.containerElement.offsetLeft + 'px';
 	} else {
 		moveBtn.setAttribute('src', 'images/prefsLeft.png');
 		moveBtn.dataset.state = 'moveLeft';
-		prefspanel.style.right = "0px";
-		prefspanel.style.left = "";
+		prefspanel.style.right = "";
+		prefspanel.style.left = (NgChm.UTIL.containerElement.getBoundingClientRect().right - (prefspanel.offsetWidth)) + 'px';
 	}
 }
 

--- a/NGCHM/src/mda/ngchm/datagenerator/GalaxyMapGen.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/GalaxyMapGen.java
@@ -24,7 +24,7 @@ import org.json.simple.parser.ParseException;
 public class GalaxyMapGen {
 	
 public static boolean debugOutput = false;
-private static String BUILDER_VERSION = "2.12.1";
+private static String BUILDER_VERSION = "2.12.2";
 
 
 	public static void main(String[] args){


### PR DESCRIPTION
PT #174869184:  Prefs panel location for embedded NGCHM.  

Notes:  The original code and Chris' changes have been incorporated. In addition, the original fix only solved the top/bottom sizing and placement of the prefs panel. The left/right placement was set to 0 right and 0 left, respectively. This had the panels being drawn off the NGCHM widget on embedded maps. Now the left right placement has also been modified to place the prefs panel inside the NGCHM widget.