### PR TITLE
Specify maps by name

### DIFF
--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -38,7 +38,7 @@ linkouts.getMapName = function(){
 }
 
 linkouts.getMapFileName = function(){
-	return NgChm.UTIL.getURLParameter("map");
+	return NgChm.UTIL.mapId;
 }
 
 // returns type of object we're linking from.
@@ -48,7 +48,7 @@ linkouts.getSourceObjectType = function() {
 
 // returns a 'unique' identifier for the current source object.
 linkouts.getSourceObjectUniqueId = function() {
-	return NgChm.UTIL.getURLParameter("map");
+	return NgChm.UTIL.mapId;
 };
 
 //adds axis linkout objects to the linkouts global variable

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -75,8 +75,8 @@ NgChm.MMGR.MatrixManager = function(fileSrc) {
 	
 	//Main function of the matrix manager - retrieve a heat map object.
 	//mapFile parameter is only used for local file based heat maps.
-	this.getHeatMap = function (heatMapName, updateCallback, mapFile) {
-		return  new NgChm.MMGR.HeatMap(heatMapName, updateCallback, fileSrc, mapFile);
+	this.getHeatMap = function (heatMapName, updateCallbacks, mapFile) {
+		return  new NgChm.MMGR.HeatMap(heatMapName, updateCallbacks, fileSrc, mapFile);
 	}	
 };    	
 
@@ -145,7 +145,7 @@ NgChm.MMGR.isRow = function isRow (axis) {
 //HeatMap Object - holds heat map properties and a tile cache
 //Used to get HeatMapData object.
 //ToDo switch from using heat map name to blob key?
-NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
+NgChm.MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 	//This holds the various zoom levels of data.
 	var mapConfig = null;
 	var mapData = null;
@@ -155,7 +155,7 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	var zipFiles = {};
 	var colorMapMgr;
 	var initialized = 0;
-	var eventListeners = [];
+	const eventListeners = updateCallbacks.slice(0);  // Create a copy.
 	var flickInitialized = false;
 	var unAppliedChanges = false;
 	NgChm.MMGR.source= fileSrc;
@@ -776,9 +776,6 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallback, fileSrc, chmFile) {
 	//************************************************************************************************************
 	
 	//Initialization - this code is run once when the map is created.
-	
-	//Add the original update call back to the event listeners list.
-	eventListeners.push(updateCallback);
 	
 	if (fileSrc !== NgChm.MMGR.FILE_SOURCE){
 		//fileSrc is web so get JSON files from server

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -550,8 +550,7 @@ NgChm.UTIL.onLoadCHM = function (sizeBuilderView) {
 				dataSource = NgChm.MMGR.LOCAL_SOURCE;
 			}
 			var matrixMgr = new NgChm.MMGR.MatrixManager(dataSource);
-			NgChm.heatMap = matrixMgr.getHeatMap(mapName, NgChm.SUM.processSummaryMapUpdate);
-			NgChm.heatMap.addEventListener(NgChm.DET.processDetailMapUpdate);
+			NgChm.heatMap = matrixMgr.getHeatMap(mapName, [NgChm.SUM.processSummaryMapUpdate, NgChm.DET.processDetailMapUpdate]);
 		}
  	} 
 	document.getElementById("summary_canvas").addEventListener('wheel', NgChm.DEV.handleScroll, NgChm.UTIL.passiveCompat({capture: false, passive: false}));
@@ -677,8 +676,7 @@ NgChm.UTIL.displayFileModeCHM = function (chmFile, sizeBuilderView) {
 	zip.useWebWorkers = false;
 	NgChm.UTIL.resetCHM();
     NgChm.UTIL.initDisplayVars();
-    NgChm.heatMap = matrixMgr.getHeatMap("",  NgChm.SUM.processSummaryMapUpdate, chmFile);
-    NgChm.heatMap.addEventListener(NgChm.DET.processDetailMapUpdate);
+    NgChm.heatMap = matrixMgr.getHeatMap("",  [NgChm.SUM.processSummaryMapUpdate, NgChm.DET.processDetailMapUpdate], chmFile);
     if ((typeof sizeBuilderView !== 'undefined') && (sizeBuilderView)) {
 	NgChm.UTIL.showDetailPane = false;
 	NgChm.Pane.showPaneHeader = false;

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -10,6 +10,8 @@ NgChm.UTIL.getURLParameter = function(name) {
   return decodeURIComponent((new RegExp('[?|&]' + name + '=' + '([^&;]+?)(&|#|;|$)').exec(location.search)||[,""])[1].replace(/\+/g, '%20'))||'';
 }
 
+NgChm.UTIL.mapId = NgChm.UTIL.getURLParameter('map');
+
 NgChm.UTIL.capitalize = function capitalize (str) {
 	return str.substr(0,1).toUpperCase() + str.substr(1);
 };
@@ -499,7 +501,7 @@ NgChm.UTIL.convertToArray = function(value) {
 	//Call functions that enable viewing in IE.
 	NgChm.UTIL.iESupport();
 
-	if (NgChm.MMGR.embeddedMapName === null && NgChm.UTIL.getURLParameter('map') !== '') {
+	if (NgChm.MMGR.embeddedMapName === null && NgChm.UTIL.mapId !== '') {
 		NgChm.MMGR.createWebTileLoader();
 	}
 })();
@@ -521,7 +523,7 @@ NgChm.UTIL.onLoadCHM = function (sizeBuilderView) {
 
 
 	// See if we are running in file mode AND not from "widgetized" code - launcHed locally rather than from a web server (
-	if ((NgChm.UTIL.getURLParameter('map') === "") && (NgChm.MMGR.embeddedMapName === null)) {
+	if ((NgChm.UTIL.mapId === "") && (NgChm.MMGR.embeddedMapName === null)) {
 		//In local mode, need user to select the zip file with data (required by browser security)
 		var chmFileItem  = document.getElementById('fileButton');
 		document.getElementById('fileOpen_btn').style.display = '';
@@ -531,7 +533,7 @@ NgChm.UTIL.onLoadCHM = function (sizeBuilderView) {
 	} else {
 		document.getElementById('loader').style.display = '';
 		//Run from a web server.
-		var mapName = NgChm.UTIL.getURLParameter('map');
+		var mapName = NgChm.UTIL.mapId;
 		var dataSource = NgChm.MMGR.WEB_SOURCE;
 		if ((NgChm.MMGR.embeddedMapName !== null) && (ngChmWidgetMode !== "web")) { 
 			mapName = NgChm.MMGR.embeddedMapName;

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -503,7 +503,7 @@ NgChm.UTIL.convertToArray = function(value) {
 	NgChm.UTIL.iESupport();
 
 	if (NgChm.MMGR.embeddedMapName === null && (NgChm.UTIL.mapId !== '' || NgChm.UTIL.mapNameRef !== '')) {
-		NgChm.MMGR.createWebLoader();
+		NgChm.MMGR.createWebLoader(NgChm.MMGR.WEB_SOURCE);
 	}
 })();
 

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -165,10 +165,10 @@ NgChm.UTIL.redrawCanvases = function () {
     if ((NgChm.UTIL.getBrowserType() !== "Firefox") && (NgChm.heatMap !== null)) {
         NgChm.SUM.drawHeatMap();
         NgChm.DET.setDrawDetailsTimeout (NgChm.DET.redrawSelectionTimeout);
-        if (NgChm.SUM.rCCanvas.width > 0) {
+        if (NgChm.SUM.rCCanvas && NgChm.SUM.rCCanvas.width > 0) {
             NgChm.SUM.drawRowClassBars();
         }
-        if (NgChm.SUM.cCCanvas.height > 0) {
+        if (NgChm.SUM.cCCanvas && NgChm.SUM.cCCanvas.height > 0) {
             NgChm.SUM.drawColClassBars();
         }
     }

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -503,7 +503,7 @@ NgChm.UTIL.convertToArray = function(value) {
 	NgChm.UTIL.iESupport();
 
 	if (NgChm.MMGR.embeddedMapName === null && (NgChm.UTIL.mapId !== '' || NgChm.UTIL.mapNameRef !== '')) {
-		NgChm.MMGR.createWebTileLoader();
+		NgChm.MMGR.createWebLoader();
 	}
 })();
 

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -11,6 +11,7 @@ NgChm.UTIL.getURLParameter = function(name) {
 }
 
 NgChm.UTIL.mapId = NgChm.UTIL.getURLParameter('map');
+NgChm.UTIL.mapNameRef = NgChm.UTIL.getURLParameter('name');
 
 NgChm.UTIL.capitalize = function capitalize (str) {
 	return str.substr(0,1).toUpperCase() + str.substr(1);
@@ -501,7 +502,7 @@ NgChm.UTIL.convertToArray = function(value) {
 	//Call functions that enable viewing in IE.
 	NgChm.UTIL.iESupport();
 
-	if (NgChm.MMGR.embeddedMapName === null && NgChm.UTIL.mapId !== '') {
+	if (NgChm.MMGR.embeddedMapName === null && (NgChm.UTIL.mapId !== '' || NgChm.UTIL.mapNameRef !== '')) {
 		NgChm.MMGR.createWebTileLoader();
 	}
 })();
@@ -523,7 +524,7 @@ NgChm.UTIL.onLoadCHM = function (sizeBuilderView) {
 
 
 	// See if we are running in file mode AND not from "widgetized" code - launcHed locally rather than from a web server (
-	if ((NgChm.UTIL.mapId === "") && (NgChm.MMGR.embeddedMapName === null)) {
+	if ((NgChm.UTIL.mapId === "") && (NgChm.UTIL.mapNameRef === "") && (NgChm.MMGR.embeddedMapName === null)) {
 		//In local mode, need user to select the zip file with data (required by browser security)
 		var chmFileItem  = document.getElementById('fileButton');
 		document.getElementById('fileOpen_btn').style.display = '';


### PR DESCRIPTION
This sequence of commits allows server maps to be specified by 'name' using a URL of the form ".../chm.html?name=the.name".

It requires the web server to implement the GetMapByName API call for translating names to a mapid.  When (if) the viewer gets the mapId, it loads the mapConfig and mapData files using the mapId.

This feature was requested by the stat analysts so improve their interactions with collaborators.