### PR TITLE
Send selected labels to plugins upon initialization

### DIFF
--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -1207,9 +1207,18 @@ NgChm.createNS('NgChm.LNK');
 		};
 		for (let ai = 0; ai < config.axes.length; ai++) {
 			const axis = config.axes[ai];
+			let fullLabels = NgChm.heatMap.getAxisLabels(axis.axisName).labels;
+			let searchItemsIdx = NgChm.MMGR.isRow(axis.axisName) ? NgChm.SRCH.getSearchRows() : NgChm.SRCH.getSearchCols();
+			let selectedLabels = []
+			for (let i=0; i<searchItemsIdx.length; i++) {
+				let selectedLabel = fullLabels[searchItemsIdx[i] - 1];
+				selectedLabel = selectedLabel.indexOf('|') !== -1 ? selectedLabel.substring(0,selectedLabel.indexOf('|')) : selectedLabel;
+				selectedLabels.push(selectedLabel)
+			}
 			data.axes.push({
-				fullLabels: NgChm.heatMap.getAxisLabels(axis.axisName).labels,
-				actualLabels: NgChm.UTIL.getActualLabels(axis.axisName)
+				fullLabels: fullLabels,
+				actualLabels: NgChm.UTIL.getActualLabels(axis.axisName),
+				selectedLabels: selectedLabels 
 			});
 			for (let idx = 0; idx < axis.cocos.length; idx++) {
 				setAxisCoCoData (data.axes[ai], axis, axis.cocos[idx]);


### PR DESCRIPTION
I think the root cause of https://github.com/MD-Anderson-Bioinformatics/ScatterPlotPlugin3D/issues/31 is that if selections have been made on one scatter plot, and then a second scatter plot is opened, that second scatter plot has nothing selected. Scrolling over that second scatter plot then highlights the point under the mouse, which is then posted to all of the other panels, effectively unselecting everything else.

By passing the selected labels to the plugin upon initialization, the plugin can use them to select those labels from the start, and its selections will be in sync with the other panes from the start. Initial testing suggests this corrects https://github.com/MD-Anderson-Bioinformatics/ScatterPlotPlugin3D/issues/31. 

I think this same problem existed in the 2D scatter plot, we just never noticed it. 