### PR TITLE
Handle WebGL context loss and restore events

### DIFF
--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -137,7 +137,6 @@ NgChm.DET.setDetailMapDisplay = function (mapItem) {
 	}
 	
 	setTimeout (function() {
-		NgChm.DET.detSetupGl(mapItem);
 		NgChm.DET.detInitGl(mapItem);
 		NgChm.SEL.updateSelection(mapItem);
 		if (NgChm.UTIL.getURLParameter("selected") !== ""){
@@ -280,22 +279,14 @@ NgChm.DET.drawDetailHeatMap = function (mapItem, drawWin) {
 
 	const renderBuffer = NgChm.DET.getDetailHeatMap (mapItem, drawWin, params);
 
-	//WebGL code to draw the summary heat map.
-	mapItem.gl.useProgram(mapItem.gl.program);
-	mapItem.gl.activeTexture(mapItem.gl.TEXTURE0);
-	mapItem.gl.texImage2D(
-			mapItem.gl.TEXTURE_2D,
-			0,
-			mapItem.gl.RGBA,
-			renderBuffer.width,
-			renderBuffer.height,
-			0,
-			mapItem.gl.RGBA,
-			mapItem.gl.UNSIGNED_BYTE,
-			renderBuffer.pixels);
-	mapItem.gl.uniform2fv(mapItem.uScale, mapItem.canvasScaleArray);
-	mapItem.gl.uniform2fv(mapItem.uTranslate, mapItem.canvasTranslateArray);
-	mapItem.gl.drawArrays(mapItem.gl.TRIANGLE_STRIP, 0, mapItem.gl.buffer.numItems);
+	//WebGL code to draw the renderBuffer.
+	if (NgChm.DET.detInitGl (mapItem)) {
+	    const ctx = mapItem.glManager.context;
+	    mapItem.glManager.setTextureFromRenderBuffer(renderBuffer);
+	    ctx.uniform2fv(mapItem.uScale, mapItem.canvasScaleArray);
+	    ctx.uniform2fv(mapItem.uTranslate, mapItem.canvasTranslateArray);
+	    mapItem.glManager.drawTexture();
+	}
 
 	// Draw the dendrograms
 	mapItem.colDendro.draw();
@@ -2268,7 +2259,7 @@ NgChm.DET.drawScatterBarPlotRowClassBar = function(mapItem, pixels, pos, start, 
 		}
 	}
 	return pos;
-}
+};
 
 //----------------------------------------------------------------------------------------------//
 //----------------------------------------------------------------------------------------------//
@@ -2276,128 +2267,88 @@ NgChm.DET.drawScatterBarPlotRowClassBar = function(mapItem, pixels, pos, start, 
 //----------------------------------------------------------------------------------------------//
 //----------------------------------------------------------------------------------------------//
 
-/*********************************************************************************************
- * FUNCTION:  detSetupGl - The purpose of this function is to set up the WebGl context for
- * a detail heat map canvas.
- *********************************************************************************************/
-NgChm.DET.detSetupGl = function (mapItem) {
-	mapItem.gl = NgChm.SUM.webGlGetContext(mapItem.canvas);
-	if (!mapItem.gl) { return; }
-	mapItem.gl.viewportWidth = mapItem.dataViewWidth+NgChm.DET.calculateTotalClassBarHeight("row");
-	mapItem.gl.viewportHeight = mapItem.dataViewHeight+NgChm.DET.calculateTotalClassBarHeight("column");
-	mapItem.gl.clearColor(1, 1, 1, 1);
+(function() {
 
-	const program = mapItem.gl.createProgram();
-	const vertexShader = NgChm.DET.getDetVertexShader(mapItem.gl);
-	const fragmentShader = NgChm.DET.getDetFragmentShader(mapItem.gl);
-	mapItem.gl.program = program;
-	mapItem.gl.attachShader(program, vertexShader);
-	mapItem.gl.attachShader(program, fragmentShader);
-	mapItem.gl.linkProgram(program);
-	mapItem.gl.useProgram(program);
-}
+    /*********************************************************************************************
+     * FUNCTION:  detInitGl - The purpose of this function is to initialize a WebGl canvas for
+     * the presentation of a detail heat map.
+     *
+     * This function *must* be called after any context switch and before any GL functions.
+     * The window may lose the GL context at any context switch (for details, see DRAW.GL.createGlManager).
+     * If we don't have the GL context (glManager.OK is false), do not execute any GL functions.
+     *
+     *********************************************************************************************/
+    NgChm.DET.detInitGl = function (mapItem) {
+	    if (!mapItem.glManager) {
+		mapItem.glManager = NgChm.DRAW.GL.createGlManager (mapItem.canvas, getDetVertexShader, getDetFragmentShader);
+	    }
+	    return mapItem.glManager.check(initDetailContext);
 
-/*********************************************************************************************
- * FUNCTION:  detInitGl - The purpose of this function is to initialize a WebGl canvas for 
- * the presentation of a detail heat map
- *********************************************************************************************/
-NgChm.DET.detInitGl = function (mapItem) {
-	if (!mapItem.gl) return;
+	    // (Re-)intialize a WebGl context for a detail map.
+	    // Each detail pane uses a different canvas and hence WebGl Context.
+	    // Each detail map uses a single context for the heat map and the covariate bars.
+	    function initDetailContext (manager, ctx, program) {
 
-	mapItem.gl.viewport(0, 0, mapItem.gl.viewportWidth, mapItem.gl.viewportHeight);
-	mapItem.gl.clear(mapItem.gl.COLOR_BUFFER_BIT);
+		ctx.viewportWidth = mapItem.dataViewWidth+NgChm.DET.calculateTotalClassBarHeight("row");
+		ctx.viewportHeight = mapItem.dataViewHeight+NgChm.DET.calculateTotalClassBarHeight("column");
+		ctx.viewport(0, 0, ctx.viewportWidth, ctx.viewportHeight);
 
-	// Vertices
-	const buffer = mapItem.gl.createBuffer();
-	mapItem.gl.buffer = buffer;
-	mapItem.gl.bindBuffer(mapItem.gl.ARRAY_BUFFER, buffer);
-	const vertices = [ -1, -1, 1, -1, 1, 1, -1, -1, -1, 1, 1, 1 ];
-	mapItem.gl.bufferData(mapItem.gl.ARRAY_BUFFER, new Float32Array(vertices), mapItem.gl.STATIC_DRAW);
-	const byte_per_vertex = Float32Array.BYTES_PER_ELEMENT;
-	const component_per_vertex = 2;
-	buffer.numItems = vertices.length / component_per_vertex;
-	const stride = component_per_vertex * byte_per_vertex;
-	const program = mapItem.gl.program;
-	const position = mapItem.gl.getAttribLocation(program, 'position');
- 	
-	
-	mapItem.uScale = mapItem.gl.getUniformLocation(program, 'u_scale');
-	mapItem.uTranslate = mapItem.gl.getUniformLocation(program, 'u_translate');
-	mapItem.gl.enableVertexAttribArray(position);
-	mapItem.gl.vertexAttribPointer(position, 2, mapItem.gl.FLOAT, false, stride, 0);
+		ctx.clear(ctx.COLOR_BUFFER_BIT);
 
-	// Texture coordinates for map.
-	const texcoord = mapItem.gl.getAttribLocation(program, "texCoord");
-	const texcoordBuffer = mapItem.gl.createBuffer();
-	mapItem.gl.bindBuffer(mapItem.gl.ARRAY_BUFFER, texcoordBuffer);
-	mapItem.gl.bufferData(mapItem.gl.ARRAY_BUFFER, new Float32Array([ 0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 1, 1 ]), mapItem.gl.STATIC_DRAW);
-	mapItem.gl.enableVertexAttribArray(texcoord);
-	mapItem.gl.vertexAttribPointer(texcoord, 2, mapItem.gl.FLOAT, false, 0, 0)
-	
-	// Texture
-	const texture = mapItem.gl.createTexture();
-	mapItem.gl.bindTexture(mapItem.gl.TEXTURE_2D, texture);
-	mapItem.gl.texParameteri(
-			mapItem.gl.TEXTURE_2D, 
-			mapItem.gl.TEXTURE_WRAP_S, 
-			mapItem.gl.CLAMP_TO_EDGE);
-	mapItem.gl.texParameteri(
-			mapItem.gl.TEXTURE_2D, 
-			mapItem.gl.TEXTURE_WRAP_T, 
-			mapItem.gl.CLAMP_TO_EDGE);
-	mapItem.gl.texParameteri(
-			mapItem.gl.TEXTURE_2D, 
-			mapItem.gl.TEXTURE_MIN_FILTER,
-			mapItem.gl.NEAREST);
-	mapItem.gl.texParameteri(
-			mapItem.gl.TEXTURE_2D, 
-			mapItem.gl.TEXTURE_MAG_FILTER, 
-			mapItem.gl.NEAREST);
-}
+		manager.setClipRegion (NgChm.DRAW.GL.fullClipSpace);
+		manager.setTextureRegion (NgChm.DRAW.GL.fullTextureSpace);
 
-NgChm.DET.getDetVertexShader = function (theGL) {
-	const source = 'attribute vec2 position;    ' +
-	             'attribute vec2 texCoord;    ' +
-		         'varying vec2 v_texPosition; ' +
-		         'uniform vec2 u_translate;   ' +
-		         'uniform vec2 u_scale;       ' +
-		         'void main () {              ' +
-		         '  vec2 scaledPosition = position * u_scale;               ' +
-		         '  vec2 translatedPosition = scaledPosition + u_translate; ' +
-		         '  gl_Position = vec4(translatedPosition, 0, 1);           ' +
-		         '  v_texPosition = texCoord;                               ' +
-		         '}';
-    //'  v_texPosition = position * 0.5 + 0.5;                   ' +
+		mapItem.uScale = ctx.getUniformLocation(program, 'u_scale');
+		mapItem.uTranslate = ctx.getUniformLocation(program, 'u_translate');
 
-	const shader = theGL.createShader(theGL.VERTEX_SHADER);
-	theGL.shaderSource(shader, source);
-	theGL.compileShader(shader);
-	if (!theGL.getShaderParameter(shader, theGL.COMPILE_STATUS)) {
-		console.log(theGL.getShaderInfoLog(shader)); //alert
+		return true;
+	    }
+    };
+
+    const vertexShaderSource = `
+	attribute vec2 position;
+	attribute vec2 texCoord;
+	varying vec2 v_texPosition;
+	uniform vec2 u_translate;
+	uniform vec2 u_scale;
+	void main () {
+	  vec2 scaledPosition = position * u_scale;
+	  vec2 translatedPosition = scaledPosition + u_translate;
+	  gl_Position = vec4(translatedPosition, 0, 1);
+	  v_texPosition = texCoord;
+	}
+    `;
+    //'   v_texPosition = position * 0.5 + 0.5;                   ' +
+    function getDetVertexShader (theGL) {
+	    const shader = theGL.createShader(theGL.VERTEX_SHADER);
+	    theGL.shaderSource(shader, vertexShaderSource);
+	    theGL.compileShader(shader);
+	    if (!theGL.getShaderParameter(shader, theGL.COMPILE_STATUS)) {
+		    console.error(theGL.getShaderInfoLog(shader)); //alert
+	    }
+	    return shader;
     }
 
-	return shader;
-}
-
-NgChm.DET.getDetFragmentShader = function (theGL) {
-	const source = 'precision mediump float;        ' +
-		  		 'varying vec2 v_texPosition;     ' +
- 		 		 'varying float v_boxFlag;        ' +
- 		 		 'uniform sampler2D u_texture;    ' +
- 		 		 'void main () {                  ' +
- 		 		 '	  gl_FragColor = texture2D(u_texture, v_texPosition); ' +
- 		 		 '}'; 
-
-
-	const shader = theGL.createShader(theGL.FRAGMENT_SHADER);
-	theGL.shaderSource(shader, source);
-	theGL.compileShader(shader);
-	if (!theGL.getShaderParameter(shader, theGL.COMPILE_STATUS)) {
-		console.log(theGL.getShaderInfoLog(shader)); //alert
+    const fragmentShaderSource = `
+	precision mediump float;
+	varying vec2 v_texPosition;
+	varying float v_boxFlag;
+	uniform sampler2D u_texture;
+	void main () {
+		  gl_FragColor = texture2D(u_texture, v_texPosition);
+	}
+    `;
+    function getDetFragmentShader (theGL) {
+	    const shader = theGL.createShader(theGL.FRAGMENT_SHADER);
+	    theGL.shaderSource(shader, fragmentShaderSource);
+	    theGL.compileShader(shader);
+	    if (!theGL.getShaderParameter(shader, theGL.COMPILE_STATUS)) {
+		    console.error(theGL.getShaderInfoLog(shader)); //alert
+	    }
+	    return shader;
     }
 
-	return shader;
-};
+})();
 
 (function() {
 	// Define a function to switch a panel to the detail view.

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -2280,7 +2280,10 @@ NgChm.DET.drawScatterBarPlotRowClassBar = function(mapItem, pixels, pos, start, 
      *********************************************************************************************/
     NgChm.DET.detInitGl = function (mapItem) {
 	    if (!mapItem.glManager) {
-		mapItem.glManager = NgChm.DRAW.GL.createGlManager (mapItem.canvas, getDetVertexShader, getDetFragmentShader);
+		mapItem.glManager = NgChm.DRAW.GL.createGlManager (mapItem.canvas, getDetVertexShader, getDetFragmentShader, () => {
+		    const drawWin = NgChm.SEL.getDetailWindow(mapItem);
+		    NgChm.DET.drawDetailHeatMap(mapItem, drawWin);
+		});
 	    }
 	    return mapItem.glManager.check(initDetailContext);
 

--- a/NGCHM/WebContent/javascript/DetailHeatMapManager.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapManager.js
@@ -54,7 +54,7 @@ NgChm.DMM.InitDetailMap = function (chm){
  * Primary heat map object and will be marked as a 'Secondary' heat map object.
  *********************************************************************************************/
 NgChm.DMM.AddDetailMap = function (chm,pane){
-	let newMapObj = Object.assign({}, NgChm.DMM.primaryMap);
+	let newMapObj = Object.assign({}, NgChm.DMM.primaryMap, { glManager: null });
 	newMapObj.pane = pane;
 	newMapObj.version = 'S';
 	NgChm.DMM.completeMapItemConfig(chm,newMapObj);

--- a/NGCHM/WebContent/javascript/Drawing.js
+++ b/NGCHM/WebContent/javascript/Drawing.js
@@ -75,8 +75,8 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
 	// fragment shaders for the GL context given as the only parameter.  They are called by
 	// GlManager when initializing or re-initializing a context.
 	//
-	constructor (canvas, getVertexShader, getFragmentShader) {
-	    this._state = getTrackedGlContext (canvas);
+	constructor (canvas, getVertexShader, getFragmentShader, onRestore) {
+	    this._state = getTrackedGlContext (canvas, onRestore);
 	    this._OK = false;
 	    this._getVertexShader = getVertexShader;
 	    this._getFragmentShader = getFragmentShader;
@@ -247,8 +247,8 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
 
     }
 
-    NgChm.DRAW.GL.createGlManager = function (canvas, getVertexShader, getFragmentShader) {
-	    return new GlManager (canvas, getVertexShader, getFragmentShader);
+    NgChm.DRAW.GL.createGlManager = function (canvas, getVertexShader, getFragmentShader, onRestore) {
+	    return new GlManager (canvas, getVertexShader, getFragmentShader, onRestore);
     };
 
     // Returns a tracked GL context for the specified canvas.
@@ -256,7 +256,7 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
     // - context The WebGL context for the canvas.
     // - lost Boolean, true on initialization or if the context was *ever* lost since the last check
     // - restored Boolean, true if the context has been restored after the most recent loss.
-    function getTrackedGlContext (canvas) {
+    function getTrackedGlContext (canvas, onRestore) {
 	const debug = true;
 	if (!!window.WebGLRenderingContext) {
 	    const names = ["webgl", "experimental-webgl", "moz-webgl", "webkit-3d"];
@@ -266,7 +266,7 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
 		    if (context && typeof context.getParameter == "function") {
 			// WebGL is enabled
 			const obj = { lost: true, restored: true, context };
-			(function(obj) {
+			(function(obj, onRestore) {
 			    canvas.addEventListener('webglcontextlost', ev => {
 				ev.preventDefault();
 				if (debug) console.debug ('WebGL context lost at ' + Date());
@@ -277,8 +277,9 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
 				ev.preventDefault();
 				if (debug) console.debug ('WebGL context restored at ' + Date());
 				obj.restored = true;
+				if (onRestore) setTimeout(onRestore);
 			    }, false);
-			})(obj);
+			})(obj, onRestore);
 			return obj;
 		    }
 		} catch(e) {}

--- a/NGCHM/WebContent/javascript/Drawing.js
+++ b/NGCHM/WebContent/javascript/Drawing.js
@@ -277,6 +277,19 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
 				ev.preventDefault();
 				if (debug) console.debug ('WebGL context restored at ' + Date());
 				obj.restored = true;
+				// Workaround for bug(s) in Chrome/Safari on Macs.
+				// The canvas 'hibernates' after the context restore.
+				// WebGL operations on the canvas aren't redrawn until
+				// there is an additional trigger to force the redraw.
+				// The commented section below works for Mac Chrome 96.0.4664.110.
+				// The uncommented code below works for both Mac Chrome & Mac Safari (14.1.2).
+				// Chrome on Linux, Firefox on Mac are not affected by the issue.
+				{ //let handler = (e) => console.log(e);
+				  //document.addEventListener('touchmove', handler, {passive: false});
+				  //document.removeEventListener('touchmove', handler);
+				  canvas.classList.add('hide');
+				  requestAnimationFrame (() => canvas.classList.remove('hide'));
+				}
 				if (onRestore) setTimeout(onRestore);
 			    }, false);
 			})(obj, onRestore);

--- a/NGCHM/WebContent/javascript/Drawing.js
+++ b/NGCHM/WebContent/javascript/Drawing.js
@@ -299,4 +299,17 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
 	return [ left, bottom, right, bottom, right, top,
 		 left, bottom, left, top, right, top ];
     }
+
+    // Helper function for debugging WebGL context issues.
+    // Intended for use by developers.
+    NgChm.DRAW.GL.getContextSimulator = function (id) {
+	if (!id) {
+	    console.log ("Usage: var ext = NgChm.DRAW.GL.getContextSimulator(id);");
+	    console.log ("       ext.loseContext();");
+	    console.log ("       ext.restoreContext();");
+	    console.log ("Valid ids are like summary_canvas, row_class_canvas, col_class_canvas, detail_canvas, detail_canvas2, etc.");
+	    return;
+	}
+	return document.getElementById(id).getContext("webgl").getExtension("WEBGL_lose_context");
+    }
 })();

--- a/NGCHM/WebContent/javascript/Drawing.js
+++ b/NGCHM/WebContent/javascript/Drawing.js
@@ -281,12 +281,21 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
 				// The canvas 'hibernates' after the context restore.
 				// WebGL operations on the canvas aren't redrawn until
 				// there is an additional trigger to force the redraw.
-				// The commented section below works for Mac Chrome 96.0.4664.110.
-				// The uncommented code below works for both Mac Chrome & Mac Safari (14.1.2).
+				//
+				// The 'Chrome on Mac fix' section below works for Mac Chrome 96.0.4664.110.
+				//
+				// The 'Safari fix' code below works for Mac Safari (14.1.2) and some, but not
+				// all, Mac Chrome installs.  Tested with Chrome 96.0.4664.110: some systems
+				// work with just this fix, some don't.
+				//
 				// Chrome on Linux, Firefox on Mac are not affected by the issue.
-				{ //let handler = (e) => console.log(e);
-				  //document.addEventListener('touchmove', handler, {passive: false});
-				  //document.removeEventListener('touchmove', handler);
+				{ // Chrome on Mac fix:
+				  // It is adding the handler for this specific event that revives the canvas.
+				  // No idea why.
+				  let handler = (e) => console.log(e);
+				  document.addEventListener('touchmove', handler, {passive: false});
+				  document.removeEventListener('touchmove', handler);
+				  // Safari fix:
 				  canvas.classList.add('hide');
 				  requestAnimationFrame (() => canvas.classList.remove('hide'));
 				}

--- a/NGCHM/WebContent/javascript/Drawing.js
+++ b/NGCHM/WebContent/javascript/Drawing.js
@@ -25,3 +25,278 @@ NgChm.DRAW.createRenderBuffer = function (width, height, pixelScaleFactor) {
 	renderBuffer.resize = resize.bind(renderBuffer);
 	return renderBuffer;
 };
+
+/***************************
+ * WebGL stuff
+ **************************/
+(function() {
+
+    NgChm.DRAW.GL = {};
+
+    // We use WebGL to display heat map and covariate bar contents.  The
+    // overall process is:
+    // 1. Prepare the content to display in a renderBuffer
+    // 2. Copy the renderBuffer to a WebGL texture
+    // 3. Render the WebGL texture to the canvas.
+
+    // ClipSpace specifies the region of the canvas in which the texture will be drawn.
+    // ClipSpace coordinates range from -1,-1 at the left bottom to 1,1 at the right top.
+    // The ClipSpace to use is specified by an array of triangles.
+    //
+    // fullClipSpace is two triangles that cover the entire canvas:
+    // #1. bottom left, bottom right, top right.
+    // #2. bottom left, top left, top right.
+    NgChm.DRAW.GL.fullClipSpace = rectToTriangles (-1, -1, 1, 1);
+
+    // TextureSpace specifies the region of the texture from which the texture will be drawn.
+    // TextureSpace coordinates range from 0,0 at the left bottom to 1,1 at the right top.
+    // The TextureSpace to use is specified by an array of triangles.
+    //
+    // fullTextureSpace is two triangles that cover the entire texture:
+    // #1. bottom left, bottom right, top right.
+    // #2. bottom left, top left, top right.
+    NgChm.DRAW.GL.fullTextureSpace = rectToTriangles (0, 0, 1, 1);
+
+    // To use WebGL for rendering, we need a WebGL context. But, the browser can remove
+    // the current window's access to a context between *any* two event callbacks.
+    // NO WebGL related functions can be used with a context when it has been lost.
+    //
+    // When the browser restores access to the context, any previous state associated
+    // with the context has been destroyed and must be recreated.
+    //
+    // We manage this via a GlManager object that:
+    // - tracks GL context loss and restore events,
+    // - initializes the GL context when it is restored, and
+    // - provides a simple interface for determining if we currently have a valid context.
+
+    class GlManager {
+	// The GlManager constructor should be called at most once for a canvas.
+	// getVertexShader and getFragmentShader are functions that create the vertex and
+	// fragment shaders for the GL context given as the only parameter.  They are called by
+	// GlManager when initializing or re-initializing a context.
+	//
+	constructor (canvas, getVertexShader, getFragmentShader) {
+	    this._state = getTrackedGlContext (canvas);
+	    this._OK = false;
+	    this._getVertexShader = getVertexShader;
+	    this._getFragmentShader = getFragmentShader;
+	    this._program = null;
+	    this._itemsToDraw = 0;
+	}
+
+	// Determine if the manager's GL context can be used.
+	//
+	// If necessary, the GL context is (re-)initialized using the
+	// getVertexShader and getFragmentShader functions.
+	//
+	// If supplied, userinit is a function to perform user initialization
+	// of the context.  It is passed the context and program and should
+	// return truthy on success, falsey on error.
+	check (userinit) {
+		let initialized;
+
+		if (this._state.lost) {
+		    // Either a new context, or the context was lost.
+		    if (this._state.restored) {
+			// Either a new context or the context has been restored: reinitialize.
+			this._state.lost = false;
+			this._state.restored = false;
+			this._OK = true;
+			initialized = false;
+		    } else {
+			// Lost but not restored - cannot use.
+			this._OK = false;
+		    }
+		} else {
+		    // Not lost since last use.
+		    this._OK = true;
+		    initialized = true;
+		}
+
+		// Initialize the GL program and shaders if needed.
+		if (this._OK && !initialized) {
+		    const ctx = this._state.context;
+		    if (ctx) {
+			ctx.clearColor(1, 1, 1, 1);
+			// Texture shaders
+			this._program = ctx.createProgram();
+			if (this._program) {
+			    const vertexShader = this._getVertexShader(ctx);
+			    const fragmentShader = this._getFragmentShader(ctx);
+			    ctx.attachShader(this._program, vertexShader);
+			    ctx.attachShader(this._program, fragmentShader);
+			    ctx.linkProgram(this._program);
+			    ctx.useProgram(this._program);
+			    this.setTextureProps();
+			    if (userinit && !userinit (this, this._state.context, this._program)) {
+				console.error ("User initialization failed for ", ctx);
+				this._OK = false;
+			    }
+			} else {
+			    console.error ("Unable to create program for ", ctx);
+			    this._OK = false;
+			}
+		    } else {
+			console.error ("No context");
+			this._OK = false;
+		    }
+		}
+
+		return this._OK;
+	}
+
+	setTextureProps () {
+		// Texture
+		const ctx = this._state.context;
+		const texture = ctx.createTexture();
+		if (texture) {
+		    ctx.bindTexture(ctx.TEXTURE_2D, texture);
+		    ctx.texParameteri(
+				    ctx.TEXTURE_2D,
+				    ctx.TEXTURE_WRAP_S,
+				    ctx.CLAMP_TO_EDGE);
+		    ctx.texParameteri(
+				    ctx.TEXTURE_2D,
+				    ctx.TEXTURE_WRAP_T,
+				    ctx.CLAMP_TO_EDGE);
+		    ctx.texParameteri(
+				    ctx.TEXTURE_2D,
+				    ctx.TEXTURE_MIN_FILTER,
+				    ctx.NEAREST);
+		    ctx.texParameteri(
+				    ctx.TEXTURE_2D,
+				    ctx.TEXTURE_MAG_FILTER,
+				    ctx.NEAREST);
+		} else {
+		    console.error ("Unable to create texture for ", ctx);
+		    this._OK = false;
+		}
+	}
+
+	// Determine if the manager's GL context can be used.
+	// This is only valid if accessed during the same top-level
+	// event handler as the last call to the check method.
+	get OK () {
+		return this._OK;
+	}
+
+	// Get the manager's GL context.
+	get context () {
+		return this._state.context;
+	}
+
+	// Get the program attached to the manager's GL context.
+	get program () {
+		return this._program;
+	}
+
+	// Indicate that the manager's GL context is unusable.
+	// Call if an error is detected using a GL function.
+	dontUse () {
+		this._OK = false;
+	}
+
+	// Set the clip region.
+	setClipRegion (vertices) {
+		const ctx = this._state.context;
+		const buffer = ctx.createBuffer();
+		ctx.bindBuffer(ctx.ARRAY_BUFFER, buffer);
+		ctx.bufferData(ctx.ARRAY_BUFFER, new Float32Array(vertices), ctx.STATIC_DRAW);
+		const byte_per_vertex = Float32Array.BYTES_PER_ELEMENT;
+		const component_per_vertex = 2;
+		const stride = component_per_vertex * byte_per_vertex;
+		const locn = ctx.getAttribLocation(this._program, 'position');	 	
+		ctx.enableVertexAttribArray(locn);
+		ctx.vertexAttribPointer(locn, 2, ctx.FLOAT, false, stride, 0);
+		this._itemsToDraw = vertices.length / component_per_vertex;
+	}
+
+	// Set the texture region to use.
+	// Only valid if the vertexShader has a "texCoord" attribute (i.e. it is for a detail map).
+	setTextureRegion (vertices) {
+		const ctx = this._state.context;
+		const buffer = ctx.createBuffer();
+		ctx.bindBuffer(ctx.ARRAY_BUFFER, buffer);
+		ctx.bufferData(ctx.ARRAY_BUFFER, new Float32Array(vertices), ctx.STATIC_DRAW);
+		const locn = ctx.getAttribLocation(this._program, "texCoord");
+		ctx.enableVertexAttribArray(locn);
+		ctx.vertexAttribPointer(locn, 2, ctx.FLOAT, false, 0, 0);
+	}
+
+	// Set the context's texture from the renderBuffer.
+	setTextureFromRenderBuffer (renderBuffer) {
+		const ctx = this._state.context;
+		ctx.activeTexture(ctx.TEXTURE0);
+		ctx.texImage2D(
+			    ctx.TEXTURE_2D,
+			    0,
+			    ctx.RGBA,
+			    renderBuffer.width,
+			    renderBuffer.height,
+			    0,
+			    ctx.RGBA,
+			    ctx.UNSIGNED_BYTE,
+			    renderBuffer.pixels);
+	}
+
+	// Draw the texture.
+	drawTexture () {
+	    const ctx = this._state.context;
+	    ctx.drawArrays(ctx.TRIANGLE_STRIP, 0, this._itemsToDraw);
+	}
+
+    }
+
+    NgChm.DRAW.GL.createGlManager = function (canvas, getVertexShader, getFragmentShader) {
+	    return new GlManager (canvas, getVertexShader, getFragmentShader);
+    };
+
+    // Returns a tracked GL context for the specified canvas.
+    // The return value is an object with three fields:
+    // - context The WebGL context for the canvas.
+    // - lost Boolean, true on initialization or if the context was *ever* lost since the last check
+    // - restored Boolean, true if the context has been restored after the most recent loss.
+    function getTrackedGlContext (canvas) {
+	const debug = true;
+	if (!!window.WebGLRenderingContext) {
+	    const names = ["webgl", "experimental-webgl", "moz-webgl", "webkit-3d"];
+	    for(let i=0;i<names.length;i++) {
+		try {
+		    const context = canvas.getContext(names[i], {preserveDrawingBuffer: true});
+		    if (context && typeof context.getParameter == "function") {
+			// WebGL is enabled
+			const obj = { lost: true, restored: true, context };
+			(function(obj) {
+			    canvas.addEventListener('webglcontextlost', ev => {
+				ev.preventDefault();
+				if (debug) console.debug ('WebGL context lost at ' + Date());
+				obj.lost = true;
+				obj.restored = false;
+			    }, false);
+			    canvas.addEventListener('webglcontextrestored', ev => {
+				ev.preventDefault();
+				if (debug) console.debug ('WebGL context restored at ' + Date());
+				obj.restored = true;
+			    }, false);
+			})(obj);
+			return obj;
+		    }
+		} catch(e) {}
+	    }
+	    // WebGL is supported, but disabled
+	    NgChm.UHM.noWebGlContext(true);
+	    return null;
+	}
+	// WebGL not supported
+	NgChm.UHM.noWebGlContext(false);
+	return null;
+    }
+
+    // Convert the sides of rectangle into an array of
+    // triangle vertices.
+    NgChm.DRAW.GL.rectToTriangles = rectToTriangles;
+    function rectToTriangles (bottom, left, top, right) {
+	return [ left, bottom, right, bottom, right, top,
+		 left, bottom, left, top, right, top ];
+    }
+})();

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -1339,7 +1339,6 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 		}
 	        NgChm.SEL.setSelectionColors();
 		NgChm.UTIL.configurePanelInterface();
-		NgChm.SUM.initSummaryDisplay();
 		document.addEventListener("keydown", NgChm.DEV.keyNavigate);
 
 		addDataLayers(mc);

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -326,7 +326,7 @@ NgChm.SUM.setSelectionDivSize = function(width, height){ // input params used fo
     //Initialize webGl for the Heat Map Canvas
     NgChm.SUM.initHeatMapGl = function() {
 	// First time: create the context manager.
-	if (!NgChm.SUM.mapGlManager) NgChm.SUM.mapGlManager = createSummaryGlManager ( NgChm.SUM.canvas );
+	if (!NgChm.SUM.mapGlManager) NgChm.SUM.mapGlManager = createSummaryGlManager ( NgChm.SUM.canvas, NgChm.SUM.drawHeatMap );
 	// Every time: check if (re-)initialization required and do so if needed.
 	return NgChm.SUM.mapGlManager.check(initSummaryGlContext);
 
@@ -334,19 +334,19 @@ NgChm.SUM.setSelectionDivSize = function(width, height){ // input params used fo
 
     //Initialize webGl for the Row Class Bar Canvas
     NgChm.SUM.initRowClassGl = function() {
-	if (!NgChm.SUM.rcGlManager) NgChm.SUM.rcGlManager = createSummaryGlManager ( NgChm.SUM.rCCanvas );
+	if (!NgChm.SUM.rcGlManager) NgChm.SUM.rcGlManager = createSummaryGlManager ( NgChm.SUM.rCCanvas, NgChm.SUM.drawRowClassBars );
 	return NgChm.SUM.rcGlManager.check(initSummaryGlContext);
     };
 
     //Initialize webGl for the Column Class Bar Canvas
     NgChm.SUM.initColClassGl = function() {
-	if (!NgChm.SUM.ccGlManager) NgChm.SUM.ccGlManager = createSummaryGlManager ( NgChm.SUM.cCCanvas );
+	if (!NgChm.SUM.ccGlManager) NgChm.SUM.ccGlManager = createSummaryGlManager ( NgChm.SUM.cCCanvas, NgChm.SUM.drawColClassBars );
 	return NgChm.SUM.ccGlManager.check(initSummaryGlContext);
     };
 
     // Create a GL manager that uses the summary map vertex and fragment shaders.
-    function createSummaryGlManager (canvas) {
-	    return NgChm.DRAW.GL.createGlManager (canvas, getVertexShader, getFragmentShader);
+    function createSummaryGlManager (canvas, onRestore) {
+	    return NgChm.DRAW.GL.createGlManager (canvas, getVertexShader, getFragmentShader, onRestore);
     }
 
     // Vertex shader for summary heat maps.
@@ -551,7 +551,7 @@ NgChm.SUM.buildRowClassTexture = function() {
 };
 
 NgChm.SUM.drawRowClassBars = function() {
-	if (NgChm.SUM.initRowClassGl()) {
+	if (NgChm.SUM.texRc && NgChm.SUM.initRowClassGl()) {
 		NgChm.SUM.rcGlManager.setTextureFromRenderBuffer (NgChm.SUM.texRc);
 		NgChm.SUM.rcGlManager.drawTexture();
 	}
@@ -601,7 +601,7 @@ NgChm.SUM.buildColClassTexture = function() {
 
 //WebGL code to draw the Column Class Bars.
 NgChm.SUM.drawColClassBars = function() {
-	if (NgChm.SUM.initColClassGl()) {
+	if (NgChm.SUM.texCc && NgChm.SUM.initColClassGl()) {
 		NgChm.SUM.ccGlManager.setTextureFromRenderBuffer (NgChm.SUM.texCc);
 		NgChm.SUM.ccGlManager.drawTexture ();
 	}


### PR DESCRIPTION
The browser can remove access to a WebGL context at basically any time.
When the context is removed, any WebGL objects for that context are
destroyed.

Until the context is restored, no WebGL functions for that context can be
used.
After the context is restored, no previous WebGL objects can be used.

To facilitate handling of the context loss and restore events and simplify
our use of WebGL, this patch creates and uses a common GLManager object
for each canvas.  GLManager is implemented in Drawing.js.