### PR TITLE
Fix tiny typo in SearchManager

### DIFF
--- a/NGCHM/WebContent/javascript/SearchManager.js
+++ b/NGCHM/WebContent/javascript/SearchManager.js
@@ -809,7 +809,7 @@ NgChm.SRCH.clearSearchItems = function (clickAxis) {
 	}
 	let markLabels = document.getElementsByClassName('MarkLabel');
 	for (let ii = 0; ii < markLabels.length; ii++){ // clear tick marks
-		NNgChm.DMM.removeLabels(markLabels[ii].id);
+		NgChm.DET.removeLabels(markLabels[ii].id);
 	}
 }
 


### PR DESCRIPTION
When testing the latest commit 3d4e463 , there was a tiny typo that prevented selections from the plugins working. This mini PR addresses that.