### PR TITLE
PTs: #173952827, #176854565, #176854607, #176803641, #176825189,

### DIFF
--- a/NGCHM/WebContent/chmHelp.html
+++ b/NGCHM/WebContent/chmHelp.html
@@ -41,7 +41,7 @@
 		<p>There are a variety of buttons on the header bar to manipulate the heat map view.  Each has a tooltip that can be displayed by hovering over 
 		the button for a view seconds with the mouse pointer. </p>
 	
-		<table class="helpTable" align="center">
+		<table class="onlineHelp" align="center">
 	    	<colgroup>
 	     	  <col span="1" style="width: 20%;">
 	     	  <col span="1" style="width: 80%;">
@@ -113,7 +113,7 @@
 	   <h2>NG-CHM Collapsable Menu Button</h2>
 	   
 	   <p>The NG-CHM collapsable (hamburger) menu button opens a drop-down menu containing features for performing a variety of tasks related to the displayed heat map.  It possible for individual NG-CHM systems to be upgraded to place additional menu items into the collapsable menu.</p>
-  		<table class="helpTable" align="center">
+  		<table class="onlineHelp" align="center">
 	    	<colgroup>
 	     	  <col span="1" style="width: 20%;">
 	     	  <col span="1" style="width: 80%;">

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -847,6 +847,18 @@ table.helpTable th {
   color: black;
 }
 
+table.onlineHelp { 
+  border-collapse: collapse; 
+  width: 90%;
+}
+  
+table.onlineHelp td, 
+table.onlineHelp th { 
+  border: 1px solid black;
+  padding: 5px; 
+  color: black;
+}
+
 #colorMenu_btn {
 	right: 30px;
 	top: 0px;

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,7 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.19.4";
+NgChm.CM.version = "2.19.5";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -124,16 +124,9 @@ NgChm.DET.flushDrawingCache = function (tile) {
  *********************************************************************************************/
 NgChm.DET.setDetailMapDisplay = function (mapItem) {
 	NgChm.DET.setDendroShow(mapItem);
-	// Small Maps - Set detail data size.  If there are less than 42 rows or columns
-	// set the to show the box size closest to the lower value ELSE
-	// set it to show 42 rows/cols.
-	const rows = NgChm.heatMap.getNumRows(NgChm.MMGR.DETAIL_LEVEL);
-	const cols = NgChm.heatMap.getNumColumns(NgChm.MMGR.DETAIL_LEVEL);
-	if ((rows < 42) || (cols < 42)) {
-		const boxSize = NgChm.DET.getNearestBoxSize(mapItem, Math.min(rows,cols));
-		NgChm.DET.setDetailDataSize(mapItem,boxSize); 
-	} else {
-		NgChm.DET.setDetailDataSize(mapItem,12);
+	//If we are opening the first detail "copy" of this map set the data sizing for initial display
+	if (NgChm.DMM.DetailMaps.length === 0) {
+		NgChm.DET.setInitialDetailDisplaySize(mapItem);
 	}
 	NgChm.LNK.createLabelMenus();
 	NgChm.SRCH.createEmptySearchItems();
@@ -162,6 +155,24 @@ NgChm.DET.setDetailMapDisplay = function (mapItem) {
   	if (mapItem.version === 'P') {
   		NgChm.DMM.primaryMap = mapItem;
   	}
+}
+
+/*********************************************************************************************
+ * FUNCTION:  setInitialDetailDisplaySize - The purpose of this function is to set the initial
+ * detail display sizing (dataPerRow/Col, dataViewHeight/Width) for the heat map.
+ *********************************************************************************************/
+NgChm.DET.setInitialDetailDisplaySize = function (mapItem) {
+	// Small Maps - Set detail data size.  If there are less than 42 rows or columns
+	// set the to show the box size closest to the lower value ELSE
+	// set it to show 42 rows/cols.
+	const rows = NgChm.heatMap.getNumRows(NgChm.MMGR.DETAIL_LEVEL);
+	const cols = NgChm.heatMap.getNumColumns(NgChm.MMGR.DETAIL_LEVEL);
+	if ((rows < 42) || (cols < 42)) {
+		const boxSize = NgChm.DET.getNearestBoxSize(mapItem, Math.min(rows,cols));
+		NgChm.DET.setDetailDataSize(mapItem,boxSize); 
+	} else {
+		NgChm.DET.setDetailDataSize(mapItem,12);
+	}
 }
 
 /*********************************************************************************************

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -750,7 +750,7 @@ NgChm.DEV.detailDataZoomOut = function (chm) {
 		if ((current > 0) &&
 		    (Math.floor((mapItem.dataViewHeight-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[current-1]) <= NgChm.heatMap.getNumRows(NgChm.MMGR.DETAIL_LEVEL)) &&
 		    (Math.floor((mapItem.dataViewWidth-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[current-1]) <= NgChm.heatMap.getNumColumns(NgChm.MMGR.DETAIL_LEVEL))){
-			NgChm.DET.setDetailDataSize (mapItem,NgChm.DET.zoomBoxSizes[current-1], mapItem);
+			NgChm.DET.setDetailDataSize (mapItem,NgChm.DET.zoomBoxSizes[current-1]);
 			NgChm.SEL.updateSelection(mapItem);
 		} else {
 			//If we can't zoom out anymore see if ribbon mode would show more of the map or , switch to full map view.
@@ -781,7 +781,6 @@ NgChm.DEV.detailDataZoomOut = function (chm) {
             NgChm.DEV.detailFullMap(mapItem);
 		}	
     }
-    NgChm.UTIL.redrawCanvases();
 }
 
 /**********************************************************************************
@@ -791,9 +790,9 @@ NgChm.DEV.detailDataZoomOut = function (chm) {
  **********************************************************************************/
 NgChm.DEV.callDetailDrawFunction = function(modeVal) {  //SEL
 	if (modeVal == 'RIBBONH' || modeVal == 'RIBBONH_DETAIL')
-		NgChm.DEV.detailHRibbon(NgChm.DMM.primaryMap.chm);
+		NgChm.DEV.detailHRibbon(NgChm.DMM.primaryMap);
 	if (modeVal == 'RIBBONV' || modeVal == 'RIBBONV_DETAIL')
-		NgChm.DEV.detailVRibbon(NgChm.DMM.primaryMap.chm);
+		NgChm.DEV.detailVRibbon(NgChm.DMM.primaryMap);
 	if (modeVal == 'FULL_MAP')
 		NgChm.DEV.detailFullMap(NgChm.DMM.primaryMap.chm);
 	if (modeVal == 'NORMAL') {

--- a/NGCHM/WebContent/javascript/DetailHeatMapManager.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapManager.js
@@ -240,11 +240,15 @@ NgChm.DMM.getMapItemFromDendro = function (dendro) {
  * is visible (i.e. contained in a visible pane).
  *********************************************************************************************/
 NgChm.DMM.isVisible = function isVisible () {
-	if (NgChm.DMM.DetailMaps.length > 0) {
-		return true;
-	} else {
-		return false;
+	let isViz = false
+	for (let i=0; i<NgChm.DMM.DetailMaps.length;i++ ) {
+		const mapItem = NgChm.DMM.DetailMaps[i];
+		const loc = NgChm.Pane.findPaneLocation (mapItem.chm);
+		if (!loc.pane.classList.contains('collapsed')) {
+			isViz = true;
+		}
 	}
+	return isViz;
 }
 
 /************************************************************************************************

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -1527,9 +1527,19 @@ NgChm.createNS('NgChm.LNK');
 			lastApplied = []
 			lastApplied.push({rangeStrings: ['','']})
 		}
+		//Remove any other open gear panels
+		removeOpenGearPanels();
+
 		let panel = NgChm.UTIL.newElement('DIV.gearPanel');
 		panel.id = paneId + "Gear";
 
+		function removeOpenGearPanels () {
+			const gears = document.getElementsByClassName('gearPanel');
+			for (item of gears) { 
+	            item.remove(); 
+	        } 
+		}
+		
 		function optionNode (type, value) {
 			const optNode = NgChm.UTIL.newElement('OPTION');
 			optNode.appendChild(NgChm.UTIL.newTxt(value));

--- a/NGCHM/WebContent/javascript/NGCHM_Embed.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Embed.js
@@ -1,0 +1,36 @@
+NgChmEmbedSingleMap = function (options) {
+	
+	//Set all option parameters to defaults if not provided
+	const divId = (options.divId === undefined) ? 'iFrameDiv' : options.divId;
+	const displayWidth = (options.displayWidth === undefined) ? '100' : options.displayWidth.substring(0,options.displayWidth.length-1);
+	const displayHeight = (options.displayHeight === undefined) ? '100' : options.displayHeight.substring(0,options.displayHeight.length-1);
+    //Path to widget file. If in servers top level web content directory, just use file name
+    //to path to another sub-directory within web content: e.g. './subdir/ngchmWidget-min.js'
+    //to path to a URL location e.g. 'http://widgetloc.com/ngchmWidget-1.2.0-min.js' (one we have tested with: 'http://cloudflare.com/..../ngchmWidget-1.2.0-min.js')
+    const widgetPath = (options.ngchmWidget === undefined) ? 'ngchmWidget-min.js' : options.ngchmWidget;
+    const iFrameName = (options.iframeId === undefined) ? 'mapIframe' : options.iframeId;
+
+	
+	
+	
+	//Retrieve required heat map div (above)
+	const embeddedDiv = document.getElementById(divId);
+	const ngchmIFrame = document.createElement('iframe');
+	ngchmIFrame.name = iFrameName; 
+    //Optional configuration for iframe
+	ngchmIFrame.scrolling = "no";
+	ngchmIFrame.style = "height:"+displayHeight+"%; width:"+displayWidth+"%; border-style:none; ";
+    //Required sandbox parameters to permit full heat map functionality
+	ngchmIFrame.sandbox = 'allow-scripts allow-same-origin allow-popups allow-forms allow-modals allow-downloads'; 
+    //Add Iframe to required DIV
+	embeddedDiv.appendChild(ngchmIFrame); 
+    //Construct a fully configured embedded iframe and add it to the html page
+	var doc = ngchmIFrame.contentWindow.document;
+	doc.open();
+	doc.write(	"<!DOCTYPE html><HTML><script>function init(){window.parent.setup_"+iFrameName+"();return true;}<");
+	doc.write(	"/script><BODY onload='init();'><div style='margin: 1em 0 0 5%; width: 90%;'><div id='NGCHMEmbed' style='display: flex; flex-direction: column; background-color: white; height: 80vh; margin-bottom: 0.25em; border: 2px solid gray; padding: 5px'></div></div><script src='"+widgetPath+"'><")
+	doc.write(	"/script></BODY></HTML>");
+	doc.close();
+}
+
+

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -1220,6 +1220,7 @@ NgChm.UTIL.embedExpandableMap = function (options) {
 	doc.write("<!DOCTYPE html><HTML><BODY style='margin:0px;width:100vw;height: 100vh;display: flex;flex-direction: column;'><div id='NGCHMEmbedWrapper' class='NGCHMEmbedWrapper' style='height: "+options.thumbnailHeight+"; width: "+options.thumbnailWidth+"'><img img id='NGCHMEmbedButton' src='"+options.thumbnail+"' alt='Show Heat Map' onclick='NgChm.UTIL.showEmbed(this,\""+displayWidth+"\",\""+displayHeight+"\",\""+customJS+"\");' /><div class='NGCHMEmbedOverlay' onclick='NgChm.UTIL.showEmbed(this,\""+displayWidth+"\",\""+displayHeight+"\",\""+customJS+"\");' ><div id='NGCHMEmbedOverText'>Expand<br>Map</div></div></div><div id='NGCHMEmbedCollapse' style='display: none;width: 100px; height: 20px;'><div><img img id='NGCHMEmbedButton' src='images/buttonCollapseMap.png' alt='Collapse Heat Map' onclick='NgChm.UTIL.hideEmbed();' /></div></div><br/><div id='NGCHMEmbed' style='display: none; background-color: white; height: 100%; width: 98%; border: 2px solid gray; padding: 5px;'></div><script src='"+options.ngchmWidget+"'><\/script><script type='text/Javascript'>NgChm.UTIL.embedCHM('"+options.ngchm+"');<\/script></BODY></HTML><br><br>");
 	doc.close();
 };
+NgChm.UTIL.defaultNgchmWidget = 'ngchmWidget-min.js';     
     
 /**********************************************************************************
  * END: EMBEDDED MAP FUNCTIONS AND GLOBALS
@@ -1236,27 +1237,6 @@ NgChm.UTIL.redrawSearchResults = function () {
 	NgChm.SEL.updateSelections();
 	NgChm.SRCH.showSearchResults();
 };
-
-/**********************************************************************************
- * FUNCTION - b64toBlob: This function reads a .ngchm file from a blob.  It is used
- * in html pages that contain an entire heat map (.ngchm, widget, html, embed)
- **********************************************************************************/
-NgChm.UTIL.b64toBlob = function (b64Data) {
-	  const sliceSize = 512;
-	  let byteCharacters = atob(b64Data);
-	  let byteArrays = [];
-	  for (var offset = 0; offset < byteCharacters.length; offset += sliceSize) {
-	    const slice = byteCharacters.slice(offset, offset + sliceSize);
-	    let byteNumbers = new Array(slice.length);
-	    for (var i = 0; i < slice.length; i++) {
-	      byteNumbers[i] = slice.charCodeAt(i);
-	    }
-	    let byteArray = new Uint8Array(byteNumbers);
-	    byteArrays.push(byteArray);
-	  }
-	  const blob = new Blob(byteArrays);
-	  return blob;
-}
 
 /**********************************************************************************
  * FUNCTION - loadAllTilesTimer: This function checks the dimensions of the heat map
@@ -1283,8 +1263,8 @@ NgChm.UTIL.loadAllTilesTimer = function() {
 }
 
 /**********************************************************************************
- * FUNCTION - b64toBlob: This function loads an .ngchm file from a blob.  It is
- * used in .html heat map files that contain: .ngchm, widget, html, and embedded logic. 
+ * FUNCTION - b64toBlob: This function reads a .ngchm file from a blob.  It is used
+ * in html pages that contain an entire heat map (.ngchm, widget, html, embed)
  **********************************************************************************/
 NgChm.UTIL.b64toBlob = function (b64Data) {
 	  const sliceSize = 512;

--- a/NGCHM/WebContent/javascript/PdfGenerator.js
+++ b/NGCHM/WebContent/javascript/PdfGenerator.js
@@ -8,6 +8,7 @@ NgChm.PDF.colDendroHeight = null;
 NgChm.PDF.customFont = false;
 NgChm.PDF.isWidget = false;
 NgChm.PDF.mdaLogo = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQYAAABsCAYAAACILRy0AAAgAElEQVR4Xu3dCZht11Uf+HXurao3aLAkyxaejS3bscVgW8RgaNwONCEkgaQTbEIY0t2hY2IwU2iGJk3sbkIIaUIScCdxAgS6TQOGThNoExI6FsQYCAgM2AaMPOEBbFmSpac31XBPvt+t+39sHd2p3qsnP0W1v6++qrr3nH32Xnut/xr22ut0Nb+NqmpSVS+vqj9XVaer6oaq+nBVXVNV/6Kq/t+quqqq/teq+raquqeqct+3VtXrq+rXZt3fUlX/qKrunvV7dVXdXlWvnPP4cVXtVdULquqzqurvNv16tnv8nJrd61nHqupbqmqrqrar6rlV9d9W1d9p7vX811bVr1bV86vqS6vqa2Z9bFTVblX92ap6VlV99+xzv589G7drNqvqb1fVW2ff/+nZc99fVb43ju+rqn8z+1+fN1XVP62qJ8ye8dtV9bVVdXbWx5Nnff7N2bzN509W1fmqum5Gc/T63qr6t1X1A1X1w1X176vqeFWdq6rPqKr/pqr+56rqqqpv6Nr+b52M2T3u/VdV9X/M7rF26P6NVfXZVfWBqjpRVfdX1d+ajcM1Gt74H6rq82fr8OiqumvGG/9nVf3fs+u+Y7YW1h3tjEX/75jRw5y+sqrQL+01VfVdVfV7VRVe8B1+QtufaGibe/DD58349MxsTfBe+HEBmx99vIgCFmpZs+AW9IlV9Y+r6r+fMQqguHcGDBbsr84Wl2BgaItngX921vnnzEDmv6uqa2cMYgH/aM7DWyElvH+lYZDrq+onq+ovzIDI7YTuy6vq1qr69Vl/f6qqvrqq/mLDHICMoP98VZ2sqjdU1d+oqt+czXGnqjD1T1XVj83GSBAx7y/PmJ7A/WFVuZYQvaKqPnEmOI+qqpur6nuq6qUNeBCS35kBqOH9y6p61wzw/P+M2RwILIH7mFn/n1RV/0tVvWQ2vvuq6iMzwPvfZuAGBK0PkAAKbxoIk/4jXP+kqp5eVV8wW8MnzQAM0Pgua2e8aOT3Y2ZACySAXNsoCuBiTaw1YLtzBjqUhPb/zOj3lqoCbuanL/RDS8DxnJlQu54SwB/oSqj9eC4FYe1+o6q+ZNZ3+OSLq+qvzUAKTwKr/3EGbi4dAuURGqxBgVXAkC4wAbT+y7PFzecshh+tqr80Y6B8jvl9jmE1wPDnq+orBmOat2hZcMzwhTPNFOamQWlLQERINMzle0zvc9rwv66ql83+j9YwHgLwi7P7WDqeT/g0Gv2fzwQP42o/PmNSYNA2wuga8wEy/6D5ElB+/+xe/QMVjPpbs2vcC3ADisZtXJ87oO0zZ3ND27TQBn0BsOf/7zNBpzXzfa7P3D0D4AEbgBzL6uNnVhTrDN00Y0eHXxnMuf23XTfgAEQIKIXRth+cWQSx7obj8j8Q8ry3V9U/rKoXzS5qrROWHosP+Pj7/2+spb83u/6bmwdbyw/OAbMlUzr6arjAyygSgURoWiHaJp9jip+ZmaSEx/8x5V5VVbfNOmfmMkeZ4QQJA9MczMUhOIS5aVCCzsrI82inH5lZEdFKhIRJDAz0zaX4zJkwsjYiHK+bMVeAgbvxnVX1Z2YC+WUzcMFgeR6XwA9NRePRXqwSQkn7EXjuB2vK958w64O1wgTXWDNcFmY8C4Q7pmWerAzAADj1GdBhidCgPjcHGhatXMOl0te/rqoXziwUFswiWlo3oM6S0b95pC9rZHxvboCB5reuLAZ0Zl3pv22hK6XB0rJO7mvNf2sFkKwz+qAbF5Klk/lzpYC9z7iuvzvrw3zNlUXBWuDeAEJ0YekF3FhcWSfWj/u1I0vhErBulcWQxX/8DBgwFsHP5xYH4vMRMbz/aVI+L/OOaat9+szi4FpgHIwN9Qn00A9cBQy0E0siwEDb/H8z5vhPM7PUeAk4M7wFBgL8xoYpuSW0lDlgzlfPLIowN+EgRO+cgQ6tytIgABph8ByWkXs+babR/v7sf4yNwVk/QOQpMwviG2ZCoo8hMOTZQAYwsCRaRg9wEBTz5kJxh4bWQgs+nv0pVfXXB+NyjT6AONppLEP0Y+mwbKwtnz9gkvhFBI8V93/N1lucISDmOi6l//9gBgzWjBvE5Hd/4hriPniH0Gf+mQ8XifY3LtcAAS7mh5o5c4soHrTQN+WAJkcxhosEh4MCA83DXAzBuRLMbYG+mKKG0gbI/M+VoLFo5bYtcyXcw1/EzPF/+fH8f5ZAgOGfzTQaV8HnLAAA8E0zC2ceMKQ/vuxjZ+DAhDaPttHIgmXM3LaFaWkwVgxrQOMf/4eZlucqDOdn/MDwfTMX5WKAIfOhzY05wDGPBSJkAsjMcNYHYCG0LADfA0oAF01rfPr9hRU8tQwYAKIGMIAg63DYovEJPrqgI5oJvuY7z2CtsTiAszGzFqwJHgtItn0LZuIZyojVdmQ5XAQ4rAsMj6sqAkhTtxYD052JbiEsahbqh6qKf8kq0AirqDFTcVULMzP1BfIscJrPBAP/q2bBRdVpbEKsCUaySMQgMEkEiVmrP65ExvmxMwuAdiEsNGPLbOZGE9F4bcs13ASBWS5SmJmVAZT0SXgJxv/U3MyfZxqzLjT+P/9ZQJVAZf78f9pVAFULg2c+iYkAXCb6PAHIZwCLRcDiS6xDn4CU28MdyXNpZoFaLgAAZSkM3Yh2PCwGa22XIhZDgAHI2IEJiIcMrbvEFUQTvAQEWHlop1EO6M+NZb0IwHIt0AY/abHYsgPmM3Pkhgp6HlkNA+Zd5991gQETCvpk67K1GP7dzBoADGEujMXEJyQas5dZjNExgPsBjO9ZGou22LgNrv32GWMQXACl7wgi/5Y5TPA1Pu97ZxoPY7VuAROfT+0zDcNjTMxoS5Umb31k1/Kv+d/GjaFpWNpLw/TM2K9rAMWcMHKASmSe2SuOYMdBoJLAAClNkJEwipG0wPC8mSVjh0UbAgNAMmduG/98kWbMfAQHAZYtXNbBp1bV18+suP/Y0BMYWmtrOM89CV/leTS9ubLuuJOtIFoXlgeNn9jSL1XV78/Am2tpPAlS64PFAKhYpsAJLf1um/HiJ3EWVhvXwhqwEACdLWK82tJt0MXRv8sosAoYWo0jOp4gUT4nnLaPmPEWJUxBEwkyYQANE0N+wUnCSMBodCa4iPUiYHAdbUtoaXT+ZbYSEzwzLqY+7RBNxLzGHIQ+YyIYhPrds+fl/k+eMSKtHXrEj2a2JqfAZwJocjgSO8HAtDEGjxBxR+zbi1toPjdP8QW5C4QA4GXONCFrgWnsGRkvKw2gApG2tWtCkGjreRq9vSd9AhFCBCwIHnCSk+H/xENiVQCPZdo247Cm1tu6APuWhra3WXfJ2ZAXwZpEG3T/uBkots/n3qEv/mGRmR/l4Ro/rCN0QStKScOD1hwPAm1r2fLjEQockAKrgOGA3T0IoYeCdpD+FmnA9vN5f7fMnO8X3TPv2nXGOJzXoufoq002St/zrp8n/IvGcjF+c2sJtf22ny+i0zo0GV6zbIwt3RetwaL7h/ei7zIaX8zYH/H3HAQY1mGsELTVAD7znJjvuSYBsGWLkPtoM3/7GSbatFHw9vn+bjXpcEy51v1+hv363j1DGukzjOg+LT517slWWzt397l+OAf/Jzo/BId5ny8S6nWYOWsQl2XeGiyi07L+l/HGkH6enfWcNz8WVmi8aCw+b2nsnqxB+pwHFuvQ6OiaOUx/RJQjChxR4IgCD9KGRyQ5osBhUCDWXSyqedbYYTznqI/LRIGDuBKXaQiPuG7nuR8PdyLEHUpcYNn25sN9ro+I8R8Bw0O7zMMo/8UEER/aEa9+2qI53Dg7mWrHQo6BXZdFsYjVTzm64iGlwDrAsOqaww7yJJh4OQgREze/E8BaFNk+zDEEFKRAS3Cy9Wvb8uEsLAEFmYt/oqokjElCk7Bki1lWqeagm0SkZXkRh0nro74ukQLLhH5dbbbudZc41Mt6e7v70e4wHOZDAwD25eUSyAp1uGy49XmYz7zcfSVvRI6KU57D5tyMayQxOWNyBAyXe0UOqf9FwBAmlkgiCUZKqyQTQaR8J7EHM0huOgytF4BxqElSjMSn9CuRKhmTmbqxSNIhyLEy9BHBdo/749Mbv6QqPzIj/dwxS/Bp60K022WHROYLiUIOJ0kokkYsW1F249sOiX6HNdaD9JM1e+rMSjAvKdwyTrPliJ4Oac07Fn6QZx1d+xBSYBUwEFBmr7RXOf3DhqmdApx35Pcg0wgAMEPly89rPnfKTuabw1syCR25XdactJMBByRkLcq8GzYnJaU8SwFm2iev/zDALs+Kpvyq2QGvVFByxkJq78NZk86zGB1NB3rWynmLI2A4iDRcAdcexJXgM0p7dYiFttMInLTceeW2DjK9CIZ0YycwCQ5Nr38mt5TXYbEU/TPFPZv1Ykyudy7BYS359CwKzKl/3wE42k06rhRawNc2z1CjQUqtdhgC2wqO4if874xVUE7KtfZwdsmSJIZe1s75Bke9A4BHwHAQabgCrl0VWGyDdawCAirXPfvSGEHe+4svgbkTlGOROBXHZYh7oFunEOXO81Vb/z+BQ+MxrjCh6LeTfus0ffN9nSHIMWT3OejjzIBDVZcKDrE8VCbK+Yl2fuokAIzDtFDWmfvluCZzSLm9I2C4HFR+CPpcBQwZQoSDIDmIpLUFOwADpr8YIco9YgtOK4oB8FU1h3IcsXUwZig4OV1JGzmR56AOV4G210+KxrRkzH67z9qkmzZ4FvMXKDiBKBZxKUI7DDpyhxzwSmDOiVGnHC+Gdg8BixzoEZmrE7BK6x0Bw4HId+VcvC4wZMGZ4Cr7MNeZ5bS97xzVpWEPKkCxFtQtIIBOSSqcqq8AgxiGqsLDvhMRp/HVbQwwCJby5VcJWnYiEiRThCZHt8PQTvjR6MPqReuuYOZnT1+AUywjR64DDOasctG84+frPsd1OYcxL7kopn76y3mFg/Q/vHaY3eh7awRYLxUYhuNtt5XXHfMierR9t+de5s0vfbTf5RTqQbfp2ySw9Jdt8ovZCUt/Gc88BdjueM27biEt1wWGCBmTm8+vOIpAIY2agzj+zxHeVceAh5aIijz2usUXHMVVg1C/hH2RxbAIGNQ9cCZ/FTBkDGjgWoKqXoHiosbvh9WhfoJiKwcFPf1nDPxtfrdqRapLqVvAuon7om6kOg7rjlnfrWAuOpA2PGzUMsLFZmAuO3SW/vGHilEHtRhW7Qitqg8RYWnpkdhNvltUu7LlB3RblcY9TFZbJGTr0GsZqC8S+HZ87RyXjX1tHj4oMCgNpmgGwRXtV+8gi8+vFPRb9+EhrJgCi4D7IIiIqQBEgOGgFsNBgSHaNqitwhPAi0bHSMAqRUrXBb02mKh6kiAjkFM3Qq1JFYhCO3ESNTLXoV0snSHjKhhjnGpDtEVlzU/iETrazbFTI5bDQouWX2dO8xhcXEgwN9ajYK/4DJA/SPBxCFLm4n0eeMI8bSun8tTwxOUiwZNIZmw/N6grYcwCwJQOJWdbPLyYbe9YA4roeM8IEEdT81NjxHgCzssshxbIjFt/nh+lwIpkMaZA8CKw1s888Bd8V11MH23lMX+rFaLAknGrQaKuZmJbKy2UgwLDF83q+CmmIchnqy9bgMpuYXwDXQdNMxH1BvVFkwIc1YOU5Yo2xdBe0rKuK3ExwNBqd7sVCsJYCExpnOIf4hAH0egZr5fbcEnaIK0EJ4lOAR+umd2eYWm0eeZty4gK4HDvVNTWp+1jBVHTbOlys+wcyU5MIwwpWyemswqQ2nkTtrzvg/AOW7Z7gQX6rcpjaJ8tVsV6VAqwbXZxBGhVAEu1p3mJYQDFThMLTGEeFZ7kVKSJRyn8E55VWcp6E/ZWsLiV4lRoO2wUotJzlCCwmsfr7dhUFAOSaGaNh02xXVWuWJSpqt7SpFUwxg38FRc2bm5udgXTb16kZLu4bWRIoplqWyt3wA4KDMpoqbmIKCyE4Y6ASkUYcZUAtQNDXIBiOxRjK9VmUQMM/G/XXG5gyJgwiJwJ44ngYhwLsqyE2nDBQwPBUK4NK0gJN02JN3MSW8kzgKE8ikW0CwPSOqog04gYLYFa/dqizXsZxFkkoJlPGk2RClo+YwURRgHRRWCe8bA2JCmZiz4pBYVvaTvzYREpBd+2VcDQ9i02pOKTRqDRnMYj2G3+CVePS5bxAgIKBUhKy24B0FY2wdHCq9G8aMFVlL+SIsByLqSq510eqUDuc2CT8elvkQJq6WjNxcBU49IkAxJ+a47nARDapYk/UbrAp+UDcqfKF/qyYNrGildCz+fAJeufa/JSosh6ZHepMjgoMEjIgdpQiQBbFMwYE4VphFnb19UN5jH9N5O2IGoiWgzWiMZywNQBhrxh6nIDQzsuuQw0S4TWd8xP5tgq7eraMAdtwezEgE+bBW2jmQKAcSdYKRZ/kYDmuWpDEhwl1TR0IoCYl2kMYFTuVkTXOtjq9QzMScPoPwVe3YOpMNc8DZx1IvQqPgMlNLE+QC4v5jEOBXitITeCcCbAuchiSN/GJb5CAQAqgpxXAOrXMwk17R2giQLyvWcSCC7pkB5cNpmYAJLF17bQXUA42hXdFNfVbHmzZNvGkgHewJiWtxZa6+PHosuWre+5yuqKDpP3uM4pspy5oQELkKsXXgFw7YuH2nQBwMk6I0MaHmW1oweayrbVkjvjb26GTYSFvLwuMKQDWZDQGbERXVMsldbJNp/KzN7PMK+0d0tEfyMuBvaTbdBsW4ZQiqGmgGvrCx9W8LFd+DAr5mRqJ5Jr/rQFRF9lDekv18Rl4B6xgvSD5uZmoS14AJCWYJrbJl0EDmFA/QMqjEtw0ocy7cDI/dYB6HJP0ryJCgPJGE22qmtpGQDfMkobcAZE6M0FIRypeel6ra2m5BniHMYRYB0mOGV+rBDrLnBNEGyH+x2fOrSyqyM2Y5s3SohSysuDjIFwmxurIUIAvAiyOIN+aWw+fvuaANYHK8ROmO+1NvEs5faNWb/ZvZIMx81tC+BmXqzqvHVNXIIgMuXTV+QgwBrBtz1PoLk4wLiNf7AubWsLhKM32lhD/MJlZPmw6FiiASfZvgLqLMwWHPAFAFzo8h8UGHIASNAjpeETd8hiWEAEy+CHwZnhDgfGAAxD8AkwQGUA8lBYDHlGm5p90INArZsU0OQP/vSM4bNFRlvYmoXoeUbMvFXgk2coVsvcRasE4Wjf9hV+2b3AGISKySnmQSizZjQqCynPDR0AFSGJNo4WZWkYcxvE8nyMv2q7MuCOL4BvTH1JaqySvPMjYJYX9xJg6ePZlm4trAiJObD2Mi8KBVAQYjtqea0hkOZvAwJWsEawWGyaDFy0Hfr65mj8gI9WJ7zo0wJ+1iSKklCqcj6cl+dEudH45AYvZH5ogSbDgCjrg/UZ+RDb8/oG1k7aMIiZjOLwGWXBlUGXueCwLjDkZouRoEfebcj/ExsQlMqDncFH9HkMHqa2u8GEhcBSrcMAsUrS16KtvMthMYQR+KuEFuKGydbNj0gfXCBMIyLMvbLgmXuusatjUWPWYmQW0qrgUOaONlyBMIkzCgk+ugYTR3j16TPzYdEBoTxXtWUH5gIi2dWwmwIkNaYnzRdtNy8an3kty3x0v/F6R0nMXxoyZ24iCGFyfRIyz2apROHQpuI+zOYIHYHnorWWHisK/e3GJOltOHYgCSzjv8e9Gm6fhp/RihXF8gAoSbYj2GQhcQ5xGGMUXF6knXOv8vd541eAxqsWxXHaXYnhrhkXBSgkM7jNVwifAEcWS2uJJSlxrjuxDjC0TIpxafBsu2VBIDlED6PFCmhAbPrnUCPbZtFXAiTAIMAQgWTyMH2GIHM5gCGLp44AP5cJm3HYRmUertLm+T5+bYJUaBVrwdjRKjsgcQUIjF2MebswLS1DR4vLKgkwBFgW+Y4ZW4Qy4Mv3BSgEJnRlsnoPR9ZUXgJ/eJGL2K7vogSn9l6RfWCgCVjnbV5Dnsn/dhxoS31kvrS2XYoolcSsWjcpiqd9u1U0f+hBkMUaKLeABiuWELoveS0Zi7UkbOJHXIXMiynPEonWT/BzWVwqPGd+lFFrySUw2oIKcASSoYH3Z3iR8jIl7DtrnAC6OYUuc/n5oMCgcxqEKeNV7iEIpI0PFR/Qlgrfrn1wCBTTxpaQqH2LiEOLgS9ui+WhBAa+LOTnJwcYCAl/bRkwZAFZGrQgDUJbWfBFTfTdDkNMT8zFJ1/2nDYQCQzCJC0gz7M6cl/ObQSQCClAinXBzWHaYlYNgFj3VUfEV1kMEWCaEG/k+QKWNDABTSBVMNP3edEPhZSM2NAyvJF+E7cJ4BF285rn1g6DrfIvBGez3rS9WFriKdbWPcMMwqy5ufPvc8iQ8Nl65dosW8t2nWxpW5uMn5UDPNsUgABDruH+sOQXAQNamT96o3v4LBsIFw0MmbiJiphiFsEOJlrry8RfjIbhU9OIQ/NZ8Icw8HMAipezhOgYYWgxLAr6XQ6LIYwtIYgwx5f2rBbEFmXFDTUyjWJ7LzGAFhzQRcCRj0vztTEagbRladiLgKHdrlwGDImhBMQBg2eG8ROIC/PR1CLctOMyN2ddYGBF2ZYLoC3BzQd9lcQ3YxafwIexBmIxhJbrpOpnzVSYEgvIm7jD29w9yis7JeFVAwv98C2acuUS70ALdDSGda1MrgSXoo0ZxV1JH0NgkCjHLV8FDImLBBgS07lkYKAFIZeJ03BJxsn2F+ZO1l2ICq1ZGW1whuZlpg7LfQ2Dj5kAH9xLVh8KiyFjkPmYiHcWPzsx61gMWYSDMnz891WH0i4VGAg5bdoCQzQrwRvGCMSTmK+LAsptPICQrDpdKV5h+zEWCiEXGCSUgmniB377SXEdW6/+9psmFbsJvdCDMA2BYWX0vfH9WSbiDFyEHNXPros5sVoBGvDVwgdDZRAryDUJ0q8Chii5NpicZwiockuvWGCQiAEYBFJEq/NquZgqAEOwDYPFaoC2sr6C6Ex0Vod9YNaCGEOYfBEwOKVnn/qhAIY8I9mY0WgYhX/GAljkL+Zz1xE64Oj6aP5FIIFufNvWOlkV6LxUYJhnMbSuRGJJAWdmKNdwVVB0lcWABtwF2lfykkbQ8ZMkq4O2dvv2YoHBMzNu1qxgn0SiZL76vk0SEzdgBcpYbBWerUTnaloraGmAr5ls+C7A1uaADBXoFWMxhGiQlHmdCHKbBZiJedcgbRET1L6sDMKgu60bQaZsxbRCNgSGgMsQMUPPy+lKZLcggiFpRN5ANNSyiDxzlFkaYQKKAc8h45uzeWaXICawPXfCwnSfF82+VGCYZzEIPiYrkkncBqradO5lwrsOMABBwJnIvfkLQANRfNTuogxjYKF7TiXm/6FghY7rWAyZT8buXaJcBzscWbeAe4CA5UKIAegwAO/aXNduUy9yP2MZ+J6FIZia7EzzSqbnFWcxZEDZLhJgoV0S+TWJMK/9WMAhGSOLE8TznXttBSahqbUC8nciuwEGSMz3utwWQ7QPl0kgFQMHGAQduUCLTMLcK2DGLBajiKWzSstijNZ1iSk69C1bgbycwADIuH9tEE0gEnCsSglfBxhoZf2jVVyZdU3uRaB0qcAQAMpuhefIe6DI/NYCWAFPgkxZJJvRzor05xZEkvexypXI9/OA4Yp1JTJo2yICikwZGWpD7ZnrkvUVoRLdtf2XLMBsqS26P2nXAQZFWKRhX25gSP+2R+0LxyTkMtHeTMdFe9G5NxmT7hFNZin5btHpxQT7/MZgNHnoljTxea7L5QQG68LXBv5tEs06B+TWAQZKA9DgiSiPZB8u2wpdZqlcKjC0fbeBcJ9zBygGuQuxIFjEADT5Hz4XC2NpZkvamGzj4+d1gcEOgy3KNg9jGMC8YlyJTCoTXxT5DlOIbjNFtWg/xEFYlkISMobEyv9B3gBDLI6hgBymK9Fq9RB+CEyLYgstwCUBTJRYtHgdayHzDiBGWPjehHEeIF0OYGhjDAJtgq2t9pP7oJDNMiZfBQy+Z2HiDyCYuUqkEowcbiEuA4OWtpcKDHiJS2CXKC2AHncF/8sybWNiQNw8WMm2Om15anGlZaFKQluYejy7PuO3AyfQHkDGg+JB+s9zrzhgkLjBzJ93eCTCEURNVD4TDKEEnQCH/4dCswgY+OxMunWBYVXgbh6zxU+UDcjfT4LKOtH4NgbDd9aXgCvtsUpTGEvuF4vJMd7QbVGK9KUCw6Lgo/HQVimc0wJDjjAvA8h8tyjBKXR2xkOAFx+gEV5Iok4C1YtAoU0RHgYfk8ewbowh98uW5OJw6Vqg93fiHuiiZobzMv52r59kJ8ql4EY6u5L1c44CuDtcuAwcwicsYwoiSsnOWAoWZ6xXHDCk8u8iYAgRESX74O0+L6ZxAMvpyXkCM9ScIQ7XxJ73usCQug7rCCViJ00Y8ttGw5gWUX4Fv5o7sEwYhllvAlPAz32rNMWQCVljGCHuRJsiHdBtwSSJSgdNcOLmYOJF25UJTrbPbIV3Xt6/a0OLRduVSUSad0jNbhV6C1jPS132fOswDOK1nx9ku7K1TqLIcpJ3yDstGCXJLzTPWR7zT5lBgGes7kucYZmbFD6Rwei05DDbtB3PFQMMQSoagzvQAsMQ1XMtBqA9bUnGWrAdxVdfdCQ7k49lMtzyHArZIlcCojPJVi1EAk1MRYIsPz7n5sVFBIJo8GUAkzFJY3WtjND2GPOy6j4t7fIMwCnBqz3u7bQin78dR4AqGYRh0tbNm6dxc19qd8bVs1aEAlDkGhF9gtYyua1qQWjFec09+Sp5VoR2CAzJ5nSuxrpaG/TCH4m/eK7dD6Y3cAgApu82TuMELg2fQ0+hDTfVuZt1LYbMNaXonMR0AG3emudaO2oODlpbc7F7gx6auInsUDsbGUOSx9ogfbs24SG8BxxlnWr6Ydmh/7KU6GUJTu1zIr+XnOBkMIiRQAs3QGJT/MGYgCn+kUGEqDFHI+BSQ302JCsfoekAACAASURBVDow8aycH0hWXO6LoCVnPcJGazH5bX9yNTJh214ACJO6p93+yvHg9lQg35GVQbg1WtrCy6hbBAoRCvTx3NSKdH+sIuCIOdpnzRPWVtMyQ/nfbb58tnbRJ9t0oVU0ZIBEHglfd54woTN6GG+i3wGGbEFnrV3DtTGW0D2CChy4SuIpw2ZNnCexJkAggEUTchXalvMa2d4LKMltsROFkdt6D9ZCINBa++2QnsN61iK8kDhYeIEl4Jh4+CD5AUNejTLyedKsk1eSpK7Igu1E9NPymkF/h1fyigXPCg/mxUKh5fBgm/FmNy5WXCyRHI4yT/RI6nbWPLtX+E0/rTKK1eLaYXkEbpE6F/PuuxDsWcSw+RyKqimgYXZaIwHG4b1BN6nTwMS2lHuYr20QxX3zgnNyBmjJTLwNws0bZ06btWmkKcW2aF7GZHElqqTYBtfBliQAaxd62MdwzAKqmAUjaQSDBrqYZiEBm63SNoMukelhnwnURjuZA/BOebVcPxxzQLvNN/FMlpIW7agCkXMtWhtv8D+hEGR1dFfWoOAloZC8JjNRnkKbd5AdLQE+f79n5q9j0KwdoSBgGo3JUsquFl+di6MlP2FIj+yIhR5qFag9QcnMaxHmxA5cY+yyeCnAYWNpsWqy1tl2D73C+4kVuD/rmBPH88ahH+Bpq1wLDw0Vky1/wNke7gvopN95MmVN3NemEeTsz9z7hgkk7aBlptFgfB4DtfhhJAk4FoEQ+9uBqtbUC6FEWJn17dnyoQanHZmFDhzxx5iDyZHInjG/zrYlU8vCQVHXO78AtMJYYUTPZx4TWIEf46bB3IPBAFvKhQEvJqSAGCtBWxZT8L08Bf04Ii1fQV/t4RtWj3iFOEMKhy7gzemzaGdmtbnYDcj8IyjGz6qxlZXiHSwDgdnUVtQ/RmJhSdCRpcrEjXmf1wwaM61LcNutNRF0gJp3embLLO5NmNw9BCAC3M4L8BMAgUWgG5oM594ejMMjAKXtP7GfeTTLaVXfGQc+lanIzbXnTwO285LJKD6GR4FYiuC265y6nHkeV4bAcUsDssBCQDkHyxI7aHmljVvk7EX6xJsyIwW3rY2WqlfojoeApiRBSjj9ci2AG54jh6ylrKk1cDRBbEPswRxTmMf9XFuyxQLjdrbgLhZGsbjPeARKL4DKPGAI6iUtdhFDt0SkpdqiD5kUAYzpNSwlFTRsrZFVz/I9c0n/8xhznftpVUAD+TGNnYeW0GGqYV/toq9LG6ADQOadMQidpYknvXad8a97DaGUrYpZtLyYZ9X97sNM7Vu4gIkks2GB0fTlWv0THC0Kwd8YVTyBEmFlogntBewC5KpNAX4abVFzH5eNtaGFfrEwV83L9xLXxFLm7YrpmzDHx3c9SwOwA9WkcJsDsBTPmRdcbvmEJUBo86a2jBGA4jmKN+nWKRqTtPu4Di0wr5pjXrbkOjELhxXjIi+7V1zL4a0LILfMYoAwzkfw4xNPSOeJK8RnslhtIZJcp3+BmJTHbgcXdGLCiq5DaYwyT+CjQRHR4F1ncVtzezjxCDhGz6Ec/rEfn7Wt3ZJaRXzfW+hU2zGmlo7Jsae5CAU/d15rA7X87yzKvPknRdY1mX+spOEaxq+3RqyA7M1z5QSzUmh02X2sDuuR+E/o7ww/bS8rEsOxiJT446sC3MyJJhLnofm4A+3bxFtatNF+oCC5jIvHemJWE8yU23dKMUohsSJ90eTuncenvg8fWA9jzEG/lkcDUNaUxYYfgSPhsr54xpF2rpP7w3fLEtcS3PYc7qo15grpl7VmLkBA6jwaAi0tCjO0RAsuTE62Wv+2hd/QC63i4rNABHLT35Cv5t231GLw0Hl+yiqBeajuWTWOdb5vI+qLLIRF/VzMPNcZ0+W85mLG3N4z9HUxJ0HDrGmuCS2Hz/N/GDpCHWHMd+02pPXhuhKeYQByuF15WHSb5z7m/Q/zFMk642hp0tKJQgV6bWDanNGiBZtLXbeD0OYBz1pmMSDUsu/bh84jUu6NubVo665lmoNM5KDXtgdv1t1GXPSMdWkTTb9qrBfrFq3qdyhsw+3FRfcvWk/znhfZH36m34DvvO+ifPL8bOW1W8j5Lv0sAvB110J/q9Zj2ZjznIMqEs8NKA4tjPD+snHN2xZetG7z1mYVj/j+QWu0ruCv6jwmZ1CnNfXaBfZ9e02EdVX/R99fWRQYuk7D0Q01XcvcWfNWW4YvojVbEF9nu/dyUGcoG5eqTFowbOlzGP0e+vwvFRgWIeG6Aw1DfLQWf91xHl13cApEGy6yGNbpsY1BrHP90TWHRIGLBYah7yQQJSAlai0Kb5tEdNfnzCdbjAJxtkUEXARJ1HYQDAqSXpHIeUh0fiR1My9mYN9dhqDgp9+2/GzV4Q9BTvwhM1Zugx0LgTjl5BI4vRhf+5FE80Of60GBYRggsR1j31pBiuzvZpD8VMLeVr9pJ2CLzuIrWyXaO2/r59AnfNThZaVAG8DzN76Q4SjHoH11nEG0W8TDQbEyKBHbnLYRKZGHK3/MCype1kU4jM4PAgztott+kQCS1FBjkSLrx3aJ7akEWmgGW5JqOMhZGL57LyWyVyUVHcZ8j/q4fBRody5kEnolHOtRs3vhDIPsPvkILMXkdgAMW5u2xyW32SLPd+5dpwjv5ZvVpfU85OmHjeWzLjDkQBL3QAaezLY0e9WSWyRTrGq2aTCMjL3sBc87Wrqqn6PvrywKBBTs0UtySkKPNbbWjsIn3XrZyJXrl0iFv3JWJkk7i86tXFmU+OPRZLxyLFjFzmOse+L2oz6ndYAhoGDRJcxIz9Ts7TpMI7lFS+R53k5DtsliPuaNQe5DLH7novqGH3UiHQ1gKQUiABJ4WAV5nZ1sSAlR7Xsu2x2pdJoAtP/DHymj7rNVL/u9EpcnlgJrWZaslGs8zlp6WFjGq4Ahiy51UwoxMy+Zde1xz1X7w1k8AIEwklay+LISmZwCTw8Lol2JnPhRGlP4I/UVMgxnTtSVyEuJhidwFw23tQqSSi/lWWp9si+v9CB1YiGsY1mN4nCUnvdcipU8LHh8VYKTxQAGjvPKFR8WkFhVbWceA4RwTnw5QZfXszuz8LAg2kdJCK+0x0aIAUDetZD8FQe88MzF8Ef6dcIWKDiDY8fLoZ+Hg4+eMaY8XhKipEOvepPXFbPGi4ChXYBUt8krutv36V1sglIWX2lsUed13tjTJlEh4DC1dl2iph/Xz8tESxQ5/V3KPnxrKbUm88WOf5gFNy9ZaBUdMv9hEtqQvssy/ALutiGdYm2VRt7ufDGg0NIL3XNYLa/5m6c4sl4tLx90zZZlV86jeU6eDmkduXEsGwjYto+LZKuWK5Gt/ty7zAI6jPX2nEX5Rm3W6APWexEwRHDz4pUct0YQuQqrKhutYs729CUfdNnrsrIvviwldtFhltaPbbeN2jz9/L3MWkkq8EHM2HUTfNaxklYlkq0aXyv0wzTpFAaZl2S2SENnzMPajlwHvjQlcinbi+E/R7e5nHx0PNfSatU24CqatDGxeecT1ul/yHcZn98AEy0CDA6xrbvtumq9553BaGUuSihrMCx1EH4Yjv/Cms0DhjCDAyQSkaBeKuKk9NU6zLwKHHxPqzh9KbllHmMOI9HOpCvYaYwQ2fFpwrpoPIsWl1mnDBc/dngNZLeIxmYv3fZrToeuy+zDcYtMOwJt/A4fMY/VlshOzqJ+h8lCovbiMbZ/NYFbJnsOMw3psIjB7Bq4h6nelsDjFmBm41KIRRuCQ56RupFhfHNe9A6QdXhh3jVODApmOt3Ytpa+rrGe+NTn6i2gCdcj2rIVgHmAIUgo10Icze5Ja+1wpcUHnLxUm4HWz3ssF/Gdz/OC29DHulnzeWCbz4br7bg3OntXLB6x3k6risvNm9siflfvA+85Bd3yGp605hLMcqL2wqIPFyRET1WblN4y6GWv3L7YxZ93X7t4JuKoL+2Rirm5B3AxXUWuh8LVLgDmRwTHaRWeMQ+l0CXfpBEWNQFcE4HyHWZQXMNRYm0ZOAwX1nMUqrFHL6bSNlaYrVr9OtI77Nf/cRWMndApOQdY2ga8lDVXZj/l0YaBOiDPHDcOYzJHtQfco6kJoVKy19ClebeGvJNh7YLwR+okphhLG0ReF0CX8cwiAfK5eSrOooYAq3aYPCWPRpEVtRAcx54nwASd9av0G/7yv3wKwqsBYWvDmqW80qyJMmnqJMjQ1HfcMjyq6hVaUDApBuR717Y7b8AHeEkQpHhanrfzx8W2e5c3meX5gI+lpgJTe/y7pTka6UPg09Fr81N7xPqnKRojdSDGAUWLFtNCNsssBgii0yy8wSOc34ex8BlgKwA+a7WBaLcyWQQjLzn1JiutrcWQcu1hgIxPgRECJStTYlVL5LxXk0ZSQUclprbFdcnJR4IiASd0G7oVLU28oUi+R1t/MSZ7y2BhcoIKJIbjd60iJqoWuZa24Hcbs+SybB27jrZTHBX6h4bmZMsQ07vWGNOSOISeXpxibQMCATgvWVXaLf1ljrQ0RkLX8Adh8damRe7HgLxr/RuTGO3afgEk4TAO2pvlh3bAPUlVHqAQ65+fFZ1xP98fGKpvwMJgNaZxf/AZwVCTQdWnYeGYtiKVQLz55l0SeVFRO7E2UWvehNFbfKbN8bDeCqegOctH8WWp44RaQaQ0ykRmKXCJ1SfxUBUr643fs3XsnsQG/Z1Cv4nF+E028pKjBwFDFt5OAW0MNRNfCOIETA7ib6/FBQ3gWCDEgWAazU4wEYBpRegsbnZJXNO+Wdv/BJs2AQCxAMwFETCI0nSYnsksiKaqDrfB94REf1rqAXh23pg01EAtKLjGG4i075tZJvb03S8XBANhbHQEdpLGUn9v6DumZD+rjfZWrCTNGNBIaf3QQbyGcGTM/HPgkCo++vHD6nAfGtBk8YX1bf76w1Q0rsScAEN+E4i4GuGPvP/jciQitaCAtmisKYPGWmpbKlXF/bWutjtZfqw2487aZhvV2lgLGlb5NIDI0gB23BjuBBfWWuErNMRDUvpT/IYg4lvWgu9UyuYChBeN1TkQdE2RWHzB5UjLO0w9w3rLC0kjuGhMy2duQMmYEwxlfUgmw8+a5+jLeLgRgAS9zK9teY/KhSrjQ4shi8rfUqU3+Qk+Zzoi2mHFFwZju2CFcGHyshbX0HgtgXzGRBNfsBgRColW7s34WmZS5UeGJoJFc9trh6wAkAkImdvAHGtJrcrUVESDeSXw2+cAmpiSTPZs4w3nyoR1rTJjWvtW5JilMdV9n0rAbZQ6Y/X2ZaZido2Gb0d2P4YQHwIQEWQuDveChpGqrPipcSRr0XXGF3MZg4U/2hfSZEzAjsa5HMCQNU0lZXOKNePvWHWhCeGgeUOTvFIga0XQWWGpL6p/Zj7as0IAD1BvYxvuAaSAvQWUvBRouMYt4BoXC6WtN5nrMzfK7qtmH7KUrWsstwi531xgMpG5qcjN5WljRaxDFkL7/lE1TZ1JYi2wsvx2HTBJwxNo9SCLIYuaNzK1B12iLS/nwreayPjylukEVaLtgUGyJ8PoAmbMSGg6z5wN4V1vDq6Jlgth8pwIZ95slP8tInNdTGNoXtPe/E6tfatSu7UVIEZXmgMDQ31A2MYnshukr/ZdB+02XAJkhJfJGbOVZqS5MHUL4piCWR162YamAPI25dAATbgpzsJwMVprKP2lpmP6cu+lvph2KFj5P3QWGwJgWl7EE9cogetcK/6A+VN12fesIrsCESA0ohTanQTKhuCnTqY1yTMSwMwLZ6K1o4nDU7EmWJ8szwg1KwVY0N7py7P1k/e6rrPeKVyb9XZq2dzytitj1j8XWhwh7o+aq+Zs/NY9ViVAd+0PzooITwc8tBhCpJhrLTBAYKbOxb54dNHC+zwL+hVXVX3vZtWZU1UnT1T97fur/u4/qTr2ipn/e1tV96eqdv/KDSee9Ev3nPvNU31/vbO5m1WnXnj8+HN/7ty5d/7YLbX1krfuE/91L3zi1kt/6X1nn1r1Tee77u+d6ftzO1XHR1WvvX8fXNAgz+/7qu51VaN7qkYvq9rpqn613y9nH0aYlut+ZdXWc26peulba/vjx+MvumcyYV3Usa77kXdMJl/4hqc+9Xi9+927L67qjdl3/vb7Z26+eePP3nGH/qatrxq9rqp76f6C8msxdfxb8QeWB/M/MYCsXcxEsYfECKxPq73DmHkJTBs7SfVu18zLOxgCbEAib0xqgUFguI2TLFvvdb/L8wkToUpMJVbkkCahi3GJuaBdLEqBSuCdt2ixANCZu6y5h+CorJ13SrQ7Zbkv75fM3LkH3FvrGfrgJ/ENGjv0HyY45VrjMLeY/1nvFkAyr7iBtkJlI0foAYvgccDJ2LJ50K43wMMn4eW41g9aj44g1ItrfPupW7sP3XvvaMawqc+/FBim986YvquazP5PMJEkzNA21imgn+J9G5/oIxSvuOGGa7/n7rsVxnzxNVV7J6ue+8F9VF/U8lZm3yMS18KWzrzG9ORfhVH47y97cdXGG5qtUvNob/7Y0egf7/b9V1X15073dfym0eif/c5k8jeba/itItki++bFTcAUF9U+bmP07Wcm/Tfv7VPoV97T920Ac1GfeQlJzMtYARgl7mBe5NO+NDeWRYCxDfbNcxkjqPx01l3S443rcgBDxsXEZvFpmDuJQ8tonBcMhyasHC+kiWKzXiwIrqLGlSDgecvWcPs89GCVEsxYEiwzn7UW2jrAkLmJL33DbAx5mdMq3mGN4LPEBvIyJ2O0RtYlaerZoTJeQVXy1SqBANQDtnHn7UrULaN69d199/Jx1e5O9bVV3caNXf9NvzGpv//6m28+9jl33LEbzZ0Z9FXjbvHr3ldN9ML3P/QJN1318++69wu+79Q5k3/z3U+79VFbJ86dOH/y3Gbt7T2h60YfOD7q+nPbm5/4mg996B/+wkfuf8brz27XNV13/tVPedRnf8kTH/veO8+df9TG+fEU1M5t7m49buvkXV93x3tfcn6v/863ndk+/6vbe8c2uu5f3juZ2M14UPujT7jpqsnG8Sc/7tob7+xuu912lV2LAMr0pblve97HPuXZV1935ht/9/e/+vTO5FtQ98R4dOfLH//ov3bD1rFT57vJDRuTflzd+IFB2snknn6vv2u02Z09vz3qR7vjs3ubd+/ddMOz7+5uuy0Zc0xhjcAD6RNPG1d/bdXk2Gh01c7e5OSkqh9XnThTo6d+uJ986UZ1G8dmq7lV3WvePpm87CWzt0i9bn9d4ndnHnnH5zwLcNHOwjJgaOMkqxLO1uGHdgxtiXhanruTuAIBFnPiNuRvsSPumPyENCnKXMMI5BAYCBlgUEho3q5bq+FZCelb0JIpL37QBmmXWQxxTbmTdncSpGRx5a1o0fSZm3tYSALY5pb5mx9rkPvfAkNe1xfLhrtptywuSMuXD1rv7l0vfurx6+4bfXnfjZ+1M+nfdNNv3MEkaYNLHmwQQaUHLOqHX/jMJ4y2r7n/httvv7e/9dbNu3bue/7GtcffvnHP5Nj25tnn18b4UaPqT/Z79YS+787WqKdhn9T13U7f9VvVdff3/eQnR119ZV/dXV1fzzk26q4bTbqfOt33N1TXf043M/dH1V0/mUaP++3NrruR3X9qMulP7026cVf9o8bj0+MOk5DG/Xl3++GGyc6kznRdXX1u0vfb/aTb6sZ3Xz3q7u6rfqcbdef6SX+8q+r7UX9T9R2mefxmV/ffft+ZN/7MR0593nXj8d7rPnzf+KU3Xvuzf+tJj3nTfXuTrxlVHTs/6U9sjbpun7LdBVuum+mTIfLuTcD5dGwpl3+267u9ruvvOz2p7d87c+45f3B+u/vD8zv9h7Z3uredOVe3n9+rD5vs4mbxRcNTKYt1xJf03rONV1bt/onR6HvP9v1X7FV/7kxfx8dVr7hzH3QO4hpGOLKVDXwTfMSIdo4OKwYVDU0zAoZotHbLdRXAsI4IPOHlCrMiFlkMrqP57TQsAwa8IZ51KcAQrd7G1Ibb2evOTWzBzhPXKWthXQ76Hs8HPK+759ZnfPV1Gxv/qO/7Oj/pa6sbvfyHP3TXM37r9LmvvXrUTf5we6ceu7U5uvWa47/9mddd8+/PV90/qu7umkCu/vnV1SdMqs52ff1AX/UnT47Hn3Fusvf+vur4ydH40bFNR1Opq5pK0KwRp51JX2cmk+2rR6OtUKuvSY1rNBWf3ZpUPzPq2kyrnWlv1Y2rK31rPlmUxB5unUJqV/2o82s0pWQyVPSxH26e1O7smeNRFTDZqK47PZn0V49G3dUb4zqztzf1nbS9BoT6/XFNE41G1Rl9kpT8ngY3gVX8rek+ardvbhnN/s2T6e9tIDbp+/v2JnVqstfftb07/qPt3VPdpN66sdnfc/1os9vr997+ge29X37y1tbkSceP3fjYY6MPPHrr2Afu2jlzb3///e9/zO99OFlyagLY6orFMM1j+LEXPvHES37pfQSoH7pRczgzwpodE0uSoKmEHGbxYQFD+mHVcfvittDWtvjQWHiJC2Avn/ADRsFXv33nbz8Kw7Q5Gu6dZzE81MAwfFUgt5kFYfmN34+5+DFHP/62pvlfXlGb5xG6DYEhx9cXWYMPBIaPPO/mbz8+Hn/zmcmeh504ORpvnJ9MMPteV90Yi25V12+ORt3mqKuzk70pJxwfjadAsjeZFO24VaPpyrl3c0RHW4mZSJP0yEJU+b427/uuH432NfzuvqhfiFtERbZKd39S+/3FbLpAlakr03eT6ljZ1XV9t6v/xh/sQsF9Ieh22QhVQi09gZ0+s5/KyL4ECwzuw1lfBL2vftJXt89kfT+adLWxNQWAqt2+7ze6rjs2GtXZvb3d6kanqibXouNGV7XT9/smthlMx991XV87+8/bH8Ne1YanJRw+qtkERsHUqcL0fDdtIXNfk3trUie60X6+wmRK+2nM5QNd1R2bXfee20+fef5vnTrzvHed3d7+3bPbW287v/u1755MFEG50N5QtTELkE6mE35wC9PRvlyTNrCVTNLD2s5OP7ZfCVACZkm7XqVRh9/HCsjvKwEYsr2ducnXQceDttbCWQQMYgtiDPOsoQc9r7v3eTd/67Vbm686v7evpc5NJlPI3xyNaqef9Ht90ZTFrydom6Pa3On7qXbhQO9WT2G2djsWd0F4u9+sbrQbAdi3ttMuBHgaGBvFCZppXEw6DWx2fTfpu37z2KijTcXnpgqX1UAz0+rHRyPuxdR9uGY0Hp3rJxHIqbbeZC7sq/Xptea7r6X3p7A526gxfyCnX8bFVC1Ob61uoxtdsGvZDR/a3gUGk8dsbIxO7U0g+ukaj17a7/WffMPW5nfds7N9vqr/o2vH46dMB91Vnd7bB99rRuNxokNTa6WfMN6mANZaIpN9UJkiVj8Dxa6vvb6r0bi6bjb+1mAabXZdtznzacxuZzLpuTFnJ0CwPnhio/vxmnT/YbRb7++vPf7269742xdehrsAJCKszg7kpa/JQGWC89HzBqulvs8anD/cGh2+Nb19k/m87vL81mJz3ZUADLEqk4MSYEg26nBHYji/RXNz3eEAw53PuvGa8dXXf271/RdX3z2huv7xo647/8Gdnd2tGj/l9GSv/72z57s/fd3VUx2y2/d39NU9pbr+XF/1R+PqnoHRd+m76idAICuBSwnf2cnee6q6f3tyNHrZ2akgTpl8dGzUdVwGpjvJn7obM9t0Z8L66PtrN8ZTofTDYvnIrifVm68ajZ93fjKZCqo4w1WjEWH6na7vf6O67i+fHI2OnZ3svbavetGjNjaexPQn2G87c77u2tntXnDNyQ/3Xb2+er5YN97sassY9rp6V9/3V42q/mM/PVfRnZyBR3/n9k533cb49HWb49/f7Mfv+N1zZ26+c2fvE1/9gQ9PXnD1idGnPeqa7SdsjP/iM/ee+Mbu937x1Ec+4VkfWxt7X9aP6j9Nuv7Xa3f0ghr113f9xngynryjzvenRpv19JrUtRvjfufffPi+r3vu1Sefc+1oPBmPanRyNHU4phaK+cTlmaYvTibl642ppTZzWGbsM+5AKldkCj69GAis9NnMZOk3Rl13vBtN12123fsn1f94Pxm/9sY3v51Pf6E1geXgt9+Ca0zv6VrOlkimqvyIw3AnAgwSc9pSb0ntXcsknoMYVxIwpGZDQM+umQzJS6Hf4QDDkHDv+8SnPfMJVz/uD7tf/MVbP+PE1hs+67qr+s+6/hoC3l07Gu8c6+o7tsadfdNfq0n99nVbG6+8Z2/vXdX3jz026q46P+nf3/Xd1T0lNm2Td2/23dfsVP+q6qbbJM+8djy+EUDs9fWWO3f7nzu/t/P5jz+2yQy/75fvO3vzNePuGAvlLWfOd595/dXvvbpG79jt+vfNtOVbtmry+rN73af85F2n/vqZfveT33L/ucmjNzdGL7zmxOd+3js/+NMfft7Tv3TUdXs3/Podr33fC572zI/ptj7+5+6678+8+f6zX/YTd923/eiN8dYnXX3iR77tznu/8CO3Pvv5k/7cbl/jx43Hk92t6t6+Pem2rrv9jnf3L3rBk3/oXe/8tn9996m/uj3pt19/dnvrU7fG3/+m7T3bXpo6El5GGv9XAMs+8Xt+7JZbtl761rcOX222SlFOheDjNkbnn3Vs89gtJ4+96xVPvv7zR7tXna/R7mePRpPndNWdnEzqlq6rp/bV31PVvbfr+qv7vm6YumsTqNCLAZ2u0TS3/uSo795w/2Tyqfft7V1348ZGf83GuDs32WOY7I+v78cbXbdxYmptsWk6efg/vTGevPGaG7vbu5+54/wsPASUw3h5m3N8d58n1/4w3Inhdl62WR0ac1qQ/30x4HAlAEPCabIrvTU7FoOduGTDXszcDs9isOC333rrxq2337479CuPd93Pf+cTHv2iX/7IqZ1PMHVqoQAAEkdJREFUv+6azWecPL59/+7ObX/hMdf/xLvPn/t319TWY0Zd/yVd1Y9PRv1ndpN6Ub/Rf0uNuj8YbdfT+270aTvbkx+96S13vOOu5z/1U3a3r37X5vGdm6v6J53Z2fvgE3/zHXLRp/u4r33y4z7p107df/K77zklNTmGgxRkZuu8VFJESPkvf0NdQnkhj2FmhMRdSXbZA/IYlkhqGDNZiOeuqjp+ev/wzjSP4dM26tPfuVe/cEaktavdq6rb2Oj7v/P2/TMGmwysGW33TfwLeR1Vt922n/B0+601ur0ev/my2z9w5nkbo1e9eXfyrf0fZyeig60wAakL7b0vfOKJk7vHbuwm191nN8j/V33wpq3xTefG3fbO6Jqnbd7Xve6t26dvffbjTu3Uoz/mt37nLS86Pv6nv3Bu78tfcf3Jvc9/7A3jZ584XtdvjGs0i9wKAu/0k+J6iIeAh9OTqX3x3hqNvuGGX3v7j8zoOUX72QEk+RvyANpTfhJ5UpCkTTFfBYrt961QyNhzLqbdj5fiLeNw3R2Vtr+PFjCkHkO7pehksJTmNlEMv9taXNdqGALI4VsMSVh61f4W1/aTqz7tD/aPBNdfOrm1e3oy2fjZc7tqMybral/hrMhhGAhoywCf+KSue/Pdff8Hp/f3cr/tMV19y3Zf5+6tOn5V1U+drvq8V1aNnOSRCOXmt1X1r6yafGzXvWGn6sVn+t5e4/ZTNuu5v7Rdv/vPqzafWdXLkJQ1+VVV55+7OXr5Xbv9q+/u+3MbVcevG42+7z2TyZe59m88MKlp6r+9rGr8mqqdZ1e9/M6qV+9Wnb+v6th1Va+5+49PYtp6lSTT1sKU6EKjiRavWtyhZv2czarXb8lXqJqc7LqNraoff2ffv+QHnvrU41e9+907L1lv92CeECYlfKqdvvHGR33ndzz9CW+6a/v8Z3TdiJ3xhzWpz62uf1Q36R476uomQVRSdHqy99rrf/2OL27WMfPiE8vxaK0GW5lSr7PxcjGxhgi8bThAHOCJZdae5Jyx4FzcSZwroJKdoYdyVyKetVRm7lcLDNLIKTfX5CwKC9T5BTROcHfe5OJhtzsSh2cxLIHxKdM+ZTT6B3t9//Xv63umnMXeeOyofvhDk/qiH6sav62qs0+eftpsSBN+1f73E9e+pGpy+621cevt+7uK11X3xnurf+Gxqu86X/X1N1T96EeqXtrJS6o6vlP1+r2qPyc78bY/fka72IptOo4awraonEBcmGyY+ciMc+BpUZQ2zB/mHFoayR5zeEsSVCscDqjIuddcl7z0kMkc9I+mklwACb/e3rj0WCDZ+u7THIFbpGFX7d1S1T+nqgMSjhK+tWrjdft9yYW+9rVV9w1B/jFV33Oq6itv6OrsqOrE+/ppQozEmAdp6vtvueVjdk/ufNxkb+/pu+O9X3nsr75bpt8ije48hToOnm9O6JmTm5n7QcAhdHfCl6UEfAMMsVY8QzaknRHrm/VvxxjQ9R0aC4pqD4XFYExoJiU6Y5ezANDaDMM2waldbycrnZFBP5/Py8KMzEnsat2q0C+Zj3HBDlRtu90KHGJEa6K8/rqqzxGnOlMlij6e7B+ymR4vvrVq89dmgrtgmyt9JznFRCVMOdmnYSxCnlJhbQ0Iac72odtIbYiSfPhoEsdrmZ6tiRlCOeAkVz4CnnoMq4DByUvbesMAUYDBMx13DvNPcxhmp/MATwsG/m6FRAEQkWnpxLIdnfjMCUJgoh/jE7sANMr3L+vPWKXXOoqb1N7EHC9kPnZVx59e9XV3VH33m174xBMvPHbzTt12mx2Pg2QsRvCc6QBqwCy+sjHmsFkCk+v03VpY5iqY6di04+b4rdltnpLBeYC8vsD/4eeWxoSMVWM8Cg63CU6AJ2clAAc3aFXmo21OuRSOYGt2oSgksY/QxJxZB9zA8HKAOOc7jANPtett/tO48exEbQ6NLZqbPrkjsk4lXbUJTubtRHHW5EBB22XA0KKrSejYUeR27zpptbm2NR/bPIRo+WjOnPxyH39UwMUE2qpR0x3CtnhEIxT26+1v209vzbB2PJBU8ouFIFjx54bHtAFOzq23AOZz9/FiLF7uyxFe/aKFOUXowgTJYqP9FZpxhD2JRp6BuRyl1jc3pM0qNTfaRuCwBQf3Oe8gW7F9uY+UWecpHBJiwmNIB3Ek/Fg3a4K2sWySXx9gd/80wWm6sbTf9s3UF1c3O9eyKq9BqTn1OpQPa8GhtUpiQrfbh+G/gEf4I0eLjSX0zrkYYzWv3Ot7dSfwUcYPtPEU/iAgAFc6sNciWjdrKW2aGxgBN24aHqAOLR3P8plrFKcBVqnORFu7TxysPXyV8yThiZwUbth4+ic+tWbOf8xbb8lknpdm/N7qxioDdnhFQSIJT9NMgxnfDi1klp1TlbGw5llZD9I6w8G2/7d+cHtmPFpaoERGnaDhqsZUJtAYJgxEOATrNIskoMWMbI9Hewazl+VAQ1twZpjaia5t00lFxvPaM9ZGrIucCMxzZZm11X4WjZ35B5HnRY5bIHEdgcQI2VlMzoaCHOZFKwnWGVeqB6V+gr6izQh6KgOhA8GZ5mzM6IKRpMLqH0OJ+Wg0otoTQKG1+Fxnvp6beWDc9hWDAYSDmP3uiZaneYGPI+da1oTPzOMhhKsaq4MlZ1wB4hxh526xBglSaByaGDOaEHy00k9ONrIACI41aBtg5vLFktFXrJxct8gCoYnbYCiBI3gtDVMBvQUySUY+95k1Y91Zf5mcKSk3nJv1J/zWGzgB36w3sMGb+GoYr4oiyHoL5Csqo5+VbZXFkA7ahzoXb3LMrrYRPGYxhobQBmTBICszmVnIXx+ejKMZJcfENM8WoL6nGX5z6t65ngCoquNsRzRNK0B8Ktt/QMLhGS/IGTaBMtqJaQh84suZG9AwFhHwYWPa2oNmiuYkJdBjVfElNX0l7jCs2+d78+LesAK0uDQRNPRCz5Tn0hdmHNZ8zNj4pI4E5/gvkEEfjGRHRtmvYWOuGzOmMQ87OhezTda6APbhWVisojRWinMUBNFzBGYTs2IhOeVpjYxfTCG7UoTFTlNoAzDVlWgrFKUaUtzUdo5yKhxBV7PAvAAjs9/6GmfciNxD0XA7gBgQcp/G5UNLx+9p6pzIzH0C8taR1eI+7gU3gsWoXYjPNXPzuTV19F8hItY4GsUSyXqzQubJKcC1bc4qDv0FONESUFnztNDT+FhYTqj6sT06t60LDG4eRngFxCykxRoWOqXZEcdiIX57yk1fzC+LICVUMYkwYxjApJjMw/swGLObhRF/k3ADqzSTZZHQEPy+eQwzJAatgmH0r8VKWES3fB6t28Y0mPR+1PJb1Gy1sZSMdZ5WChADUfQhNIsaJqZ14msHYAGu79pM02XzaY9qX8w2YxurITgYXoovZsXcbQNEtBy6iVEMv8c/1k9xIOsbywAwAhw8QODz+XBemJ6A4yEtNCGAqdu5am3zpjXXsSQA6Dot242uta3NFRg2WhuQcEHJQrtm1tvzFskmt4J7ymrRWlBuT6EOnxlwyOftEe8HKYODAEM6HG7B8bmY91AYumNmiwcsCJpCl/wvE+Ib+8GwfDltOKgwGMGS/AGpaX1mskIxhLhdbMwlQi0PnDbBNBpNZDxtTGRIrJzLomVp/1gMTDVuTVtvoL3X554L/FgbWisYAA1YcS0IqP8xgBOPzMm4Ccu2pFo6o63+CBnf2Dg9l5XGMsphJrTMHFgWMacxxTwhCm0IJkFkil+MxRDaJC7UAosxyENggfkbv+AP68Plsb1LkPEFnqDV8ArFMaRra7nSjLSsWII+PVs/4jloPK+kPt5kbVjvBPradUU7P9bWeFKCHi9niz6xkuF9oTHebqtBi21QoCwIzzU+7lL6HlqK+kUrcxuuN3fF3Fgg+3GgB+5Y4Hd0XcS37fzEvOK+DOViISo96MKjD44ocESBRw4FLsZieORQ52imRxR4hFLgCBgeoQt/NO0jCiyjwBEwHPHHEQWOKHAUYzjigSMKHFFgNQWOLIbVNDq64ogCjzgKHAHDI27JjyZ8RIHVFLgSgEH+gUQPL1e9EsazmmpX7hXDJJYrd6T/5Y3soaL9Q/KcVhDbHHnJODKjnElIjvtBBnSQa6U3O7bshOKV0OaN/SDz+WjOYdU4Jc14J4NEGElnioRM31V4hbVV85g33I/2ui0b80dLti56WYfAkP9l6skmdNBEfvjlbClQcdDDO5drTBfDlJdrLAftd9nYZU8qCuLUnSPusg+dsJSVd6W1i1mDi7nnMOe9ChgOS7YeknkuAgYEc4pNOnMOdbQDkkKrJFvelOsgUkp8u7e91t9yxr13ADM6KeZdAU77DcHAeNbpuz2PkKPe3vib9yY4rOU0nuPd0lPl7ef0p9RWWtOJO2mxzjsQFgd75o1nOB/3fOvsiLi0aVrXsV9N0Ri57jSy8wC+k/46ry0bR565iG6+l1+vvoQ1cODGGKSDL3LHnBNwNFrNi3ltHbqvS2N0xA/WA70c8LJmqYG5TLsvWoNLXbd15reM3uus1yLaD+d7WLK1ak6+V0vEYUA84vwIuXV+SUo9PsX3mjRwKfFStz+0zGLwyntHXhX9GAqHQ0zOR0TbOMDjxasOBs0DBgdQlAEDNJjFyUjFSYbX+n+dvuWLOyjlFGf6cFhFgVKHZBwPd7JSDQb/W/BYPk73OdXoFBzhIrzOFeR1datMUn06FqwIi8M+QMLcNONx+s4hKSDou7ZYSyuQ64xjGd2cYHQuX01K62gNgN0i5nSOwNmNRfUz16H7ujRGQ1aJsWncFSUCHb+et+bzeGY4j3XoNbynXct15reM3hfz/Kx3Ow7W+GHJ1qo5OWzlLEl4kEyQPXQS13MehZLUfM5LUNPjAUw0RGpxBkd1czSznZy4gOPIKVIKZRDVgaF5i6xmQs6BO0YMpXKceCiI6/StMIijri3hHY1NpSdn+dv/HXZadFyZ1ndwx0GcdZjW4Rou1ryX7TrNyWJAi0UC2IJD+/e8cSyjm8NkTgC2a+CY7yJgQBOH0S68ZXswkHXovi6NrSmLLWPzNzCfxx/zhGcdc/mg67bO/JbRe7hu6zy/nVt7/2HJ1qo5+Z5yz2Eph9jwOh5xoMwp4hQEUu9ERbTpC28WWQzcB1oW4+VV1e1iOTXpaC1m0widl5XMcztWaeDh9+v0HfdhHlPNE+72GSwH5pR3IuZcfeIc6wDDcHztgjsNx9xmZQEppdbacmzttYc9jlSqWmYxGNewYEnGtA7dl7meQ/cRL6zDH+sCw+Wg1yKenTemi3n+vH4OU7ZWrZnvnQyNMhjyiLoiamQAA5sMeYP2QmAwIcc3mf7zNPsqpBoyyTIT72IshmX9rQIGmpYJxtxnSdCiKeTh3rYa1LyF5ZupjzDPYsj1xmcHQHyBFprXVo1jFaAOLQZa2ZiWxRiY994DOa8dZE1X0XhoMdBUjofHYsCwrI8UaFXejlmbsc9bg1X0WrVuB53fcI6rnr9u8PEwZWvVnJZZDMbhODy3W/yHK30hEL3MYhCQU4ORFhwSiV+u03T0g7PtRtpyeO0qBh9+f5C+5wnuKqbFgKwhmlzNBwE7hVZDC/UBuFBtKbJ2jIqHKF6reg6N08YYBNn4dZjINYRwUcGWVeNYRTfgZg3UrND48WIfi4DBroSKRgKzAq5iIOIluf+gdB+Ob6gM1A5I398/i+kkBiXe4HsBUyXuBMhYp8vWYBW9Vq3bQec35KNVz18XGFgMhyVbq+bke/KbGIN1UN2p5RGxQRYzfhKcnrZFeQwQXWxBkCSly9qJM0kIlGinJuKtfl1Mx0uxGA7S98UAA00uOsvHstjeAq2aTmgBPQEcEyyftfMRvRX4U2WKVQUI7A5odgh8p+YgYBFo5cfNa6vGsQoYEnH+glnE2TyW7UoYQ5vHIB6CcYC6dlC6rwKG7EqgF1NVgDYmrZiU6l1qENq94doJbC5bg1X0WrVuB53fEBhWPX8VMIQHDlO2Vs3J9ywCAXi7Eipa4e221KBqUT7HsxfK1C/SLgt4+ejjIwqsRYF1godrdXR00aFSQPlCgfG27qral+qCAvIL7QgYDpXuR53NKHAEDFcOK7BmWWQsTC9ZUpGadaWJr8lwVsBYDsMRMFw56/Zf5EiOgOHKWVY7YxL9uA+2jOXwCPpaI66DvJsHFaw9shiunAU8GskRBa4YChwBwxWzFEcDOaLAlUOBI2C4ctbiaCRHFLhiKPCfAekXYCBpbQLOAAAAAElFTkSuQmCC";
+NgChm.PDF.isGenerating = false;
 
 /**********************************************************************************
  * FUNCTION - openPdfPrefs: This function is called when the user clicks the pdf
@@ -18,6 +19,7 @@ NgChm.PDF.canGeneratePdf = function() {
 };
 
 NgChm.PDF.openPdfPrefs = function(e) {
+	NgChm.PDF.isGenerating = true;
 	NgChm.UHM.closeMenu();
 	NgChm.UHM.hlpC();
 	if (e.classList.contains('disabled')) {
@@ -68,6 +70,7 @@ NgChm.PDF.openPdfPrefs = function(e) {
  * the user presses the cancel button.
  **********************************************************************************/
 NgChm.PDF.pdfCancelButton = function() {
+	NgChm.PDF.isGenerating = false;
 	document.getElementById('pdfErrorMessage').style.display="none";
 	var prefspanel = document.getElementById('pdfPrefs');
 	prefspanel.classList.add ('hide');
@@ -189,6 +192,12 @@ NgChm.PDF.pdfDataReady = function(event, tile) {
  * https://mrrio.github.io/jsPDF/doc/symbols/jsPDF.html#setLineCap
  **********************************************************************************/
 NgChm.PDF.getViewerHeatmapPDF = function() {
+	NgChm.SEL.updateSelections(true);
+	setTimeout(function(){ NgChm.PDF.genViewerHeatmapPDF(); }, 1500);
+}
+
+NgChm.PDF.genViewerHeatmapPDF = function() {
+	NgChm.PDF.isGenerating = true;
 	//Validate User-entered font size
 	if (validateInputFont() === false) {
 		return
@@ -271,7 +280,6 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 	if (includeSummaryMap) {
 		// Scale summary dendro canvases for PDF page size and Redraw because otherwise they can show up blank
 		resizeSummaryDendroCanvases(sumMapW, sumMapH, rowDendroWidth, colDendroHeight);
-		NgChm.SEL.updateSelection(NgChm.DMM.primaryMap);
 
 		sumMapCanvas = document.createElement('canvas');
 		configureCanvas(sumMapCanvas, NgChm.SUM.canvas, sumMapW*2, sumMapH*2);
@@ -385,6 +393,8 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 	
 	// Reset cursor to default
 	document.body.style.cursor = 'default';
+	NgChm.PDF.isGenerating = false;
+
 	
 	// Save the PDF document 
 	doc.save( NgChm.heatMap.getMapInformation().name + '.pdf');
@@ -773,8 +783,7 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 	 * FUNCTION:  resizeDetailDendroCanvases - This page resizes the detail dendroram
 	 * canvases for the PDF and redraws them.  
 	 **********************************************************************************/
-	function resizeDetailDendroCanvases(detMapW,detMapH, rowDendroW, colDendroH){
-        const mapItem = NgChm.DMM.primaryMap;
+	function resizeDetailDendroCanvases(mapItem,detMapW,detMapH, rowDendroW, colDendroH){
         mapItem.canvas.style.height = detMapH + 'px';
         mapItem.canvas.style.width = detMapW+ 'px';
  		NgChm.DET.updateDisplayedLabels();
@@ -880,17 +889,22 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 	 **********************************************************************************/
 	function drawDetailHeatMapPages(theFont) {
 		for (let i=0; i<NgChm.DMM.DetailMaps.length;i++ ) {
+			const mapItem = NgChm.DMM.DetailMaps[i];
+			const loc = NgChm.Pane.findPaneLocation (mapItem.chm);
+			if (loc.pane.classList.contains('collapsed')) {
+				break;
+			}
+
 			if (i > 0) {
 				doc.addPage();
 			}
-			const mapItem = NgChm.DMM.DetailMaps[i];
 			let detVer = "Primary";
 			if (mapItem.version === 'S') {
 				detVer = "Ver " + mapItem.panelNbr;
 			}
 			createHeader(theFont, "Detail - " + detVer);
-			const rcw = + mapItem.rowDendroCanvas.width;
-			const cch = + mapItem.colDendroCanvas.height;
+			const rcw = + mapItem.rowDendroCanvas.clientWidth;
+			const cch = + mapItem.colDendroCanvas.clientHeight;
 			const hmw = + mapItem.canvas.width;
 			const hmh = + mapItem.canvas.height;
 			const rowDendroPctg = rcw / (hmw + rcw);
@@ -909,32 +923,48 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 			if (rowDendroConfig.show !== 'ALL') {
 				imgLeft = paddingLeft;
 				detMapW = detImgW;
-				detRowClassWidth = detMapW*(NgChm.DET.calculateTotalClassBarHeight("row")/NgChm.DMM.primaryMap.canvas.width);
+				detRowClassWidth = detMapW*(NgChm.DET.calculateTotalClassBarHeight("row")/mapItem.canvas.width);
 				detRowDendroWidth = 0;
 			}
 			if (colDendroConfig.show !== 'ALL') {
 				imgTop = paddingTop;
 				detMapH = detImgH;
-				detColClassHeight = detMapH*(NgChm.DET.calculateTotalClassBarHeight("col")/NgChm.DMM.primaryMap.canvas.height);
+				detColClassHeight = detMapH*(NgChm.DET.calculateTotalClassBarHeight("col")/mapItem.canvas.height);
 				detColDendroHeight = 0;
 			}
-			resizeDetailDendroCanvases(detMapW,detMapH,detRowDendroWidth,detColDendroHeight);
+			resizeDetailDendroCanvases(mapItem,detMapW,detMapH,detRowDendroWidth,detColDendroHeight);
+			
 			var detRowDendroData = mapItem.rowDendroCanvas.toDataURL('image/png');
 			var detColDendroData = mapItem.colDendroCanvas.toDataURL('image/png');
-			var detImgData = mapItem.canvas.toDataURL('image/png');  //new 
-			var detBoxImgData = mapItem.boxCanvas.toDataURL('image/png'); //new
-			if (rowDendroConfig.show === 'ALL') {
-				doc.addImage(detRowDendroData, 'PNG', rowDendroLeft, imgTop+detColClassHeight, detRowDendroWidth, detMapH-detColClassHeight);
+			var detImgData = mapItem.canvas.toDataURL('image/png'); 
+			const blankCanvas = getBlankCanvas(mapItem.canvas);
+			const blankImgData = blankCanvas.toDataURL('image/png');
+			if (detImgData === blankImgData) {
+				doc.setFontSize(12);
+				doc.setFontType("bold");
+				doc.text(70, 90, "The image for this detail panel was not retrieved. Please try again.", null);
+			} else {
+				var detBoxImgData = mapItem.boxCanvas.toDataURL('image/png');  
+				if (rowDendroConfig.show === 'ALL') {
+					doc.addImage(detRowDendroData, 'PNG', rowDendroLeft, imgTop+detColClassHeight, detRowDendroWidth, detMapH-detColClassHeight);
+				}
+				if (colDendroConfig.show === 'ALL') {
+					doc.addImage(detColDendroData, 'PNG',imgLeft+detRowClassWidth, colDendroTop, detMapW-detRowClassWidth,detColDendroHeight);
+				}
+				doc.addImage(detImgData, 'PNG', imgLeft, imgTop, detMapW, detMapH);
+				doc.addImage(detBoxImgData, 'PNG', imgLeft, imgTop, detMapW, detMapH);
+				drawDetailSelectionsAndLabels(mapItem);  
 			}
-			if (colDendroConfig.show === 'ALL') {
-				doc.addImage(detColDendroData, 'PNG',imgLeft+detRowClassWidth, colDendroTop, detMapW-detRowClassWidth,detColDendroHeight);
-			}
-			doc.addImage(detImgData, 'PNG', imgLeft, imgTop, detMapW, detMapH);
-			doc.addImage(detBoxImgData, 'PNG', imgLeft, imgTop, detMapW, detMapH);
-			drawDetailSelectionsAndLabels(mapItem);
 		}
 	}
-	
+
+	function getBlankCanvas(canvas) {  
+		var blankCanvas = document.createElement("canvas");	
+		blankCanvas.width = canvas.width;
+		blankCanvas.height = canvas.height;
+		return blankCanvas
+	}
+
 	/**********************************************************************************
 	 * FUNCTION:  drawDetailSelectionsAndLabels - This function draws any selection 
 	 * boxes and then labels onto the detail heat map page.
@@ -1178,7 +1208,7 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 			}
 		}
 	}
-
+	
 	/**********************************************************************************
 	 * FUNCTION:  drawColClassLegends - This function draws the legend blocks for each
 	 * column covariate bar on the heat map to the PDF legends page.
@@ -1244,6 +1274,7 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 	 * inputs: classBar object, colorMap object, and string for name
 	 **********************************************************************************/
 	function getBarGraphForDiscreteClassBar(key, type){
+		var barScale = isChecked("pdfInputPortrait") ? .50 : .65;
 		var foundMissing = 0;
     	var truncTitle = key.length > 40 ? key.substring(0,40) + "..." : key;
 		var splitTitle = doc.splitTextToSize(truncTitle, classBarFigureW);
@@ -1332,7 +1363,7 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 					doc.text(leftOff +barW + 5, bartop + classBarLegendTextSize, thresholds[j].toString(), null);
 					doc.text(leftOff +barW + threshMaxLen + 10, bartop + classBarLegendTextSize, "n = " + count + " (" + (count/classBarData.values.length*100).toFixed(2) + "%)", null);
 				} else {
-					var barW = (count/maxCount*classBarFigureW)*.65;  //scale bars to fit page
+					var barW = (count/maxCount*classBarFigureW)*barScale;  //scale bars to fit page
 					doc.rect(leftOff + maxLabelLength, bartop, barW, barHeight, "FD");
 					doc.setFontSize(classBarLegendTextSize);
 					doc.text(leftOff + maxLabelLength - doc.getStringUnitWidth(thresholds[j].toString())*classBarLegendTextSize - 4, bartop + classBarLegendTextSize, thresholds[j].toString() , null);
@@ -1368,6 +1399,7 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 	 * classBar legend. inputs: classBar object, colorMap object, and string for name
 	 **********************************************************************************/
 	function getBarGraphForContinuousClassBar(key, type){
+		var barScale = isChecked("pdfInputPortrait") ? .50 : .65;
 		var foundMissing = 0;
 		// Write class bar name to PDF
 		var splitTitle = doc.splitTextToSize(key, classBarFigureW);
@@ -1494,7 +1526,7 @@ NgChm.PDF.getViewerHeatmapPDF = function() {
 				doc.text(leftOff +barW + 5, bartop + classBarLegendTextSize, valLabel, null);
 				doc.text(leftOff +barW + threshMaxLen + 10, bartop + classBarLegendTextSize, "n = " + value + " (" + (value/classBarData.values.length*100).toFixed(2) + "%)" , null);
 			} else { // histogram
-				var barW = (value/maxCount*classBarFigureW)*.65;  //scale bars to fit page
+				var barW = (value/maxCount*classBarFigureW)*barScale;  //scale bars to fit page
 				doc.rect(leftOff + maxLabelLength, bartop, barW, barHeight, "FD"); // make the histo bar
 				doc.setFontSize(classBarLegendTextSize);
 				doc.text(leftOff + maxLabelLength - doc.getStringUnitWidth(valLabel)*classBarLegendTextSize - 4, bartop + classBarLegendTextSize, valLabel , null);

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -914,17 +914,20 @@ NgChm.SUM.onMouseUpCanvas = function(evt) {
 //This is a helper function that can set a sub-ribbon view that best matches a user
 //selected region of the map.
 NgChm.SUM.setSubRibbonView  = function(startRow, endRow, startCol, endCol) {
+	const selRows = Math.abs(endRow - startRow);
+	const selCols = Math.abs(endCol - startCol);
 	//In case there was a previous dendo selection - clear it.
 	NgChm.SUM.clearSelectionMarks();
 	NgChm.SUM.colDendro.draw();
 	NgChm.SUM.rowDendro.draw();
 	//If tiny tiny box was selected, discard and go back to previous selection size
 	if (endRow-startRow<1 && endCol-startCol<1) {
-		NgChm.DET.setDetailDataSize (NgChm.DMM.primaryMap.dataBoxWidth, NgChm.DMM.primaryMap);
+		NgChm.DET.setDetailDataSize (NgChm.DMM.primaryMap, NgChm.DMM.primaryMap.dataBoxWidth);
 	//If there are more rows than columns do a horizontal sub-ribbon view that fits the selection. 	
-	} else if (NgChm.heatMap.getNumRows("d") >= NgChm.heatMap.getNumColumns("d")) {
+//	} else if (NgChm.heatMap.getNumRows("d") >= NgChm.heatMap.getNumColumns("d")) {
+	} else if (selRows >= selCols) {
 		var boxSize = NgChm.DET.getNearestBoxHeight(NgChm.DMM.primaryMap, endRow - startRow + 1);
-		NgChm.DET.setDetailDataHeight(boxSize, NgChm.DMM.primaryMap); 
+		NgChm.DET.setDetailDataHeight(NgChm.DMM.primaryMap,boxSize); 
 		NgChm.DMM.primaryMap.selectedStart= startCol;
 		NgChm.DMM.primaryMap.selectedStop=endCol;
 		NgChm.DMM.primaryMap.currentRow = startRow;

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -877,7 +877,7 @@ NgChm.UHM.ribbonHBtnOver = function(btn,val) {
 	if (!btn.src.includes(selStr)) {
 		ribbonButton = 'images/ribbonH.png';
 	}
-	if (NgChm.DMM.primaryMap.mode !=='RIBBONH') {
+	if (!NgChm.DMM.primaryMap.mode.includes('RIBBONH')) { 
 		if (val === 0) {
 			btn.setAttribute('src', ribbonButton);
 		} else {
@@ -891,7 +891,7 @@ NgChm.UHM.ribbonVBtnOver = function(btn,val) {
 	if (!btn.src.includes(selStr)) {
 		ribbonButton = 'images/ribbonV.png';
 	}
-	if (NgChm.DMM.primaryMap.mode !=='RIBBONV') {
+	if (!NgChm.DMM.primaryMap.mode.includes('RIBBONV')) { 
 		if (val === 0) {
 			btn.setAttribute('src', ribbonButton);
 		} else {

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -393,7 +393,6 @@ NgChm.UPM.prefsSuccess = function() {
 	NgChm.UPM.bkpColorMaps = null;
 	NgChm.SUM.summaryInit();  
 	NgChm.SEL.updateSelections(true);
-	document.getElementById("summaryDisplayPref").value = NgChm.heatMap.getMapInformation().summary_width;
 	NgChm.UPM.applyDone = true;
 	NgChm.UPM.setMessage("");
 }
@@ -419,7 +418,6 @@ NgChm.UPM.prefsApply = function() {
 	var rowDendroConfig = NgChm.heatMap.getRowDendroConfig();   
 	var rowOrganization = NgChm.heatMap.getRowOrganization();
 	var rowOrder = rowOrganization['order_method'];
-	NgChm.heatMap.setDividerPref(document.getElementById("summaryDisplayPref").value);
 	if (rowOrder === "Hierarchical") {
 		var rowDendroShowVal = document.getElementById("rowDendroShowPref").value;
 		rowDendroConfig.show = rowDendroShowVal;
@@ -1762,10 +1760,6 @@ NgChm.UPM.setupRowColPrefs = function(e, prefprefs) {
 	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Map Version:", NgChm.heatMap.getMapInformation().version_id]);
 	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Builder Version:", NgChm.heatMap.getMapInformation().builder_version]);
 	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Read Only:", NgChm.heatMap.getMapInformation().read_only]);
-	var summaryDisplaySelect = "<select name='summaryDisplayPref' id='summaryDisplayPref'>"
-	var summaryDisplayOptions = "<option value='10'>10%</option><option value='15'>15%</option><option value='20'>20%</option><option value='25'>25%</option><option value='30'>30%</option><option value='35'>35%</option><option value='40'>40%</option><option value='45'>45%</option><option value='50'>50%</option><option value='55'>55%</option><option value='60'>60%</option><option value='65'>65%</option><option value='70'>70%</option><option value='75'>75%</option><option value='80'>80%</option><option value='85'>85%</option><option value='90'>90%</option></select>";
-	summaryDisplaySelect = summaryDisplaySelect + summaryDisplayOptions;
-	NgChm.UHM.setTableRow(prefContents,["&nbsp;&nbsp;Summary Display Width:",summaryDisplaySelect]); 
 	NgChm.UHM.addBlankRow(prefContents,2);
 	NgChm.UHM.setTableRow(prefContents,["ROW INFORMATION:"], 2);
 	var rowLabels = NgChm.heatMap.getRowLabels();
@@ -1840,9 +1834,6 @@ NgChm.UPM.showDendroSelections = function() {
 	var rowDendroConfig = NgChm.heatMap.getRowDendroConfig();
 	var rowOrganization = NgChm.heatMap.getRowOrganization();
 	var rowOrder = rowOrganization['order_method'];
-	var sumPercent = NgChm.UTIL.roundUpDown(NgChm.heatMap.getMapInformation().summary_width,5);
-	sumPercent = sumPercent > 90 ? 90 :  sumPercent;
-	document.getElementById("summaryDisplayPref").value = sumPercent;
 	if (rowOrder === "Hierarchical") {
 		var dendroShowVal = rowDendroConfig.show;
 		document.getElementById("rowDendroShowPref").value = dendroShowVal;
@@ -1975,9 +1966,6 @@ NgChm.UPM.getResetVals = function(){
 
 NgChm.UPM.prefsResetButton = function(){
 	var resetVal = JSON.parse(NgChm.UPM.resetVal);
-	var sumPercent = NgChm.UTIL.roundUpDown(resetVal.matrix.summary_width,5);
-	sumPercent = sumPercent > 90 ? 90 :  sumPercent;
-	document.getElementById("summaryDisplayPref").value = sumPercent;
 	// Reset the Row/Col panel items
 	if (document.getElementById("rowDendroShowPref") !== null) {
 		document.getElementById("rowDendroShowPref").value = resetVal.rowDendroConfig.show;

--- a/NGCHM/src/mda/ngchm/datagenerator/GalaxyMapGen.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/GalaxyMapGen.java
@@ -24,7 +24,7 @@ import org.json.simple.parser.ParseException;
 public class GalaxyMapGen {
 	
 public static boolean debugOutput = false;
-private static String BUILDER_VERSION = "2.12.2";
+private static String BUILDER_VERSION = "2.13.1";
 
 
 	public static void main(String[] args){


### PR DESCRIPTION
Merge 2.19.5 Version bug fixes and enhancements to master branch.

This request contains the following Pivotal Tracker items:
PT: #176854565 - Summary drag select not working.
PT: #176854607 - When in Horiz or Vertical sub-ribbon view, the ribbon buttons do not draw correctly when hovered over.
PT: #176803641 - Shift-Drag in summary pane causes error in console.
PT: #176825189 - If only detail pane on map is collapsed, pdf font size defaults to -2.
PT: #176825270 - If create pdf when only detail pane is collapsed, pdf creation fails silently with error in console.
PT: #176824830 - Detail panes past first two come out blank for some maps in portrait mode.
PT: #176824325 - Parts of some labels for covariates off side of page in portrait mode with histograms.
PT: #176803488 - Zooming out on detail panes not working correctly.
PT: #176824224 - GUI Builder need to disable two get PDF buttons while PDF being created or at least keep them from taking multiple inputs by accident.
PT: #176820884 - GUI Builder has problems with clustering at limit of allowed size of filtered matrix.
PT: #176969878 - Additional detail heat maps always being opened in original 42x42 view panel instead of at same zoom level as Primary map.
PT: #176803136 - In viewer clicking on dendrogram in summary pane causes error in console.
PT: #175752191: In Viewer remaining pane drawn incorrectly when lower pane closed.
PT: #175506466 - Only one panel gear dialog should be visible at a time.
PT: #176987772 - Remove Summary Display Width from Preferences.
PT: #176988192 - Tables drawn in chm html help file being rendered extremely thin.
PT: #173952827 - Modify  Non-expandable map embedding to utilize iFRAME.
