### PR TITLE
Speed up draw selections

### DIFF
--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -654,6 +654,7 @@ NgChm.DET.setDetailDataHeight = function (mapItem, size) {
 			console.log ("Detail map ", k+1, ": Drew ", mapItemVars.strokes, " boxes in ", elapsedTime, " ms.");
 		}
 	}
+	mapItemVars.ctx = null;   // Remove reference to last context.
     };
 
     /**********************************************************************************
@@ -707,7 +708,7 @@ NgChm.DET.setDetailDataHeight = function (mapItem, size) {
      * Output:
      * an array of visible pixel ranges (each an array of two pixel coordinate values)
      *
-     * Only at least partially visible ranges are include in the output array.
+     * Only at least partially visible ranges are included in the output array.
      *
      **********************************************************************************/
     function calcVisRanges (axis, ranges, currentPosn, viewportStart, viewportEnd, cellSize) {


### PR DESCRIPTION
Improve performance of drawSelections when there many searchBoxes on both axes.  Test case found by James was taking tens of seconds to redraw the screen and freezing the browser window for the duration.

This pull request addresses most cases.

There is still an issue in an extreme case (whole map displayed in the detail pane(s), with a large number of search boxes on both axes).