### PR TITLE
Change 'caption' to 'description' in ShaidyMapGen

### DIFF
--- a/NGCHM/src/mda/ngchm/datagenerator/ShaidyRMapGen.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/ShaidyRMapGen.java
@@ -449,15 +449,18 @@ public class ShaidyRMapGen {
 						if (count > 0) fileout.print(",");
 						fileout.print("{\"" + label + "\": \"" + value + "\"}");
 						count++;
-						if (label.toLowerCase().equals("chm.info.caption"))
+						if (label.toLowerCase().equals("chm.info.description")) {
 							description = value;
+						} else if (label.toLowerCase().equals("chm.info.caption")) { // maintained for backward compatibility
+							description = value;
+						}
 					} 	
 				}
 			}
 			fileout.println("],");
 
 			if (description.equals("-"))
-				warnings.append("Warning: No heat map description provided in properties : chm.info.caption.\n");
+				warnings.append("Warning: No heat map description provided in properties : chm.info.description.\n");
 			fileout.println("\t\"chm_description\": \""+ description + "\",");
 
 			


### PR DESCRIPTION
With the goal of obtaining a uniform language for users (of the viewer and NGCHM R package) change the special property 'chm.info.caption' to 'chm.info.description'. This property is displayed under the label 'Description' when users hover over the label 'Map Name' in the NGCHM viewer.

Backwards compatibility is maintained for maps using 'chm.info.caption'.