### PR TITLE
Use class inSelection to indicate selected labels

### DIFF
--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -2,6 +2,22 @@
 /**
  *  */
 
+:root {
+        /* Variables used to specify the colors of selected labels.
+         * Set by javascript based on the current color scheme.
+         */
+	--in-selection-color: rgb(0,0,0);
+	--in-selection-background-color: rgb(0,255,56);
+}
+
+/* Extra class added to selected labels.
+ * Used for coloring their text and background colors.
+ */
+.inSelection {
+	color: var(--in-selection-color);
+	background-color: var(--in-selection-background-color);
+}
+
 body.NgChmViewer {
 	margin: 8px;
 	width: calc(100vw - 16px);

--- a/NGCHM/WebContent/javascript/ColorMapManager.js
+++ b/NGCHM/WebContent/javascript/ColorMapManager.js
@@ -95,7 +95,7 @@ NgChm.CMM.ColorMap = function(colorMapObj) {
 			color = rgbaMissingColor;
 		}else if(value <= NgChm.SUM.minValues){
 			var layers = NgChm.heatMap.getDataLayers();
-			var dl = layers[NgChm.SEL.currentDl];
+			var dl = layers[NgChm.SEL.getCurrentDL()];
 			if (typeof dl.cuts_color !== 'undefined') {
 				color = this.getHexToRgba(dl.cuts_color);
 			} else {

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -1591,21 +1591,6 @@ NgChm.DET.addLabelDiv = function (mapItem, parent, id, className, text ,longText
 	if (NgChm.DET.labelIndexInSearch(index,axis)) {
 		div.classList.add('inSelection');
 	}
-	if (text == "<") {
-		// What is a label with text == "<"?
-		// Can this condition be eliminated?
-		const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",mapItem.currentDl);
-		const dataLayer = NgChm.heatMap.getDataLayers()[mapItem.currentDl];
-		const selectionRgba = colorMap.getHexToRgba(dataLayer.selection_color);
-		let divFontColor = "#FFFFFF";
-		const selColor = colorMap.getHexToRgba(dataLayer.selection_color);
-		if (colorMap.isColorDark(selColor)) {
-			divFontColor = "#000000";
-		}
-	//	div.style.backgroundColor = "rgba(3,255,3,0.2)";
-		div.style.color = divFontColor;
-		div.style.backgroundColor = "rgba("+selectionRgba.r+","+selectionRgba.g+","+selectionRgba.b+",0.2)";
-	}
 	if (rotate == 'T') {
 		div.style.transformOrigin = 'left top';
 		div.style.transform = 'rotate(90deg)';

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -1578,16 +1578,8 @@ NgChm.DET.addLabelDiv = function (mapItem, parent, id, className, text ,longText
 	    NgChm.DET.updateLabelDiv (mapItem, parent, id, className, text ,longText, left, top, fontSize, rotate, index,axis,xy);
 	    return;
 	}
-	const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",mapItem.currentDl);
-	const dataLayer = NgChm.heatMap.getDataLayers()[mapItem.currentDl];
-	const selectionRgba = colorMap.getHexToRgba(dataLayer.selection_color);
 	div = document.createElement('div');
 	mapItem.labelElements[id] = { div, parent };
-	let divFontColor = "#FFFFFF";
-	const selColor = colorMap.getHexToRgba(dataLayer.selection_color);
-	if (colorMap.isColorDark(selColor)) {
-		divFontColor = "#000000";
-	}
 	div.id = id;
 	div.className = className;
 	div.dataset.index = index;
@@ -1597,10 +1589,19 @@ NgChm.DET.addLabelDiv = function (mapItem, parent, id, className, text ,longText
 		div.dataset.axis = 'Row';
 	}
 	if (NgChm.DET.labelIndexInSearch(index,axis)) {
-		div.style.backgroundColor = dataLayer.selection_color;
-		div.style.color = divFontColor;
+		div.classList.add('inSelection');
 	}
 	if (text == "<") {
+		// What is a label with text == "<"?
+		// Can this condition be eliminated?
+		const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",mapItem.currentDl);
+		const dataLayer = NgChm.heatMap.getDataLayers()[mapItem.currentDl];
+		const selectionRgba = colorMap.getHexToRgba(dataLayer.selection_color);
+		let divFontColor = "#FFFFFF";
+		const selColor = colorMap.getHexToRgba(dataLayer.selection_color);
+		if (colorMap.isColorDark(selColor)) {
+			divFontColor = "#000000";
+		}
 	//	div.style.backgroundColor = "rgba(3,255,3,0.2)";
 		div.style.color = divFontColor;
 		div.style.backgroundColor = "rgba("+selectionRgba.r+","+selectionRgba.g+","+selectionRgba.b+",0.2)";
@@ -1681,18 +1682,10 @@ NgChm.DET.updateLabelDiv = function (mapItem, parent, id, className, text ,longT
 	mapItem.labelElements[id] = { div, parent };
 	delete mapItem.oldLabelElements[id];
 
-	const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",mapItem.currentDl);
-	const dataLayer = NgChm.heatMap.getDataLayers()[mapItem.currentDl];
-	const selectionRgba = colorMap.getHexToRgba(dataLayer.selection_color);
-	const selColor = colorMap.getHexToRgba(dataLayer.selection_color);
-	const divFontColor = colorMap.isColorDark(selColor) ? "#000000" : "#FFFFFF";
-
 	if (NgChm.DET.labelIndexInSearch(index,axis)) {
-		div.style.backgroundColor = dataLayer.selection_color;
-		div.style.color = divFontColor;
+		div.classList.add ('inSelection');
 	} else {
-		div.style.removeProperty('background-color');
-		div.style.removeProperty('color');
+		div.classList.remove ('inSelection');
 	}
 	
 	//div.style.position = "absolute";

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -550,7 +550,7 @@ NgChm.DEV.flickChange = function(fromList) {
 			return;
 		}
 	} 
-	NgChm.SEL.currentDl = mapItem.currentDl;
+	NgChm.SEL.setCurrentDL (mapItem.currentDl);
 	NgChm.SEL.flickInit();
     NgChm.SUM.buildSummaryTexture();
 	NgChm.DET.setDrawDetailTimeout(mapItem,NgChm.DET.redrawSelectionTimeout);

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -1022,11 +1022,11 @@ NgChm.createNS('NgChm.LNK');
 	// Return an array of values for the rows/columns specified by idx along axis.
 	function getDataValues (axis, idx) {
 		const isRow = NgChm.MMGR.isRow (axis);
-		const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.currentDl);
+		const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.getCurrentDL());
 		const colorThresholds = colorMap.getThresholds();
 		idx = idx === undefined ? [] : Array.isArray(idx) ? idx : [idx];
 		const win = {
-			layer: NgChm.SEL.currentDl,
+			layer: NgChm.SEL.getCurrentDL(),
 			level: NgChm.MMGR.DETAIL_LEVEL,
 			firstRow: 1,
 			firstCol: 1,
@@ -1091,7 +1091,7 @@ NgChm.createNS('NgChm.LNK');
 		for (let i=0; i < axisIdx.length; i++) {
 			// Get access window for each axisIdx (one vector per iteration)
 			const win = {
-				layer: NgChm.SEL.currentDl,
+				layer: NgChm.SEL.getCurrentDL(),
 				level: NgChm.MMGR.DETAIL_LEVEL,
 				firstRow: isRow ? 1+axisIdx[i] : 1,
 				firstCol: isRow ? 1 : 1+axisIdx[i],
@@ -1194,7 +1194,7 @@ NgChm.createNS('NgChm.LNK');
 	}
 
 	function getDataColors (axis, idx) {
-		const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.currentDl);
+		const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.getCurrentDL());
 		const { breaks, classColors } = getDiscMapFromContMap (colorMap.getThresholds(), colorMap.getColors());
 		const values = getDataValues (axis, idx);
 		const valClasses = getValueClassesColors (values, breaks, classColors, colorMap.getMissingColor(),'Class');
@@ -1318,7 +1318,7 @@ NgChm.createNS('NgChm.LNK');
 		};
 
 		if (msg.testToRun === 'Mean') {
-		    const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.currentDl);
+		    const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.getCurrentDL());
 		    const vColorMap = {
 		        thresholds: colorMap.getThresholds(),
 			colors: colorMap.getColors().map(NgChm.CMM.darkenHexColorIfNeeded),
@@ -1416,7 +1416,7 @@ NgChm.createNS('NgChm.LNK');
 				const idx = axis[valueField][ci].labelIdx; 
 				const values = getDataValues(isRow ? 'column' : 'row', idx);
 				cocodata[valueField].push(values);
-				const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.currentDl);
+				const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.getCurrentDL());
 
 				var colorsForThisData = []
 				for (var idv = 0; idv < values.length; idv++) {

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -708,7 +708,7 @@ NgChm.UTIL.builderViewSizing = function (event) {
  **********************************************************************************/
 NgChm.UTIL.resetCHM = function () {
 //	NgChm.SEL.mode = 'NORMAL';      
-	NgChm.SEL.currentDl = "dl1"; 
+	NgChm.SEL.setCurrentDL ("dl1");
 	NgChm.SEL.currentRow=null; 
 	NgChm.SEL.currentCol=null; 
 //	NgChm.SEL.dataPerRow=null; 

--- a/NGCHM/WebContent/javascript/PdfGenerator.js
+++ b/NGCHM/WebContent/javascript/PdfGenerator.js
@@ -343,7 +343,7 @@ NgChm.PDF.genViewerHeatmapPDF = function() {
 		}
 
 	}
-	var colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",NgChm.SEL.currentDl);
+	var colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",NgChm.SEL.getCurrentDL());
 
 	// Add row and column labels to the PDF
 	if (mapsToShow !== "S") {
@@ -991,7 +991,7 @@ NgChm.PDF.genViewerHeatmapPDF = function() {
 	 * boxes and selected label boxes onto the detail heat map page.
 	 **********************************************************************************/
 	function drawDetailSelectionBoxes(mapItem,detClient2PdfWRatio,detClient2PdfHRatio,selectedColor) {
-		var colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",NgChm.SEL.currentDl);
+		var colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",NgChm.SEL.getCurrentDL());
 		const mapLabels = mapItem.labelElements;
 		// Draw selection boxes first (this way they will not overlap text)
 		var rowLabels = 0;
@@ -1062,7 +1062,7 @@ NgChm.PDF.genViewerHeatmapPDF = function() {
 	 **********************************************************************************/
 	function getDataMatrixDistributionPlot(){
 		// function ripped from UPM used in the gear panel
-		var currentDl = NgChm.SEL.currentDl;
+		var currentDl = NgChm.SEL.getCurrentDL();
 		var cm = NgChm.heatMap.getColorMapManager().getColorMap("data",currentDl);
 		var thresholds = cm.getThresholds();
 		var numBreaks = thresholds.length;

--- a/NGCHM/WebContent/javascript/SearchManager.js
+++ b/NGCHM/WebContent/javascript/SearchManager.js
@@ -603,11 +603,15 @@ NgChm.SRCH.findNextSearchItem = function (index, axis) {
 	const searchTarget = document.getElementById('search_target').value;
 	let curr = index;
 	while( !NgChm.SRCH.searchItems[axis][++curr] && curr <  axisLength){}; // find first searchItem in row
-	if (curr >= axisLength) { // if no searchItems exist in first axis, move to other axis
+	if (NgChm.SRCH.searchItems[axis][curr] === 1) {
+		NgChm.SRCH.setSearchItem(axis, curr);
+	} else if (curr >= axisLength) { // if no more searchItems exist in first axis, move to other axis
 		if (document.getElementById('search_target').value === 'Both') {
 			curr = -1;
 			while( !NgChm.SRCH.searchItems[otherAxis][++curr] && curr <  otherAxisLength){};
-			if (curr >=otherAxisLength){ // if no matches in the other axis, check the earlier indices of the first axis (loop back)
+			if (NgChm.SRCH.searchItems[otherAxis][curr] === 1) {
+				NgChm.SRCH.setSearchItem(otherAxis, curr);
+			} else if (curr >= otherAxisLength){ // if no matches in the other axis, check the earlier indices of the first axis (loop back)
 				NgChm.SRCH.findNextReturnOnAxis(curr, index, axis);
 			} else {
 				NgChm.SRCH.setSearchItem(otherAxis, curr);

--- a/NGCHM/WebContent/javascript/SelectionManager.js
+++ b/NGCHM/WebContent/javascript/SelectionManager.js
@@ -10,10 +10,43 @@
 NgChm.createNS('NgChm.SEL');
 
 //Globals that provide information about heat map position selection.
-NgChm.SEL.currentDl = "dl1";    // Set (default) to Data Layer 1 (set in application by user when flick views are toggled)
 NgChm.SEL.currentRow = null;      // Top row of current selected position
 NgChm.SEL.currentCol = null;      // Left column of the current selected position
 NgChm.SEL.scrollTime = null;    // timer for scroll events to prevent multiple events firing after scroll ends
+
+// Global for the current data layer being displayed.
+// Set in application by user when flick views are toggled.
+// Hide so that it can only be changed using NgChm.SEL.setCurrentDL.
+{
+    let currentDl = "dl1"; // Set default to Data Layer 1.
+
+    NgChm.SEL.setCurrentDL = function (dl) {
+	// Update the selection colors when the current data layer changes.
+        if (currentDl != dl) {
+	    currentDl = dl;
+	    NgChm.SEL.setSelectionColors();
+	}
+    };
+
+    NgChm.SEL.getCurrentDL = function (dl) {
+        return currentDl;
+    };
+}
+
+/*********************************************************************************************
+ * FUNCTION:  setSelectionColors - Set the colors for selected labels based on the
+ * current layer's color scheme.
+ *********************************************************************************************/
+NgChm.SEL.setSelectionColors = function () {
+    const currentDl = NgChm.SEL.getCurrentDL();
+    const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data",currentDl);
+    const dataLayer = NgChm.heatMap.getDataLayers()[currentDl];
+    const selColor = colorMap.getHexToRgba(dataLayer.selection_color);
+    const textColor = colorMap.isColorDark(selColor) ? "#000000" : "#FFFFFF";
+    const root = document.documentElement;
+    root.style.setProperty('--in-selection-color', textColor);
+    root.style.setProperty('--in-selection-background-color', dataLayer.selection_color);
+};
 
 /*********************************************************************************************
  * FUNCTION:  updateSelection - The purpose of this function is to set the state of a given

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -123,7 +123,7 @@ NgChm.UPM.editPreferences = function(e,errorMsg) {
 		NgChm.UPM.searchPerformed = false;
 		NgChm.UPM.showClassPrefs();
 	} else {
-		NgChm.UPM.showLayerBreak(NgChm.SEL.currentDl);
+		NgChm.UPM.showLayerBreak(NgChm.SEL.getCurrentDL());
 		NgChm.UPM.showLayerPrefs();
 	}
 	errorMsg = null;


### PR DESCRIPTION
Allows test frameworks to more easily determine selected labels.

Instead of modifying the styles of selected labels, add a secondary class to them and use that to determine colors.
The central modifications are to: 
 - SelectionManager.js
 - DetailHeatMapDisplay.js
 - NGCHM.css

A lot of incidental changes caused by requiring the current data layer to be get/set by functions.  Ensures that current data layer can't be changed without updating selection colors.

I've tested the following:
- Heat maps with non-default selection color in first (default) data layer
- Changing selection color in preferences dialog
- Toggling between layers with different selection colors.

There is a section of code in DetailHeatMapDisplay for setting the colors of labels with text == "<".  I couldn't figure out what that was used for or cause that code to be executed.

If it's obsolete we could remove that code (in a separate commit).  If it is used, we need a comment describing what it's for and to test how these changes affect that.

Since these changes affect selection label drawing in a fundamental way, I think James should test.
 