### PR TITLE
PT #177796443: Several icons missing in "Installed Plug-ins" Information

### DIFF
--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -717,7 +717,6 @@ th.breakpointContainer {
 
 #linkBoxTxt, #linkBoxAllTxt {
 	font-size: 12px;
-	background-color: #FFFFFF;
 	overflow-y: auto;
 }
 

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -1000,7 +1000,7 @@ NgChm.UHM.openMapLinkoutsHelp = function() {
 			validPluginCtr++;
 			var plugLogo;
 			//If there is no plugin logo, replace it with hyperlink using plugin name
-			var logoImage = typeof plugin.logo !== 'undefined' ? "<img src='"+ plugin.logo+"' width='100px'>" : plugin.name;
+			var logoImage = typeof plugin.logo !== 'undefined' ? "<img src='"+ plugin.logo+"' width='100px'>" : "<b>" + plugin.name + "</b>";
 			var hrefSite = typeof plugin.site !== 'undefined' ? "<a href='"+plugin.site+"' target='_blank'> " : "<a>";
 			var logo = hrefSite + logoImage + "</a>";
 			var tr = pluginTbl.insertRow();
@@ -1065,7 +1065,7 @@ NgChm.UHM.openAllLinkoutsHelp = function() {
 			validPluginCtr++;
 			var plugLogo;
 			//If there is no plugin logo, replace it with hyperlink using plugin name
-			var logoImage = typeof plugin.logo !== 'undefined' ? "<img src='"+ plugin.logo+"' width='100px'>" : plugin.name;
+			var logoImage = typeof plugin.logo !== 'undefined' ? "<img src='"+ plugin.logo+"' width='100px'>" : "<b>" + plugin.name + "</b>";
 			var hrefSite = typeof plugin.site !== 'undefined' ? "<a href='"+plugin.site+"' target='_blank'> " : "<a>";
 			var logo = hrefSite + logoImage + "</a>";
 			var tr = pluginTbl.insertRow();

--- a/NGCHM/WebContent/javascript/custom/custom.js
+++ b/NGCHM/WebContent/javascript/custom/custom.js
@@ -513,7 +513,7 @@ linkouts.addPlugin({
 	description: "Adds linkouts for viewing a set of genes and/or mirs on an interactive ideogram.",
 	version: "0.1.0",
 	site: "http://bioinformatics.mdanderson.org/main/IdeogramViewer:Overview",
-        logo: "http://bioinformatics.mdanderson.org/people/Bradley.Broom/IdeogramViewerLogo.png",
+    logo: "https://bioinformatics.mdanderson.org//public-software/ideogramviewer/IdeogramViewerLogo.png",
 	linkouts: [
 	    { menuEntry: "View ideogram", typeName: "bio.gene.hugo", selectMode: linkouts.MULTI_SELECT, linkoutFn: viewIdeogramGene },
             { menuEntry: "View ideogram", typeName: "bio.mirna", selectMode: linkouts.MULTI_SELECT, linkoutFn: viewIdeogramMIRNA }
@@ -541,7 +541,7 @@ linkouts.addPlugin({
 	description: "Adds linkout to search MaveDB.",
 	version: "0.1.0",
 	site: "https://www.mavedb.org",
-	logo: "https://www.mavedb.org/static/core/mavedb/dna.png",
+	logo: "https://www.mavedb.org/static/core/mavedb/ve-logo.png",
 	linkouts: [
 	    { menuEntry: "Search MaveDB", typeName: "bio.gene.hugo", selectMode: linkouts.SINGLE_SELECT, linkoutFn: openMavedbGene }
 	]
@@ -820,7 +820,7 @@ linkouts.addPlugin({
         description: "Antibody RRID.",
 //        version: "0.1.3",
         site: "http://antibodyregistry.org/",
-//        logo: "https://www.ncbi.nlm.nih.gov/coreutils/img/pubmed256blue.png",
+        logo: "https://scicrunch.org/upload/community-components/resources_66006.png",
         linkouts: [
             { menuEntry: "Search Antibody Registry", typeName: "bio.rrid", selectMode: linkouts.SINGLE_SELECT, linkoutFn: searchAntibodyRegistry },
             { menuEntry: "Search SCICrunch for ", typeName: "bio.rrid", selectMode: linkouts.SINGLE_SELECT, linkoutFn: searchSCICrunch },
@@ -870,7 +870,7 @@ linkouts.addPlugin({
     }
     linkouts.addPlugin({
         name: "TCGA",
-        logo: "https://cancergenome.nih.gov/PublishedContent/Images/SharedItems/Images/TCGA_54px%20Logo%20COLOR.__v30030670.svg",
+        logo: "https://www.cancer.gov/sites/g/files/xnrzdm211/files/styles/cgov_social_media/public/cgov_image/media_image/100/000/3/files/TCGA%20topic%20-%20feature%20card.png",
         site: "https://cancergenome.nih.gov/",
         description: "Enhances linkouts to The Cancer Genome Atlas.",
         version: "0.1.0",


### PR DESCRIPTION
This pull request is for a single Pivotal tracker item (PT #177796443: Several icons missing in "Installed Plug-ins" Information panel).  I believe we want to merge this small change into the Master before tagging the new 2.20.1 version but will leave that to the group to decide.
The following is a list of changes made in this fix:
1. New Ideogram viewer logo URL added. (custom.js)
2. New Cancer Genome Atlas logo URL added (custom.js)
3. New Mave DB logo URL added. (custom.js)
4. New RRID logo URL added. (custom.js)
5. For plugins without a logo, I added bold font to the hyperlink that appears in lieu of a logo (UserHelpManager.js)
6. The background color of the list display was changed from white to gray because the logos for QuickGO and Depmap Portal are white with a transparent background and, therefore, invisible. (NGCHM.css)