### PR TITLE
Change strict to loose equality for gear init

### DIFF
--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2350,7 +2350,7 @@ NgChm.createNS('NgChm.LNK');
 						} else {
 							const choice = NgChm.UTIL.newElement('OPTION');
 							choice.value = cc.value;
-							if (cc.value === optParam) selectedIndex = idx;
+							if (cc.value == optParam) selectedIndex = idx;
 							choice.innerText = cc.label;
 							input.append(choice);
 							idx++;


### PR DESCRIPTION
This is the part of the code that fills in the gear dialog with any existing previous values (so that if the user clicked 'APPLY', closed the gear dialog, and reopened the dialog, the previously applied values are automatically filled it.)

Suggesting changing this equality so that '1.0' and 1.0 are regarded as equal. 

Without this change either plugin developers will have to set numeric values to be strings, or further changes will have to be made to the NGCHM code to ensure '1.0' is regarded as equal to 1.0 and previously applied numeric values are properly initialized.
