### PR TITLE
Allow longer values for upper/lower bounds of bar/scatter covariate bars

### DIFF
--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -1382,8 +1382,8 @@ NgChm.UPM.setupClassBreaks = function(e, key, barType, classBar) {
 	NgChm.UHM.addBlankRow(prefContents, 3);
 	var bgColorInput = "<input class='spectrumColor' type='color' name='"+keyRC+"_bgColorPref' id='"+keyRC+"_bgColorPref' value='"+classBar.bg_color+"'>"; 
 	var fgColorInput = "<input class='spectrumColor' type='color' name='"+keyRC+"_fgColorPref' id='"+keyRC+"_fgColorPref' value='"+classBar.fg_color+"'>"; 
-	var lowBound = "<input name='"+keyRC+"_lowBoundPref' id='"+keyRC+"_lowBoundPref' value='"+classBar.low_bound+"' maxlength='3' size='2'>&emsp;";
-	var highBound = "<input name='"+keyRC+"_highBoundPref' id='"+keyRC+"_highBoundPref' value='"+classBar.high_bound+"' maxlength='3' size='2'>&emsp;";
+	var lowBound = "<input name='"+keyRC+"_lowBoundPref' id='"+keyRC+"_lowBoundPref' value='"+classBar.low_bound+"' maxlength='10' size='2'>&emsp;";
+	var highBound = "<input name='"+keyRC+"_highBoundPref' id='"+keyRC+"_highBoundPref' value='"+classBar.high_bound+"' maxlength='10' size='2'>&emsp;";
 	if (typ === 'Discrete') {
 		NgChm.UHM.setTableRow(prefContents,["&nbsp;Bar Type: ","<b>"+barPlot+"</b>"]);
 	} else {


### PR DESCRIPTION
In the co-variate bar tab of the map properties dialog box, individual co-variate bar mode, the inputs for the lower and upper bounds of bar and scatter plots are limited to a maximum input length of three.  Many co-variates have range limits that need more digits than that.  e.g. you can't input a range of 1300 to 1500.

This patch increases the length of the input fields to 10, which should be ample.  Note that for very large numbers, scientific notation is allowed, so the maximum input length really limits the precision available for separating the bounds.