### PR TITLE
Drag and drop

### DIFF
--- a/NGCHM/Documentation/DragAndDrop.md
+++ b/NGCHM/Documentation/DragAndDrop.md
@@ -1,0 +1,89 @@
+# NG-CHM Viewer Drag-and-Drop Functionality
+
+Users can add plugins to an NG-CHM Viewer at runtime by dragging a
+plugin-specification and dropping it onto the NG-CHM Viewer near the hamburger
+menu.  The drop target will highlight when a dragged item is above it.
+
+Plugin specifications are JSON objects (e.g. from a file).  They must
+have:
+- a "type" field that equals "linkout.spec",
+- a "kind" field of type string, and
+- a "spec" field of type object.
+
+Three kinds of plugins can be loaded:
+- "panel-plugin" A plugin that displays in a user-interface panel.
+- "linkout-plugin" A plugin that provides one or more link-out menu entries.
+- "hamburger-plugin" A plugin that provides a hamburger menu entry.
+
+## Common Spec Fields
+
+The following fields are common to all three plugin types:
+
+- "name" The name of the plugin as shown in menus, dialogs, etc.
+- "src" The URL for the plugin page (HTML).
+- "version" The current version of the plugin.
+- "description" A long description of the plugin shown in some dialogs.
+- "site" A URL for a website that describes the plugin.
+- "logo" A URL for a logo for the plugin or website.
+
+The "name" and "src" fields are required.
+
+All three link-out types open a HTML document (loaded from "src") in an iframe within the NG-CHM viewer.
+This iframe is shown in the panel for panel plugins and is hidden for link-out and hamburger plugins.
+
+## Panel Plugins
+
+The "kind" field of a panel plugin must equal "panel-plugin".
+
+The "spec" object for a panel plugin must also include the "params" object for defining
+the panel plugin gear menu (see the panel plugin documentation for details).
+
+An example panel plugin specification:
+
+    {
+      "type": "linkout.spec",
+      "kind": "panel-plugin",
+      "spec": {
+        "name": "<plugin name>",
+        "description": "<plugin description>",
+        "version": "<plugin version number>",
+        "logo": "<url for plugin logo>",
+        "site": "<url for plugin website>",
+        "helpText": "<plugin help text>",
+        "params": {}, 
+        "src": "<plugin url>"
+      }
+    }
+
+## Link-out Plugins
+
+The "kind" field of a link-out plugin must equal "linkout-plugin".
+
+The "spec" object for a link-out plugin must include two additional
+arrays: "linkouts" and "matrixLinkouts".
+
+Each element of the "linkouts"  array is an object describing an axis linkout, with the
+following fields:
+- "menuEntry" The name of the menu entry.
+- "typeName" The type of label the menu entry applies to.
+- "selectMode" Either "singleSelection" or "multiSelection".
+- "messageId" Included in message sent to HTML page. Used to distinguish different menu items.
+
+Each element of the "maxtrixLinkouts" array is an object describing a matrix linkout, with the
+following fields:
+- "menuEntry" The name of the menu entry.
+- "typeName1" One type of label the menu entry applies to.
+- "typeName2" The type of the other axis label the menu entry applies to.
+- "selectMode" Either "singleSelection" or "multiSelection".
+- "messageId" Included in the message sent to the HTML page. Used to distinguish different menu items in the same plugin.
+
+## Hamburger Plugins
+
+The "kind" field of a link-out plugin must equal "hamburger-plugin".
+
+The "spec" object for a hamburger plugin must include the following additional fields:
+
+- The "label" specifies the text to display in the hamburger menu.
+- The "icon" field is a URL for an icon image to display beside the label in the hamburger menu.
+- The "messageId" field is a string that is included in messages send to the plugin HTML page.
+

--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -117,6 +117,7 @@
 				    </div>
 					<img id='colorMenu_btn' src='images/barColors.png' alt='Open Alert' onmouseout="NgChm.UHM.colorOver(0);NgChm.UHM.hlpC();" onmouseover='NgChm.UHM.colorOver(1);NgChm.UHM.hlp(this,"Edit Map Colors",80,0)' onclick='NgChm.UPM.editPreferences(this,null);' style="vertical-align: top;"   />
 					<img id='barMenu_btn' class='farRightButton' src='images/barMenu.png' alt='Open Menu' onmouseout='NgChm.UHM.menuOver(0);NgChm.UHM.hlpC();' onmouseover='NgChm.UHM.menuOver(1);NgChm.UHM.hlp(this,"Open NG-CHM Options Menu",140,0)' onclick='NgChm.UHM.openMenu(this);' style="vertical-align: top;"/>
+			                <div id="droptarget" class="">DROP HERE</div>
 			    </div>
 		        <img id='aboutMenu_btn' class='farRightButton' src='images/aboutNgchm.png' alt='About NG-CHM' onmouseout='NgChm.UHM.menuOver(0);NgChm.UHM.hlpC();' onmouseover='NgChm.UHM.menuOver(1);NgChm.UHM.hlp(this,"Open NG-CHM About",140,0)' onclick='NgChm.UHM.widgetHelp();' style="vertical-align: top;"/>
 		    </div>

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -436,6 +436,7 @@ span.button.negative {
 	top: 0px;
 	position: absolute;
 	right: 60px;
+	z-index: 2;
 }
 
 #helptext {
@@ -862,12 +863,14 @@ table.onlineHelp th {
 	right: 30px;
 	top: 0px;
     position: absolute;
+    z-index: 2;
 }
 
 .farRightButton {
 	right: 0px;
 	top: 0px;
     position: absolute;
+    z-index: 2;
 }
 
 .tdTop {
@@ -1117,3 +1120,23 @@ iframe.nopointer {
 }
 
 
+div#droptarget {
+    position:  absolute;
+    top: 0px;
+    right: 0px;
+    width: fit-content;
+    height: fit-content;
+    text-align: center;
+    vertical-align: middle;
+    padding: 1em 2em;
+    z-index: 1;
+    color: rgba(0,0,0,0);
+    background-color: rgba(1,0,0,0.01);
+    user-select: none;
+}
+
+div#droptarget.visible {
+    z-index: 100;
+    color: rgba(0,0,0,1);
+    background-color: rgba(255,128,128,1);
+}

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -899,7 +899,16 @@ NgChm.createNS('NgChm.LNK');
 		}
 
 		NgChm.LNK.registerPanePlugin = function(p) {
-			panePlugins.push (new PanePlugin (p));
+			const pp = new PanePlugin (p);
+			// Replace any existing plugin with the same name.
+			for (let idx = 0; idx < panePlugins.length; idx++) {
+			    if (panePlugins[idx].name === pp.name) {
+				panePlugins[idx] = pp;
+				return;
+			    }
+			}
+			// Add new pane plugin if no plugin with the same name already exists.
+			panePlugins.push (pp);
 		};
 
 		NgChm.LNK.getPanePlugins = function() {

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -127,13 +127,15 @@ NgChm.createNS('NgChm.LNK');
 		var burgerMenu = document.getElementById('burgerMenuPanel');
 		//Verify params and set defaults
 		if (params.name === undefined) {return;}
+		params.name = "plugin-" + params.name;
 		if (params.label === undefined) {params.label = params.name;}
 		if (params.icon === undefined) {params.icon = 'images/link.png';}
-		if (params.action === undefined) {params.action = 'NgChm.UHM.hamburgerLinkMissing();'}
+		if (params.action === undefined) {params.action = NgChm.UHM.hamburgerLinkMissing;}
 		//Create linkout div using params
 		var wrapper= document.createElement('div');
-		wrapper.innerHTML= "<div id='"+params.name+"' class='menuitem' onclick='"+params.action+"'> <img id='menu"+params.name+"_btn' class='menuitem' name ='menu"+params.name+"' src='"+params.icon+"' align='middle'>&nbsp;&nbsp;"+params.label+"...<br><br></div>";
+		wrapper.innerHTML= "<div id='"+params.name+"' class='menuItem'> <img id='plugin-"+params.name+"_btn' src='"+params.icon+"'>"+params.label+"...</div>";
 		var burgerLinkDiv= wrapper.firstChild;
+		burgerLinkDiv.onclick = params.action;
 		//Add linkout to burger menu
 		burgerMenu.insertBefore(burgerLinkDiv, burgerMenu.children[NgChm.LNK.hamburgerLinkCtr]);
 		NgChm.LNK.hamburgerLinkCtr++;

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2799,7 +2799,8 @@ NgChm.createNS('NgChm.LNK');
 		{ label: 'T-test', value: 'T-test' }
 	];
 
-	/**
+	defineVanodiMessageHandler ('getTestData',
+	    /**
 		Calls getAxisTestData to perform statistical tests, and posts results to plugin
 
 		@function vanodiSendTestData
@@ -2811,8 +2812,8 @@ NgChm.createNS('NgChm.LNK');
 		@option {Array<String>} axisLabels labels of nodes from plugin (e.g. gene symbols from PathwayMapper)
 		@option {Array<String>} group1 NGCHM labels for group 1
 		@option {Array<String>} group2 NGCHM labels for group 2
-	*/
-	defineVanodiMessageHandler ('getTestData', function vanodiSendTestData (instance, msg) {
+	    */
+	    function vanodiSendTestData (instance, msg) {
 		// axisName: 'row',
 		// axisLabels: labels of axisName elements to test
 		// testToRun: name of test to run

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2868,4 +2868,7 @@ NgChm.createNS('NgChm.LNK');
 		}
 	})();
 
+        NgChm.LNK.loadLinkoutSpec = function loadLinkoutSpec (kind, spec) {
+	   console.log ({ m: 'loadLinkoutSpec', kind, spec });
+	};
 })(); // end of big IIFE

--- a/NGCHM/WebContent/javascript/custom/custom.js
+++ b/NGCHM/WebContent/javascript/custom/custom.js
@@ -36,13 +36,13 @@ linkouts.addPanePlugin ({
 	/*BEGIN SAMPLE Linkouts to the Hamburger Menu
 	//TODO: replace with "real" hamburger linkout(s)
 	//Using default icon
-	linkouts.addHamburgerLinkout({name: "menuLink2", label: "Execute Menu Link 1", action: "linkoutHelp();"});
+	linkouts.addHamburgerLinkout({name: "menuLink2", label: "Execute Menu Link 1", action: linkoutHelp});
 	//Using different icon from server
-	linkouts.addHamburgerLinkout({name: "menuLink3", label: "Execute Menu Link 2", icon: "images/redX.png", action: "linkoutHelp();"}); 
+	linkouts.addHamburgerLinkout({name: "menuLink3", label: "Execute Menu Link 2", icon: "images/redX.png", action: linkoutHelp}); 
 	//Using external icon from the web
-	linkouts.addHamburgerLinkout({name: "menuLink4", label: "Execute Menu Link 3", icon: "http://amigo.geneontology.org/static/images/go-logo-icon.small.png", action: "openWidgetHelp();"});
+	linkouts.addHamburgerLinkout({name: "menuLink4", label: "Execute Menu Link 3", icon: "http://amigo.geneontology.org/static/images/go-logo-icon.small.png", action: openWidgetHelp});
 	//No label provided
-	linkouts.addHamburgerLinkout({name: "menuLink5", action: "openWidgetHelp();"});
+	linkouts.addHamburgerLinkout({name: "menuLink5", action: openWidgetHelp});
 	//No action provided
 	linkouts.addHamburgerLinkout({name: "menuLink6"});
 	//END SAMPLE Linkouts to the Hamburger Menu*/


### PR DESCRIPTION

Adds ability to drag-and-drop a plugin onto the NG-CHM viewer at runtime.
- Allows users to add their own plugins.
- Simplifies plugin development and testing.

