### PR TITLE
PTs #177308891 and #177372993

### DIFF
--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,7 +13,7 @@ NgChm.CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-NgChm.CM.version = "2.19.7";
+NgChm.CM.version = "2.19.8";
 NgChm.CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 NgChm.CM.viewerAppUrl = "http://tcga.ngchm.net/";
 NgChm.CM.classOrderStr = ".classifications_order";

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -3,6 +3,8 @@
 //Define Namespace for NgChm Events
 NgChm.createNS('NgChm.DEV');
 
+NgChm.DEV.targetCanvas = null;
+
 /**********************************************************************************
  * FUNCTION - addEvents: These function adds event listeners to canvases on a
  * given heat map panel.  
@@ -787,15 +789,16 @@ NgChm.DEV.detailDataZoomOut = function (chm) {
  * mode changes on the Summary Panel by calling the appropriate detail drawing
  * function. It acts only on the Primary heat map pane.
  **********************************************************************************/
-NgChm.DEV.callDetailDrawFunction = function(modeVal) {  //SEL
+NgChm.DEV.callDetailDrawFunction = function(modeVal, target) { 
+	let mapItem = (typeof target !== 'undefined') ? target : NgChm.DMM.primaryMap;
 	if (modeVal == 'RIBBONH' || modeVal == 'RIBBONH_DETAIL')
-		NgChm.DEV.detailHRibbon(NgChm.DMM.primaryMap);
+		NgChm.DEV.detailHRibbon(mapItem);
 	if (modeVal == 'RIBBONV' || modeVal == 'RIBBONV_DETAIL')
-		NgChm.DEV.detailVRibbon(NgChm.DMM.primaryMap);
+		NgChm.DEV.detailVRibbon(mapItem);
 	if (modeVal == 'FULL_MAP')
-		NgChm.DEV.detailFullMap(NgChm.DMM.primaryMap);
+		NgChm.DEV.detailFullMap(mapItem);
 	if (modeVal == 'NORMAL') {
-		NgChm.DEV.detailNormal(NgChm.DMM.primaryMap.chm);	
+		NgChm.DEV.detailNormal(mapItem);	
 	}
 }
 

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -439,6 +439,7 @@ NgChm.createNS('NgChm.LNK');
 	}
 
 	NgChm.LNK.labelHelpOpen = function(axis, e){
+		NgChm.DEV.targetCanvas = e.currentTarget;
 		NgChm.LNK.labelHelpCloseAll();
 		//Get the label item that the user clicked on (by axis) and save that value for use in NgChm.LNK.selection
 	    var index = e.target.dataset.index;

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -311,8 +311,9 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 		thisPane.style.height = topContainer.clientHeight + 'px';
 		thisPane.style.display = '';
 		//Resize panels
-		NgChm.UTIL.chmResize();
+//		NgChm.UTIL.chmResize();
 		NgChm.DMM.detailResize();
+		NgChm.SUM.summaryResize();
 	}
 	
 	function closeFullScreen (paneId) {

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -311,7 +311,6 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 		thisPane.style.height = topContainer.clientHeight + 'px';
 		thisPane.style.display = '';
 		//Resize panels
-//		NgChm.UTIL.chmResize();
 		NgChm.DMM.detailResize();
 		NgChm.SUM.summaryResize();
 	}

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -1203,6 +1203,10 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 				pClone = p.cloneNode(true);
 				NgChm.DMM.nextMapNumber++;
 				pClone.id = p.id + NgChm.DMM.nextMapNumber;
+				//If primary is collapsed set chm detail of clone to visible
+				if ((pClone.className === 'detail_chm') && (pClone.style.display === 'none')) {
+					pClone.style.display = 'inline-block';
+				}
 				renameElements(pClone);
 				clientElements.push (pClone);
 				NgChm.DMM.AddDetailMap(pClone, newPane);

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -914,6 +914,8 @@ NgChm.SUM.onMouseUpCanvas = function(evt) {
 //This is a helper function that can set a sub-ribbon view that best matches a user
 //selected region of the map.
 NgChm.SUM.setSubRibbonView  = function(startRow, endRow, startCol, endCol) {
+	let mapItem = (NgChm.DEV.targetCanvas !== null) ? NgChm.DMM.getMapItemFromCanvas(NgChm.DEV.targetCanvas) : NgChm.DMM.primaryMap;
+	NgChm.DEV.targetCanvas = null;
 	const selRows = Math.abs(endRow - startRow);
 	const selCols = Math.abs(endCol - startCol);
 	//In case there was a previous dendo selection - clear it.
@@ -922,26 +924,25 @@ NgChm.SUM.setSubRibbonView  = function(startRow, endRow, startCol, endCol) {
 	NgChm.SUM.rowDendro.draw();
 	//If tiny tiny box was selected, discard and go back to previous selection size
 	if (endRow-startRow<1 && endCol-startCol<1) {
-		NgChm.DET.setDetailDataSize (NgChm.DMM.primaryMap, NgChm.DMM.primaryMap.dataBoxWidth);
+		NgChm.DET.setDetailDataSize (mapItem, mapItem.dataBoxWidth);
 	//If there are more rows than columns do a horizontal sub-ribbon view that fits the selection. 	
-//	} else if (NgChm.heatMap.getNumRows("d") >= NgChm.heatMap.getNumColumns("d")) {
 	} else if (selRows >= selCols) {
-		var boxSize = NgChm.DET.getNearestBoxHeight(NgChm.DMM.primaryMap, endRow - startRow + 1);
-		NgChm.DET.setDetailDataHeight(NgChm.DMM.primaryMap,boxSize); 
-		NgChm.DMM.primaryMap.selectedStart= startCol;
-		NgChm.DMM.primaryMap.selectedStop=endCol;
-		NgChm.DMM.primaryMap.currentRow = startRow;
-		NgChm.DEV.callDetailDrawFunction('RIBBONH');
+		var boxSize = NgChm.DET.getNearestBoxHeight(mapItem, endRow - startRow + 1);
+		NgChm.DET.setDetailDataHeight(mapItem,boxSize); 
+		mapItem.selectedStart= startCol;
+		mapItem.selectedStop=endCol;
+		mapItem.currentRow = startRow;
+		NgChm.DEV.callDetailDrawFunction('RIBBONH', mapItem);
 	} else {
 		//More columns than rows, do a vertical sub-ribbon view that fits the selection. 	
-		var boxSize = NgChm.DET.getNearestBoxSize(NgChm.DMM.primaryMap, endCol - startCol + 1);
-		NgChm.DET.setDetailDataWidth(NgChm.DMM.primaryMap,boxSize); 
-		NgChm.DMM.primaryMap.selectedStart=startRow;
-		NgChm.DMM.primaryMap.selectedStop=endRow;
-		NgChm.DMM.primaryMap.currentCol = startCol; 
-		NgChm.DEV.callDetailDrawFunction('RIBBONV');
+		var boxSize = NgChm.DET.getNearestBoxSize(mapItem, endCol - startCol + 1);
+		NgChm.DET.setDetailDataWidth(mapItem,boxSize); 
+		mapItem.selectedStart=startRow;
+		mapItem.selectedStop=endRow;
+		mapItem.currentCol = startCol; 
+		NgChm.DEV.callDetailDrawFunction('RIBBONV', mapItem);
 	}
-	NgChm.SEL.updateSelection(NgChm.DMM.primaryMap);
+	NgChm.SEL.updateSelection(mapItem);
 }
 
 NgChm.SUM.clickSelection = function(xPos, yPos) {


### PR DESCRIPTION
Contains the following fixes:
PT #177308891: "Set selection as detail view" on map detail should set the detail pane where the menu option was used to the selection rather than setting the pane selected as primary to the selection.
PT #177372993: Summary map does not expand into a maximized panel when not full height
Viewer Version updated to 2.19.8
These changes also checked in, via widget, to GUI Builder with the version of the builder updated to 2.19.5
Builder also received the following fix:
PT #177311041: GUI Builder - Map Description field should allow as many types of commonly used characters as possible without allowing build to break instead of just alphanumeric and a few special characters.
