### PR TITLE
Replace only the children of NgChm.UTIL.containerElement

### DIFF
--- a/NGCHM/WebContent/javascript/RecreatePanes.js
+++ b/NGCHM/WebContent/javascript/RecreatePanes.js
@@ -31,7 +31,6 @@ NgChm.createNS('NgChm.RecPanes');
 			window.dispatchEvent(new Event('resize'));
 			NgChm.SUM.summaryPaneResizeHandler();
 			NgChm.heatMap.setUnAppliedChanges(false);
-			NgChm.UTIL.containerElement = document.getElementById('ngChmContainer');
 			setFlickState();
 			setNextMapNumber();
 			setTimeout(() => {
@@ -47,10 +46,9 @@ NgChm.createNS('NgChm.RecPanes');
 	 */ 
 	function reconstructPanelLayoutFromMapConfig() {
 		try {
-			let baseNgChmContainer = document.getElementById('ngChmContainer');
 			let panel_layoutJSON = NgChm.RecPanes.mapConfigPanelConfiguration.panel_layout;
 			let reconstructedPanelLayout = domJSON.toDOM(panel_layoutJSON);
-			baseNgChmContainer.parentNode.replaceChild(reconstructedPanelLayout, baseNgChmContainer);
+			NgChm.UTIL.containerElement.replaceChildren(...reconstructedPanelLayout.firstChild.children);
 		} catch(err) {
 			console.error("Cannot reconstruct panel layout: "+err);
 			throw "Error reconstructing panel layout from mapConfig.";


### PR DESCRIPTION
This is really a question for Mary.

Was there a specific reason for replacing the ngChmContainer element in RecreatePanes?

My initial thoughts are that we want to keep the current ngChmContainer element in case there have been any changes to its properties etc. since the map being loaded was saved.

I tried this patch with save files containing a single panel as well as save files containing multiple panels. All appears fine.