### PR TITLE
Use Action to build NGCHMSupportFiles artifacts

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,0 +1,68 @@
+##
+##  GitHub Action to build artifacts for NGCHMSupportFiles,
+##  triggered by published release.
+##
+
+name: Build artifacts for NGCHMSupportFiles
+on:
+  release:
+    types: [published]
+jobs:
+  Build-ShaidyMapGen-and-ngchmWdiget-min:
+    runs-on: macOS-latest
+    env:
+      NGCHMSupportFiles_REPOSITORY: 'MD-Anderson-Bioinformatics/NGCHMSupportFiles'
+      NGCHMSupportFiles_BRANCH: 'main'
+    steps:
+      - name: Check out release tag
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.ref }}
+      - name: Get version number for use in NGCHMSupportFiles R package
+        ## This collects just the version number, e.g. '2.20.3', for use 
+        ## in DESCRIPTION file of NGCHMSupportFiles R package
+        id: get_version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/}
+      - name: Set up JDK for java 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Build ShaidyMapGen.jar
+        run: |
+          cd NGCHM
+          ant -f build_shaidyRmapgen.xml
+      - name: Build ngchmWidget-min.js
+        run: |
+          cd NGCHM
+          ant -f build_ngchmApp.xml
+      - name: Check out NGCHMSupportFiles
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ env.NGCHMSupportFiles_REPOSITORY }}
+          token: ${{ secrets.ACTIONS_TOKEN }}
+          ref: ${{ env.NGCHMSupportFiles_BRANCH }}
+          path: './NGCHMSupportFiles'
+      - name: Copy artifacts to NGCHMSupportFiles, and update version
+        run: |
+          cd NGCHMSupportFiles
+          cp ../NGCHM/ShaidyMapGen.jar inst/java
+          cp ../NGCHM/ngchmWidget-min.js inst/js
+          sed -i.bak '/Version:/d' DESCRIPTION
+          echo "Version: ${{ steps.get_version.outputs.version }}" >> DESCRIPTION
+          cat DESCRIPTION
+      - name: Verify NGCHMSupportFile R build
+        run: |
+          cd NGCHMSupportFiles
+          R CMD build .
+      - name: Commit and push update
+        run: |
+          cd NGCHMSupportFiles
+          git config --local user.email "actions@github.com"
+          git config --local user.name "GitHub Actions"
+          git add inst/java/ShaidyMapGen.jar
+          git add inst/js/ngchmWidget-min.js
+          git add DESCRIPTION
+          git commit -m "Update for NG-CHM Release ${{ steps.get_version.outputs.version }}"
+          git push origin ${{ env.NGCHMSupportFiles_BRANCH }}
+

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -36,14 +36,14 @@ jobs:
         run: |
           cd NGCHM
           ant -f build_ngchmApp.xml
-      - name: Check out NGCHMSupportFiles
+      - name: Check out NGCHMSupportFiles repo
         uses: actions/checkout@v2
         with:
           repository: ${{ env.NGCHMSupportFiles_REPOSITORY }}
           token: ${{ secrets.DQS_DEV_BCB_ACTIONS_TOKEN }}
           ref: ${{ env.NGCHMSupportFiles_BRANCH }}
           path: './NGCHMSupportFiles'
-      - name: Copy artifacts to NGCHMSupportFiles, and update version
+      - name: Copy artifacts to NGCHMSupportFiles and update NGCHMSupportFiles version
         run: |
           cd NGCHMSupportFiles
           cp ../NGCHM/ShaidyMapGen.jar inst/java
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd NGCHMSupportFiles
           R CMD build .
-      - name: Commit and push update
+      - name: Commit and push update to NGCHMSupportFiles repo
         run: |
           cd NGCHMSupportFiles
           git config --local user.email "actions@github.com"
@@ -65,7 +65,7 @@ jobs:
           git add DESCRIPTION
           git commit -m "Update for NG-CHM Release ${{ steps.get_version.outputs.version }}"
           git push origin ${{ env.NGCHMSupportFiles_BRANCH }}
-      - name: Create a release
+      - name: Create a release in NGCHMSupportFiles repo
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.DQS_DEV_BCB_ACTIONS_TOKEN }}

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,6 +1,6 @@
 ##
 ##  GitHub Action to build artifacts for NGCHMSupportFiles,
-##  triggered by published release.
+##  triggered by publishing a release
 ##
 
 name: Build artifacts for NGCHMSupportFiles
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ${{ env.NGCHMSupportFiles_REPOSITORY }}
-          token: ${{ secrets.ACTIONS_TOKEN }}
+          token: ${{ secrets.DQS_DEV_BCB_ACTIONS_TOKEN }}
           ref: ${{ env.NGCHMSupportFiles_BRANCH }}
           path: './NGCHMSupportFiles'
       - name: Copy artifacts to NGCHMSupportFiles, and update version
@@ -65,4 +65,11 @@ jobs:
           git add DESCRIPTION
           git commit -m "Update for NG-CHM Release ${{ steps.get_version.outputs.version }}"
           git push origin ${{ env.NGCHMSupportFiles_BRANCH }}
+      - name: Create a release
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.DQS_DEV_BCB_ACTIONS_TOKEN }}
+          body: "Version ${{ steps.get_version.outputs.version }}"
+          repository: ${{ env.NGCHMSupportFiles_REPOSITORY }}
+
 


### PR DESCRIPTION
This pull request adds a GitHub action to build and push artifacts to the [NGCHMSupportFiles](https://github.com/MD-Anderson-Bioinformatics/NGCHMSupportFiles) project.

The action is triggered by new releases, and with the following main steps:

- Checks out release tag
- Builds ShaidyMapGen.jar
- Builds ngchmWidget-min.js
- Checks out  the NGCHMSupportFiles project
- Adds ShaidyMapGen.jar and ngchmWidget-min.js to  the NGCHMSupportFiles project
- Updates version number of NGCHMSupportFiles project to match release tag
- Commits and pushes updates back to  the NGCHMSupportFiles project
- Makes release of NGCHMSupportFiles project for new version

The Action is configured to use the DQS-Dev-BCB service account.

