### PR TITLE
Add new function: vanodiSendProperty()

### DIFF
--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2656,7 +2656,7 @@ NgChm.createNS('NgChm.LNK');
 					nonce, 
 					op: 'labels', 
 					labels: NgChm.UTIL.getActualLabels(msg.axisName), 
-					pathways: {'ndexUUID': linkouts.getAttribute('ndexUUID')}
+					pathways: {'ndexUUIDs': linkouts.getAttribute('ndexUUIDs')}
 				}
 			}, '*');
 		} else {

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2665,7 +2665,9 @@ NgChm.createNS('NgChm.LNK');
 	/*
 		Send an NGCHM property to plugin.
 		
-		Post message to plugin with value of given property.
+		Post message to plugin with value of given property, typically in response to a 
+		'getProperty' message from a plugin. 
+		Example incoming message: {vanodi: {op: 'getProperty', propertyName: 'ndexUUIDs', nonce: <nonce>}}.
 		These are properties added to the NGCHM at build time, for example by using
 		the R function 'chmAddProperty()'. 
 		

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2627,6 +2627,7 @@ NgChm.createNS('NgChm.LNK');
 		if (msg.op === 'mouseover') vanodiMouseover (nonce, loc, msg);
 		if (msg.op === 'getLabels') vanodiSendLabels (nonce, loc, msg);
 		if (msg.op === 'getTestData') vanodiSendTestData (nonce, loc, msg);
+		if (msg.op === 'getProperty') vanodiSendProperty (nonce, loc, msg);
 	}
 
 	function vanodiRegister (nonce, loc, msg) {
@@ -2650,6 +2651,35 @@ NgChm.createNS('NgChm.LNK');
 		} else {
 			console.log ({ m: 'Malformed getLabels request', msg, detail: 'msg.axisName must equal row or column' });
 		}
+	}
+
+	/*
+		Send an NGCHM property to plugin.
+		
+		Post message to plugin with value of given property.
+		These are properties added to the NGCHM at build time, for example by using
+		the R function 'chmAddProperty()'. 
+		
+		Inputs:
+			nonce: plugin's nonce.
+			loc: location of plugin.
+			msg: message from plugin. Should have attribute 'propertyName',
+			     whose value is the name of the property to retrieve from the NGCHM.
+	*/
+	function vanodiSendProperty (nonce, loc, msg) {
+		if (!msg.hasOwnProperty('propertyName')) {
+			console.error('Incoming message missing attribute "propertyName"')
+			return
+		}
+		const { plugin, params, iframe, source } = pluginData[nonce];
+		(source||iframe.contentWindow).postMessage({
+			vanodi: {
+				nonce,
+				op: 'property',
+				propertyName: msg.propertyName,
+				propertyValue: linkouts.getAttribute(msg.propertyName) 
+			}
+		},'*')
 	}
 
 	const vanodiKnownTests = [

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2641,12 +2641,24 @@ NgChm.createNS('NgChm.LNK');
 		}
 	}
 
+	/*
+		Send label and pathway information to plugins.
+		
+		Here 'ndexUUID' is a UUID for a pathway in http://www.ndexbio.org/. Error trapping
+		for undefined/non-existing UUID is performed in the plugin.
+	*/
 	function vanodiSendLabels (nonce, loc, msg) {
 		console.log ({ 'Vanodi sendLabels': msg, loc:loc });
 		const { plugin, params, iframe, source } = pluginData[nonce];
-		// msg.axisName
 		if (msg.axisName === 'row' || msg.axisName === 'column') {
-			(source||iframe.contentWindow).postMessage({ vanodi: { nonce, op: 'labels', labels: NgChm.UTIL.getActualLabels(msg.axisName) }}, '*');
+			(source||iframe.contentWindow).postMessage({ 
+				vanodi: { 
+					nonce, 
+					op: 'labels', 
+					labels: NgChm.UTIL.getActualLabels(msg.axisName), 
+					pathways: {'ndexUUID': linkouts.getAttribute('ndexUUID')}
+				}
+			}, '*');
 		} else {
 			console.log ({ m: 'Malformed getLabels request', msg, detail: 'msg.axisName must equal row or column' });
 		}

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2641,24 +2641,12 @@ NgChm.createNS('NgChm.LNK');
 		}
 	}
 
-	/*
-		Send label and pathway information to plugins.
-		
-		Here 'ndexUUID' is a UUID for a pathway in http://www.ndexbio.org/. Error trapping
-		for undefined/non-existing UUID is performed in the plugin.
-	*/
 	function vanodiSendLabels (nonce, loc, msg) {
 		console.log ({ 'Vanodi sendLabels': msg, loc:loc });
 		const { plugin, params, iframe, source } = pluginData[nonce];
+		// msg.axisName
 		if (msg.axisName === 'row' || msg.axisName === 'column') {
-			(source||iframe.contentWindow).postMessage({ 
-				vanodi: { 
-					nonce, 
-					op: 'labels', 
-					labels: NgChm.UTIL.getActualLabels(msg.axisName), 
-					pathways: {'ndexUUIDs': linkouts.getAttribute('ndexUUIDs')}
-				}
-			}, '*');
+			(source||iframe.contentWindow).postMessage({ vanodi: { nonce, op: 'labels', labels: NgChm.UTIL.getActualLabels(msg.axisName) }}, '*');
 		} else {
 			console.log ({ m: 'Malformed getLabels request', msg, detail: 'msg.axisName must equal row or column' });
 		}


### PR DESCRIPTION
Added a new function to the vanodi API. This function allows plugins to request a property from the NGCHM. These are properties embedded in the NGCHM at build time, for example via the function chmAddProperty() from [NGCHM-R](https://github.com/MD-Anderson-Bioinformatics/NGCHM-R).

(There are several commits, but it's only a tiny bit of Linkouts.js that is changed).