### PR TITLE
Add Promise-based getAccessWindow

### DIFF
--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -1185,7 +1185,8 @@ NgChm.createNS('NgChm.LNK');
 		const values = [];
 		// Both axisIdx and groupIdx can be disjoint.
 		// TODO: Improve efficiency by grouping adjacent indices.
-		for (let i=0; i < axisIdx.length; i++) {
+		let getAccessWindowPromises = []
+		for (let i=0; i<axisIdx.length; i++) {
 			// Get access window for each axisIdx (one vector per iteration)
 			const win = {
 				layer: NgChm.SEL.getCurrentDL(),
@@ -1195,24 +1196,32 @@ NgChm.createNS('NgChm.LNK');
 				numRows: isRow ? 1 : NgChm.heatMap.getNumRows(NgChm.MMGR.DETAIL_LEVEL),
 				numCols: isRow ? NgChm.heatMap.getNumColumns(NgChm.MMGR.DETAIL_LEVEL) : 1
 			};
-			const accessWindow = NgChm.heatMap.getAccessWindow(win)
-			const thisVec = []
-			// Iterate over groupIdx to get vector of values from heatmap for summarization.
-			if (isRow) {
-				for (let j=0; j < groupIdx.length; j++) {
-					const val = accessWindow.getValue(win.firstRow, 1+groupIdx[j]);
-					thisVec.push(val);
-				}
-			} else {
-				for (let j=0; j < groupIdx.length; j++) {
-					const val = accessWindow.getValue(1+groupIdx[j], win.firstCol);
-					thisVec.push(val);
-				}
-			}
-			var statsForVec = getStats(thisVec)
-			values.push(statsForVec)
+			getAccessWindowPromises.push(NgChm.heatMap.getAccessWindowPromise(win))
 		}
-		return values;
+		return new Promise((resolve, reject) => {
+			Promise.all(getAccessWindowPromises).then(accessWindows => {
+				accessWindows.forEach(accessWindow => {
+					const thisVec = []
+					// Iterate over groupIdx to get vector of values from heatmap for summarization.
+					if (isRow) {
+						for (let j=0; j < groupIdx.length; j++) {
+							const val = accessWindow.getValue(accessWindow.win.firstRow, 1+groupIdx[j]);
+							thisVec.push(val);
+						}
+					} else {
+						for (let j=0; j < groupIdx.length; j++) {
+							const val = accessWindow.getValue(1+groupIdx[j], accessWindow.win.firstCol);
+							thisVec.push(val);
+						}
+					}
+					var statsForVec = getStats(thisVec)
+					values.push(statsForVec)
+				})
+				resolve(values)
+			}).catch(error => {
+				reject(error)
+			})
+		})
 	} // end function getSummaryStatistics 
 
 	function getDiscMapFromContMap (colorThresholds, colorVec) {
@@ -1362,13 +1371,10 @@ NgChm.createNS('NgChm.LNK');
 		// group1: labels of other axis elements in group 1
 		// group2: labels of other axis elements in group 2 (optional)
 	function getAxisTestData (msg) {
-		//console.log ({ m: '> getAxisTestData', msg });
 		if (msg.axisLabels.length < 1) {
 			NgChm.UHM.systemMessage("NG-CHM PathwayMapper", "No pathway present in PathwayMapper. Please import or create a pathway and try again."); 
 			return false;
 		}
-		var allSummaries = [];
-		var nResultsToReturn;
 		var otherAxisName = NgChm.MMGR.isRow(msg.axisName) ? 'column' : 'row';
 		var otherAxisLabels = NgChm.UTIL.getActualLabels (otherAxisName);
 		var heatMapAxisLabels = NgChm.UTIL.getActualLabels (msg.axisName); //<-- axis labels from heatmap (e.g. gene names in heatmap)
@@ -1410,72 +1416,74 @@ NgChm.createNS('NgChm.LNK');
 			NgChm.UHM.systemMessage('Group too small','Group 2 must have at least 2 members.')
 			return false;
 		}
-		var summaryStatistics1 = getSummaryStatistics(msg.axisName, axisIdx, idx1);
-		var summaryStatistics2 = getSummaryStatistics(msg.axisName, axisIdx, idx2);
-
-		var cocodata = {
-			labels: [],
-			results: []
-		};
-
-		if (msg.testToRun === 'Mean') {
-		    const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.getCurrentDL());
-		    const vColorMap = {
-		        thresholds: colorMap.getThresholds(),
-			colors: colorMap.getColors().map(NgChm.CMM.darkenHexColorIfNeeded),
-		        type: "linear",
-		        missing: '#fefefe'
-		    };
-		    cocodata.results.push({
-			    label: "mean",
-			    values: [],
-			    colorMap: vColorMap
-		    });
-		    for (let i=0; i < axisIdx.length; i++) {
-			    const summary1 = summaryStatistics1[i];
-			    cocodata.labels.push (pluginLabels[i]);
-			    if (msg.group2 == null || msg.group2.length == 0) {
-				cocodata.results[0].values.push(summary1.mu);
-			    } else {
-			        const summary2 = summaryStatistics2[i];
-				cocodata.results[0].values.push(summary1.mu - summary2.mu);
-			    }
-		    }
-		} else if (msg.testToRun === 'T-test') {
-		    cocodata.results.push({
-			    label: "t_statistics",
-			    values: [],
-			    colorMap: {
-				    type: "linear",
-				    thresholds: [ -3.291, -1.96, 1.96, 3.291 ],
-				    colors: [ '#1c2ed4', '#cbcff7', '#f9d4d4', '#d41c1c' ],
-				    missing: '#fefefe'
-			    }
-		    });
-		    cocodata.results.push({
-			    label: "p_values",
-			    values: [],
-			    colorMap: {
-				    type: "linear",
-				    thresholds: [ 0.001, 0.05, 1 ],
-				    colors: [ '#fefefe', '#777777', '#000000' ],
-				    missing: '#fefefe'
-			    }
-		    });
-
-		    for (let i=0; i < axisIdx.length; i++) {
-			    const summary1 = summaryStatistics1[i];
-			    const summary2 = summaryStatistics2[i];
-			    const tvalue = Welch_tValue(summary1, summary2);
-			    const dof = degreesOfFreedom(summary1, summary2);
-			    const pvalue = pValue(tvalue, dof);
-			    cocodata.labels.push (pluginLabels[i]);
-			    cocodata.results[0].values.push(tvalue);
-			    cocodata.results[1].values.push(pvalue);
-		    }
-		}
-		//console.log ({ m: '< getAxisTestData', msg, cocodata });
-		return cocodata;
+		return new Promise((resolve, reject) => {
+			Promise.all([getSummaryStatistics(msg.axisName, axisIdx, idx1), getSummaryStatistics(msg.axisName, axisIdx, idx2)]).then(summaryStatistics => {
+				let summaryStatistics1 = summaryStatistics[0]
+				let summaryStatistics2 = summaryStatistics[1]
+				var cocodata = {
+					labels: [],
+					results: []
+				};
+				if (msg.testToRun === 'Mean') {
+					const colorMap = NgChm.heatMap.getColorMapManager().getColorMap("data", NgChm.SEL.getCurrentDL());
+					const vColorMap = {
+						thresholds: colorMap.getThresholds(),
+						colors: colorMap.getColors().map(NgChm.CMM.darkenHexColorIfNeeded),
+						type: "linear",
+						missing: '#fefefe'
+					};
+					cocodata.results.push({
+						label: "mean",
+						values: [],
+						colorMap: vColorMap
+					});
+					for (let i=0; i < axisIdx.length; i++) {
+						const summary1 = summaryStatistics1[i];
+						cocodata.labels.push (pluginLabels[i]);
+						if (msg.group2 == null || msg.group2.length == 0) {
+							cocodata.results[0].values.push(summary1.mu);
+						} else {
+							const summary2 = summaryStatistics2[i];
+							cocodata.results[0].values.push(summary1.mu - summary2.mu);
+						}
+					}
+				} else if (msg.testToRun === 'T-test') {
+					cocodata.results.push({
+						label: "t_statistics",
+						values: [],
+						colorMap: {
+							type: "linear",
+							thresholds: [ -3.291, -1.96, 1.96, 3.291 ],
+							colors: [ '#1c2ed4', '#cbcff7', '#f9d4d4', '#d41c1c' ],
+							missing: '#fefefe'
+						}
+					});
+					cocodata.results.push({
+						label: "p_values",
+						values: [],
+						colorMap: {
+							type: "linear",
+							thresholds: [ 0.001, 0.05, 1 ],
+							colors: [ '#fefefe', '#777777', '#000000' ],
+							missing: '#fefefe'
+						}
+					});
+					for (let i=0; i < axisIdx.length; i++) {
+						const summary1 = summaryStatistics1[i];
+						const summary2 = summaryStatistics2[i];
+						const tvalue = Welch_tValue(summary1, summary2);
+						const dof = degreesOfFreedom(summary1, summary2);
+						const pvalue = pValue(tvalue, dof);
+						cocodata.labels.push (pluginLabels[i]);
+						cocodata.results[0].values.push(tvalue);
+						cocodata.results[1].values.push(pvalue);
+					}
+				}
+				resolve(cocodata)
+			}).catch(error => {
+				reject(error)
+			})
+		})
 	} // end function getAxisTestData
 
 	// Add the values and colors to cocodata for the 'coco' attributes of axis.
@@ -2812,9 +2820,15 @@ NgChm.createNS('NgChm.LNK');
 		} else if (msg.group1 == null) {
 			console.log ({ m: 'Malformed getTestData request', msg, detail: 'group1 is required' });
 		} else {
-			var testData = getAxisTestData (msg);
+			/*var testData = getAxisTestData (msg);
 			if (testData == false) {return;} // return if no data to send
-			NgChm.LNK.sendMessageToPlugin ({ nonce: msg.nonce, op: 'testData', data: testData });
+			NgChm.LNK.sendMessageToPlugin ({ nonce: msg.nonce, op: 'testData', data: testData });*/
+			getAxisTestData(msg).then(testData => {
+				if (testData == false) { return;}
+				NgChm.LNK.sendMessageToPlugin ({ nonce: msg.nonce, op: 'testData', data: testData });
+			}).catch(error => {
+				throw error
+			})
 		}
 	});
 


### PR DESCRIPTION
In order to deal with issues such as [PathwayMapper #17](https://github.com/MD-Anderson-Bioinformatics/pathway-mapper/issues/17), this pull request adds a function similar to `getAccessWindow`, but returning a Promise that resolves when all needed tiles for the window are available in the tileCache.

The existing `getAccessWindow` was designed to return a summary result for `getValue` if the needed tile is not available in cache. This was done to optimize drawing of large maps. Example usage:

```js
let accessWindow = NgChm.heatMap.getAccessWindow(win)
let val = accessWindow.getValue(rowIdx, colIdx) // <-- summary value returned if needed tile not in cache
```

However for plugins doing calculations such as mean, t-test, etc, the actual value is required. The newly added function `getAccessWidnowPromise` returns when all needed tiles are in cache:

```js
NgChm.heatMap.getAccessWindowPromise(win).then((accessWindow) => {
  let val = accessWindow.getValue(rowIdx, colIdx) // <-- actual value returned
})
```

The newly add `getAccessWindowPromise` functionality is used in `getDataValues` (e.g. used by [ScatterPlotPlugin](https://github.com/MD-Anderson-Bioinformatics/ScatterPlotPlugin) and [ScatterPlotPlugin3D](https://github.com/MD-Anderson-Bioinformatics/ScatterPlotPlugin3D)) and `getSummaryStatistics` (e.g. used by [PathwayMapper](https://github.com/MD-Anderson-Bioinformatics/pathway-mapper) plugin).
