### PR TITLE
PTs: #176825189, #176803488, #177100513, #177100342, #177098084, #177164355, #177168626, #177162760, and #177169016

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -156,7 +156,7 @@
 						<tr class="chmTblRow">
 							<td>
 								<div id="pdfprefprefs" style="display: block; background-color: rgb(203, 219, 246);">
-									<div style="display: inherit; width: 290px; height: 315px;">
+									<div style="display: inherit; width: 290px; height: 350px;">
 										<h3 style="margin-bottom:0px;">Show maps:</h3>
 										<input id="pdfInputSummaryMap" type="radio" name="pages" value="summary"> Summary<br>
 										<input id="pdfInputDetailMap" type="radio" name="pages" value="detail"> Detail<br>

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,7 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.19.6";
+NgChm.CM.version = "2.19.7";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -734,7 +734,6 @@ NgChm.DEV.detailDataZoomIn = function (mapItem) {
 			NgChm.SEL.updateSelection(mapItem,true);
 		}
 	}
-    NgChm.UTIL.redrawCanvases();
 }	
 
 /**********************************************************************************
@@ -794,7 +793,7 @@ NgChm.DEV.callDetailDrawFunction = function(modeVal) {  //SEL
 	if (modeVal == 'RIBBONV' || modeVal == 'RIBBONV_DETAIL')
 		NgChm.DEV.detailVRibbon(NgChm.DMM.primaryMap);
 	if (modeVal == 'FULL_MAP')
-		NgChm.DEV.detailFullMap(NgChm.DMM.primaryMap.chm);
+		NgChm.DEV.detailFullMap(NgChm.DMM.primaryMap);
 	if (modeVal == 'NORMAL') {
 		NgChm.DEV.detailNormal(NgChm.DMM.primaryMap.chm);	
 	}

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -1536,7 +1536,8 @@ NgChm.createNS('NgChm.LNK');
 		function removeOpenGearPanels () {
 			const gears = document.getElementsByClassName('gearPanel');
 			for (item of gears) { 
-	            item.remove(); 
+				const paneId = item.id.substring(0,item.id.indexOf("Gear"));
+				NgChm.Pane.clearExistingGearDialog(paneId); 
 	        } 
 		}
 		

--- a/NGCHM/WebContent/javascript/NGCHM_Embed.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Embed.js
@@ -71,6 +71,9 @@ function embedNGCHM (selector, srcType, srcSpec, params = {}) {
     doc.write(`<!DOCTYPE html><HTML><BODY>`);
     doc.write(`<div style='${P.docStyle}'><div id='NGCHMEmbed' style='${P.embedStyle}'></div></div>`);
     S(`src='${P.widgetPath}'`);
+    if ('${P.customJS}' !== '') {
+        S(`src='${P.customJS}'`);
+    }
     S("",`window.parent.embedNGCHM.setUpFrame("${ngchmIFrame.name}");`);
     doc.write(`</BODY></HTML>`);
     doc.close();

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -259,12 +259,16 @@ NgChm.UTIL.getShownLabels = function (axis) {
  * label is in excess, the first 9 and last 8 characters will be written out 
  * separated by ellipsis (...);
  **********************************************************************************/
-NgChm.UTIL.getLabelText = function(text,type) { 
+NgChm.UTIL.getLabelText = function(text,type,builder) { 
 	var size = parseInt(NgChm.heatMap.getColConfig().label_display_length);
 	var elPos = NgChm.heatMap.getColConfig().label_display_method;
 	if (type.toUpperCase() === "ROW") {
 		size = parseInt(NgChm.heatMap.getRowConfig().label_display_length);
 		elPos = NgChm.heatMap.getRowConfig().label_display_method;
+	}
+	//Done for displaying labels on Summary side in builder
+	if (typeof builder !== 'undefined') {
+		size = 16;
 	}
 	if (text.length > size) {
 		if (elPos === 'END') {
@@ -727,31 +731,6 @@ NgChm.UTIL.initDisplayVars = function() {
 	NgChm.UTIL.shownAxisLabelParams = { ROW: {}, COLUMN: {} };	
 	NgChm.UTIL.removeElementsByClass("DynamicLabel");
 	NgChm.SRCH.currentSearchItem = {};
-//	NgChm.DMM.primaryMap = null;
-//	NgChm.DMM.DetailMaps = [];
-//	NgChm.DET.firstSwitch = true;
-//	NgChm.DET.initialized = false;
-//	NgChm.DET.resetLabelLengths();  
-//	NgChm.DET.labelElements = {};
-//	NgChm.DET.oldLabelElements = {};
-//	NgChm.DET.dataViewHeight = 506;
-//	NgChm.DET.dataViewWidth = 506;
-//	NgChm.DET.colDendro = null;
-//	NgChm.DET.rowDendro = null;
-//	NgChm.DET.oldMousePos = [0, 0];
-//	NgChm.DET.offsetX = 0;
-//	NgChm.DET.offsetY = 0;
-//	NgChm.DET.pageX = 0;
-//	NgChm.DET.pageY = 0;
-//	NgChm.DET.dendroHeight = 105;
-//	NgChm.DET.dendroWidth = 105;
-//	NgChm.DET.labelLastClicked = {};
-//	NgChm.DET.rowLabelLen = 0;
-//	NgChm.DET.colLabelLen = 0;
-//	NgChm.DET.rowLabelFont = 0;
-//	NgChm.DET.colLabelFont = 0;
-//	NgChm.DET.colClassLabelFont = 0;
-//	NgChm.DET.rowClassLabelFont = 0;
 }
 
 /**********************************************************************************
@@ -829,16 +808,18 @@ NgChm.UTIL.combinePngImage = function (img1, img2,img3, width, height, dl, callb
 		var canvas = document.createElement("canvas");
 		var ctx = canvas.getContext("2d");
 		ctx.imageSmoothingEnabled = false;
+		const rowDConfShow = NgChm.heatMap.getRowDendroConfig().show;
+		const colDConfShow = NgChm.heatMap.getColDendroConfig().show;
+		var cDShow = (colDConfShow === 'NONE') || (colDConfShow === 'NA') ? false : true;
+		var rDShow = (rowDConfShow === 'NONE') || (rowDConfShow === 'NA') ? false : true;
 		var mapWidth = width;
 		var mapHeight = height;
 		var cDWidth = width;
-		var cDHeight = height/4;
-		var rDWidth = width/4;
+		var cDHeight = (cDShow === false) ? 0 : height/4;
+		var rDWidth = (rDShow === false) ? 0 : width/4;
 		var rDHeight = height;
 		canvas.width = width + rDWidth;
 		canvas.height= height + cDHeight;
-		var cDShow = (NgChm.heatMap.getColDendroConfig().show === 'ALL') || (NgChm.heatMap.getColDendroConfig().show === 'SUMMARY') ? true : false;
-		var rDShow = (NgChm.heatMap.getRowDendroConfig().show === 'ALL') || (NgChm.heatMap.getRowDendroConfig().show === 'SUMMARY') ? true : false;
 		var mapStartX = 0;
 		var mapStartY = 0;
 		// draw the img into canvas

--- a/NGCHM/WebContent/javascript/PdfGenerator.js
+++ b/NGCHM/WebContent/javascript/PdfGenerator.js
@@ -60,7 +60,12 @@ NgChm.PDF.openPdfPrefs = function(e) {
 	if (labels.length > 0) {
 		document.getElementById("pdfInputFont").value = parseInt(labels[0].style["font-size"]);
 	} else {
-		document.getElementById("pdfInputFont").value = Math.min(NgChm.DMM.primaryMap.colLabelFont,NgChm.DMM.primaryMap.rowLabelFont);
+		const fSize = Math.min(NgChm.DMM.primaryMap.colLabelFont,NgChm.DMM.primaryMap.rowLabelFont);
+		if (fSize > 0) {
+			document.getElementById("pdfInputFont").value = fSize;
+		} else {
+			document.getElementById("pdfInputFont").value = NgChm.DET.minLabelSize;
+		}
 	}
     NgChm.UTIL.redrawCanvases();
 }

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -1260,7 +1260,7 @@ NgChm.SUM.drawRowClassBarLabels = function () {
 		var key = classBarConfigOrder[j];
 		var currentClassBar = classBarsConfig[key];
 		if (currentClassBar.show === 'Y') {
-			var covLabel = NgChm.UTIL.getLabelText(key,'COL');
+			var covLabel = NgChm.UTIL.getLabelText(key,'COL', true);
 			var covPct = parseInt(currentClassBar.height) / totalHeight;
 			//scaled width of current bar
 			var barWidth = (NgChm.SUM.rowClassBarWidth*covPct);
@@ -1304,7 +1304,7 @@ NgChm.SUM.drawColClassBarLabel = function(key, currentClassBar, prevHeight) {
 	//find the first, middle, and last vertical positions for the bar legend being drawn
 	var topPos =  beginClasses+prevHeight;
 	var midPos =  topPos+((currentClassBar.height-15)/2)-1;
-	var midVal = NgChm.UTIL.getLabelText(key,'ROW'); 
+	var midVal = NgChm.UTIL.getLabelText(key,'ROW', true); 
 	//Create div and place mid legend value
 	NgChm.SUM.setLabelDivElement(key+"ColLabel",midVal,midPos,leftPos,false);
 }


### PR DESCRIPTION
This pull request contains the fixes for the bugs from the latest round of 2.19.x testing.  I have also documented fixes that were added to the NGCHM GUI Builder project as there were a number of fixes to the builder this round.  Some of these, but not all, being fixes made in Viewer code.  The Viewer version has been moved to 2.19.7 and the builder to 2.19.4 after these modifications.

The fixes for all of the bugs in the latest round of testing are as follows:

PT #176825189: If only detail pane on map is collapsed, pdf font size defaults to -2.
PT #176803488: Zooming out on detail panes not working correctly.
PT #177100513: If invalid value selected for font size in PDF Generation dialog, error message pushes other fields off visible area of popup.
PT #177098084: NGCHM Thumbnail generated incorrectly when heat map does not have row dendrograms.
PT #177162760: Long Column Covariate labels can wrap and overwrite each other and overwrite row labels if row name contains dashes or spaces. Error in builder, fix in viewer

These are builder only items that have also been checked in at the same time as the above Viewer changes.
PT #177100342: Transforms: Filter data.  Restriction error messages should only be applied for currently selected entry Keep % or Keep # rows/column options. 
PT #177164355: Build error if use two or more rows of sample matrix as covariates.
PT #177168626: Error in creating expanded pdf.
PT #177169016: Build error and questionable error message related to matrices with too many NA values.
