### PR TITLE
Fix widgetized image issues

### DIFF
--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -2405,6 +2405,7 @@ NgChm.DET.getDetFragmentShader = function (theGL) {
 	// See additional comments in that function.
 	NgChm.DET.switchPaneToDetail = switchPaneToDetail;
 	NgChm.Pane.registerPaneContentOption ('Detail heatmap', switchPaneToDetail);
+	NgChm.DET.setButtons = setButtons;
 
 	let savedChmElements = [];
 	NgChm.DET.initialSwitchPaneToDetail = true
@@ -2499,6 +2500,29 @@ NgChm.DET.getDetFragmentShader = function (theGL) {
 		if (buttonMode == 'RIBBONV') return 'ribbonV';
 		return 'full';
 	}
+
+	/**********************************************************************************
+	 * FUNCTION - setButtons: The purpose of this function is to set the state of
+	 * buttons on the detail pane header bar when the user selects a button.
+	 **********************************************************************************/
+	function setButtons (mapItem) {
+		const full_btn = document.getElementById('full_btn'+mapItem.panelNbr);
+		const ribbonH_btn = document.getElementById('ribbonH_btn'+mapItem.panelNbr);
+		const ribbonV_btn = document.getElementById('ribbonV_btn'+mapItem.panelNbr);
+		let full_src= "full";
+		let ribbonH_src= "ribbonH";
+		let ribbonV_src= "ribbonV";
+		if (mapItem.mode=='RIBBONV')
+			ribbonV_src += "_selected";
+		else if (mapItem.mode == "RIBBONH")
+			ribbonH_src += "_selected";
+		else
+			full_src += "_selected";
+		full_btn.src = imageTable[full_src];
+		ribbonH_btn.src = imageTable[ribbonH_src];
+		ribbonV_btn.src = imageTable[ribbonV_src];
+	}
+
 
 	// Update a mode button image when the mouse enters/leaves the button.
 	// btn is the IMG element for the button.

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -2477,6 +2477,22 @@ NgChm.DET.getDetFragmentShader = function (theGL) {
 		NgChm.Pane.registerPaneEventHandler (loc.pane, 'resize', resizeDetailPane);
 	}
 
+	// Table to convert image names to image source names.
+	// A table is required for this otherwise trivial conversion
+	// because the minimizer will convert all the filenames in the
+	// table to inline data sources.
+	const imageTable = {
+	    full: 'images/full.png',
+	    fullHover: 'images/fullHover.png',
+	    full_selected: 'images/full_selected.png',
+	    ribbonH: 'images/ribbonH.png',
+	    ribbonHHover: 'images/ribbonHHover.png',
+	    ribbonH_selected: 'images/ribbonH_selected.png',
+	    ribbonV: 'images/ribbonV.png',
+	    ribbonVHover: 'images/ribbonVHover.png',
+	    ribbonV_selected: 'images/ribbonV_selected.png',
+	};
+
 	// Return the baseName of the zoom mode buttons.
 	function buttonBaseName (buttonMode) {
 		if (buttonMode == 'RIBBONH') return 'ribbonH';
@@ -2507,7 +2523,7 @@ NgChm.DET.getDetFragmentShader = function (theGL) {
 			if (hovering) {
 			        buttonSrc += 'Hover';
 			}
-			btn.setAttribute('src', 'images/' + buttonSrc + '.png');
+			btn.setAttribute('src', imageTable[buttonSrc]);
 		}
 	}
 
@@ -2552,8 +2568,7 @@ NgChm.DET.getDetFragmentShader = function (theGL) {
 	function modeButton (mapNumber, paneId, selected, mode, btnHelp, btnSize, clickFn) {
 		const baseName = buttonBaseName (mode);
 		const selStr = selected ? '_selected' : '';
-		const btnIcon = 'images/' + baseName + selStr + '.png';
-		const img = NgChm.UTIL.newElement ('IMG', { src: btnIcon, alt: btnHelp });
+		const img = NgChm.UTIL.newElement ('IMG', { src: imageTable[baseName+selStr], alt: btnHelp });
 		img.id = baseName + '_btn' + mapNumber;
 		img.dataset.mode = mode;
 		img.onmouseout = function (e) {

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -490,7 +490,7 @@ NgChm.DEV.matrixRightClick = function (e) {
     let selection = window.getSelection();
     selection.removeAllRanges();
     return false;
-}
+};
 
 /************************************************************************************************
  * FUNCTION: flickChange - Responds to a change in the flick view control.  All of these actions 
@@ -500,43 +500,48 @@ NgChm.DEV.matrixRightClick = function (e) {
  * to the 2 dropdowns, AND the current visible data layer is for the opposite dropdown. 
  * If any of the above cases are met, the currentDl is changed and the screen is redrawn.
  ***********************************************************************************************/ 
-NgChm.DEV.flickChange = function(fromList) {
+(function() {
+    // Table of flick button images so that Widgetizer only adds one
+    // data: URL for each to the widget.
+    const toggleButtons = {
+	flickUp: 'images/toggleUp.png',
+	flickDown: 'images/toggleDown.png'
+    };
+    NgChm.DEV.flickChange = function(fromList) {
 	const mapItem = NgChm.DMM.primaryMap;
 	const flickBtn = document.getElementById("flick_btn");
 	const flickDrop1 = document.getElementById("flick1");
 	const flickDrop2 = document.getElementById("flick2");
 	if (typeof fromList === 'undefined') {
 		if (flickBtn.dataset.state === 'flickUp') {
-			flickBtn.setAttribute('src', 'images/toggleDown.png');
 			flickBtn.dataset.state = 'flickDown';
 			mapItem.currentDl = flickDrop2.value;
 		} else {
-			flickBtn.setAttribute('src', 'images/toggleUp.png');
 			flickBtn.dataset.state = 'flickUp';
 			mapItem.currentDl = flickDrop1.value;
 		}
+		flickBtn.setAttribute('src', toggleButtons[flickBtn.dataset.state]);
 	} else if (fromList === null) {
 		if (flickBtn.dataset.state === 'flickUp') {
-			flickBtn.setAttribute('src', 'images/toggleUp.png');
 			flickBtn.dataset.state = 'flickUp';
 			mapItem.currentDl = flickDrop1.value === "" ? 'dl1' : flickDrop1.value;
 		} else {
-			flickBtn.setAttribute('src', 'images/toggleDown.png');
 			flickBtn.dataset.state = 'flickDown';
 			mapItem.currentDl = flickDrop2.value === "" ? 'dl1' : flickDrop2.value;
 		}
+		flickBtn.setAttribute('src', toggleButtons[flickBtn.dataset.state]);
 	} else {
 		if ((fromList === "flick1") && (flickBtn.dataset.state === 'flickUp')) {
 			mapItem.currentDl = document.getElementById(fromList).value;
 		} else if ((fromList === "flick2") && (flickBtn.dataset.state === 'flickDown')) {
 			mapItem.currentDl = document.getElementById(fromList).value;
 		} else if ((fromList === "toggle1") && (flickBtn.dataset.state === 'flickDown')) {
-			flickBtn.setAttribute('src', 'images/toggleUp.png');
 			flickBtn.dataset.state = 'flickUp';
+			flickBtn.setAttribute('src', toggleButtons[flickBtn.dataset.state]);
 			mapItem.currentDl = flickDrop1.value;
 		} else if ((fromList === "toggle2") && (flickBtn.dataset.state === 'flickUp')) {
-			flickBtn.setAttribute('src', 'images/toggleDown.png');
 			flickBtn.dataset.state = 'flickDown';
+			flickBtn.setAttribute('src', toggleButtons[flickBtn.dataset.state]);
 			mapItem.currentDl = flickDrop2.value;
 		} else {
 			return;
@@ -550,7 +555,8 @@ NgChm.DEV.flickChange = function(fromList) {
 	})
 	NgChm.DET.setDrawDetailsTimeout(NgChm.DET.redrawSelectionTimeout,true);
 	NgChm.SEL.updateSelections(true);
-}
+    };
+})();
 
 /*********************************************************************************************
  * FUNCTION:  handleMouseOut - The purpose of this function is to handle the situation where 

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -867,7 +867,7 @@ NgChm.DEV.detailNormal = function (mapItem) {
 	NgChm.UHM.hlpC();	
 	const previousMode = mapItem.mode;
 	NgChm.SEL.setMode(mapItem,'NORMAL');
-	NgChm.DEV.setButtons(mapItem);
+	NgChm.DET.setButtons(mapItem);
 	mapItem.dataViewHeight = NgChm.DET.SIZE_NORMAL_MODE;
 	mapItem.dataViewWidth = NgChm.DET.SIZE_NORMAL_MODE;
 	if ((previousMode=='RIBBONV') || (previousMode=='RIBBONV_DETAIL')) {
@@ -937,26 +937,6 @@ NgChm.DEV.detailFullMap = function (mapItem) {
 }
 
 /**********************************************************************************
- * FUNCTION - setButtons: The purpose of this function is to set the state of 
- * buttons on the detail pane header bar when the user selects a button.
- **********************************************************************************/
-NgChm.DEV.setButtons = function (mapItem) {
-	const full = document.getElementById('full_btn'+mapItem.panelNbr);
-	const ribbonH = document.getElementById('ribbonH_btn'+mapItem.panelNbr);
-	const ribbonV = document.getElementById('ribbonV_btn'+mapItem.panelNbr);
-	full.src= "images/full.png";
-	ribbonH.src= "images/ribbonH.png";
-	ribbonV.src= "images/ribbonV.png";
-	if (mapItem.mode=='RIBBONV')
-		ribbonV.src= "images/ribbonV_selected.png";
-	else if (mapItem.mode == "RIBBONH")
-		ribbonH.src= "images/ribbonH_selected.png";
-	else
-		full.src= "images/full_selected.png";	
-}
-
-
-/**********************************************************************************
  * FUNCTION - detailHRibbonButton: The purpose of this function is to clear dendro
  * selections and call processing to change to Horizontal Ribbon Mode.
  **********************************************************************************/
@@ -977,7 +957,7 @@ NgChm.DEV.detailHRibbon = function (mapItem) {
 	const prevWidth = mapItem.dataBoxWidth;
 	mapItem.saveCol = mapItem.currentCol;
 	NgChm.SEL.setMode(mapItem,'RIBBONH');
-	NgChm.DEV.setButtons(mapItem);
+	NgChm.DET.setButtons(mapItem);
 	if (previousMode=='FULL_MAP') {
 		NgChm.DET.setDetailDataHeight(mapItem, NgChm.DET.zoomBoxSizes[0]);
 	}
@@ -1047,7 +1027,7 @@ NgChm.DEV.detailVRibbon = function (mapItem) {
 	mapItem.saveRow = mapItem.currentRow;
 	
 	NgChm.SEL.setMode(mapItem, 'RIBBONV');
-	NgChm.DEV.setButtons(mapItem);
+	NgChm.DET.setButtons(mapItem);
 
 	// If normal (full) ribbon, set the width of the detail display to the size of the horizontal ribbon view
 	// and data size to 1.

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -502,7 +502,7 @@ NgChm.createNS('NgChm.LNK');
 		topDiv.classList.add("labelMenuCaption");
 		topDiv.innerHTML = axis !== "Matrix" ? axis.replace("Covar"," Classification") + ' Label Menu:' : axis + ' Menu';
 		var closeMenu = document.createElement("IMG");
-		closeMenu.src = "images/closeButton.png";
+		closeMenu.src = NgChm.UTIL.imageTable.closeButton;
 		closeMenu.alt = "close menu";
 		closeMenu.classList.add('labelMenuClose')
 		closeMenu.addEventListener('click', function(){NgChm.LNK.labelHelpClose(axis)},false);
@@ -1046,7 +1046,7 @@ NgChm.createNS('NgChm.LNK');
 		NgChm.UHM.initMessageBox();
 		NgChm.UHM.setMessageBoxHeader("Warning: Unable to save some plugin data");
 		NgChm.UHM.setMessageBoxText(warningText);
-		NgChm.UHM.setMessageBoxButton(1, 'images/okButton.png', 'OK Button');
+		NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.okButton, 'OK Button');
 		dialog.style.display = '';
 		let okButton = dialog.querySelector('#msgBoxBtnImg_1');
 		okButton.addEventListener('click', function handleOkClick(e) {

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -1547,4 +1547,12 @@ NgChm.UTIL.isOnObject = function (e,type) {
     return "#" + (0x1000000 | rgb).toString(16).substring(1);
 }  
 
-
+// A table of frequently used images.
+// Used to reduce widget size by having a single data: URL for each image instead of one per use.
+NgChm.UTIL.imageTable = {
+    cancelSmall: 'images/cancelSmall.png',
+    closeButton: 'images/closeButton.png',
+    okButton: 'images/okButton.png',
+    prefCancel: 'images/prefCancel.png',
+    saveNgchm: 'images/saveNgchm.png',
+};

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -587,8 +587,8 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 				NgChm.UHM.initMessageBox();
 				NgChm.UHM.setMessageBoxHeader('PathwayMapper Pane Reset Warning');
 				NgChm.UHM.setMessageBoxText('This action will delete all the information in PathwayMapper. Would you like to continue?')
-				NgChm.UHM.setMessageBoxButton(1, 'images/cancelSmall.png', 'Cancel Button')
-				NgChm.UHM.setMessageBoxButton(2, 'images/okButton.png', 'OK Button')
+				NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.cancelSmall, 'Cancel Button')
+				NgChm.UHM.setMessageBoxButton(2, NgChm.UTIL.imageTable.okButton, 'OK Button')
 				dialog.style.display = '';
 				return new Promise(function(resolve, reject) {
 					let okButton = dialog.querySelector('#msgBoxBtnImg_2')
@@ -990,8 +990,8 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 						NgChm.UHM.initMessageBox();
 						NgChm.UHM.setMessageBoxHeader('PathwayMapper Pane Reset Warning');
 						NgChm.UHM.setMessageBoxText('This action will delete all information in PathwayMapper. Would you like to continue?')
-						NgChm.UHM.setMessageBoxButton(1, 'images/cancelSmall.png', 'Cancel Button')
-						NgChm.UHM.setMessageBoxButton(2, 'images/okButton.png', 'OK Button')
+						NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.cancelSmall, 'Cancel Button')
+						NgChm.UHM.setMessageBoxButton(2, NgChm.UTIL.imageTable.okButton, 'OK Button')
 						dialog.style.display = '';
 						return new Promise(function(resolve, reject) {
 							let okButton = dialog.querySelector('#msgBoxBtnImg_2')

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -559,28 +559,28 @@ NgChm.UHM.saveHeatMapChanges = function() {
 				text = "<br>You have elected to save changes made to this NG-CHM heat map file.<br><br>You may save them to a new NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
 			}
 			NgChm.UHM.setMessageBoxText(text);
-			NgChm.UHM.setMessageBoxButton(1, "images/saveNgchm.png", "Save To NG-CHM File", "NgChm.heatMap.saveHeatMapToNgchm");
-			NgChm.UHM.setMessageBoxButton(4, "images/closeButton.png", "Cancel Save", "NgChm.UHM.messageBoxCancel");
+			NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.saveNgchm, "Save To NG-CHM File", "NgChm.heatMap.saveHeatMapToNgchm");
+			NgChm.UHM.setMessageBoxButton(4, NgChm.UTIL.imageTable.closeButton, "Cancel Save", "NgChm.UHM.messageBoxCancel");
 		} else {
 			// If so, is read only?
 			if (NgChm.heatMap.isReadOnly()) {
 				text = "<br>You have elected to save changes made to this READ-ONLY heat map. READ-ONLY heat maps cannot be updated.<br><br>However, you may save these changes to an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
 				NgChm.UHM.setMessageBoxText(text);
-				NgChm.UHM.setMessageBoxButton(1, "images/saveNgchm.png", "Save To NG-CHM File", "NgChm.heatMap.saveHeatMapToNgchm");
-				NgChm.UHM.setMessageBoxButton(4, "images/closeButton.png", "Cancel Save", "NgChm.UHM.messageBoxCancel");
+				NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.saveNgchm, "Save To NG-CHM File", "NgChm.heatMap.saveHeatMapToNgchm");
+				NgChm.UHM.setMessageBoxButton(4, NgChm.UTIL.imageTable.closeButton, "Cancel Save", "NgChm.UHM.messageBoxCancel");
 			} else {
 				text = "<br>You have elected to save changes made to this heat map.<br><br>You have the option to save these changes to the original map OR to save them to an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
 				NgChm.UHM.setMessageBoxText(text);
-				NgChm.UHM.setMessageBoxButton(1, "images/saveNgchm.png", "Save To NG-CHM File", "NgChm.heatMap.saveHeatMapToNgchm");
+				NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.saveNgchm, "Save To NG-CHM File", "NgChm.heatMap.saveHeatMapToNgchm");
 				NgChm.UHM.setMessageBoxButton(2, "images/saveOriginal.png", "Save Original Heat Map", "NgChm.heatMap.saveHeatMapToServer");
-				NgChm.UHM.setMessageBoxButton(3, "images/closeButton.png", "Cancel Save", "NgChm.UHM.messageBoxCancel");
+				NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.closeButton, "Cancel Save", "NgChm.UHM.messageBoxCancel");
 			}
 		}
 	} else {
 		text = "<br>There are no changes to save to this heat map at this time.<br><br>However, you may save the map as an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
 		NgChm.UHM.setMessageBoxText(text);
-		NgChm.UHM.setMessageBoxButton(1, "images/saveNgchm.png", "Save To NG-CHM File", "NgChm.heatMap.saveHeatMapToNgchm");
-		NgChm.UHM.setMessageBoxButton(4, "images/closeButton.png", "Cancel Save", "NgChm.UHM.messageBoxCancel");
+		NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.saveNgchm, "Save To NG-CHM File", "NgChm.heatMap.saveHeatMapToNgchm");
+		NgChm.UHM.setMessageBoxButton(4, NgChm.UTIL.imageTable.closeButton, "Cancel Save", "NgChm.UHM.messageBoxCancel");
 	}
 	document.getElementById('msgBox').style.display = '';
 }
@@ -602,7 +602,7 @@ NgChm.UHM.widgetHelp = function() {
 	text = text + "<p><b>Citation:</b> Bradley M. Broom, Michael C. Ryan, Robert E. Brown, Futa Ikeda, Mark Stucky, David W. Kane, James Melott, Chris Wakefield, Tod D. Casasent, Rehan Akbani and John N. Weinstein, A Galaxy Implementation of Next-Generation Clustered Heatmaps for Interactive Exploration of Molecular Profiling Data. Cancer Research 77(21): e23-e26 (2017): <a href='http://cancerres.aacrjournals.org/content/77/21/e23' target='_blank'>http://cancerres.aacrjournals.org/content/77/21/e23</a></p>";
 	text = text + "<p>The NG-CHM Viewer is also available for a variety of other platforms.</p>";
 	NgChm.UHM.setMessageBoxText(text);
-	NgChm.UHM.setMessageBoxButton(3, "images/closeButton.png", "Close button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.closeButton, "Close button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 }
 
@@ -617,13 +617,13 @@ NgChm.UHM.zipSaveNotification = function(autoSave) {
 	NgChm.UHM.setMessageBoxHeader("NG-CHM File Viewer");
 	if (autoSave) {
 		text = "<br>This NG-CHM archive file contains an out dated heat map configuration that has been updated locally to be compatible with the latest version of the NG-CHM Viewer.<br><br>In order to upgrade the NG-CHM and avoid this notice in the future, you will want to replace your original file with the version now being displayed.<br><br>";
-		NgChm.UHM.setMessageBoxButton(1, "images/saveNgchm.png", "Save NG-CHM button", "NgChm.heatMap.zipSaveNgchm");
+		NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.saveNgchm, "Save NG-CHM button", "NgChm.heatMap.zipSaveNgchm");
 	} else {
 		text = "<br>You have just saved a heat map as a NG-CHM file.  In order to see your saved changes, you will want to open this new file using the NG-CHM File Viewer application.  If you have not already downloaded the application, press the Download Viewer button to get the latest version.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>" 
 		NgChm.UHM.setMessageBoxButton(1, "images/downloadViewer.png", "Download NG-CHM Viewer App", "NgChm.UHM.zipAppDownload");
 	}
 	NgChm.UHM.setMessageBoxText(text);
-	NgChm.UHM.setMessageBoxButton(3, "images/cancelSmall.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.cancelSmall, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 }
 
@@ -637,7 +637,7 @@ NgChm.UHM.viewerAppVersionExpiredNotification = function(oldVersion, newVersion)
 	NgChm.UHM.setMessageBoxHeader("New NG-CHM File Viewer Version Available");
 	NgChm.UHM.setMessageBoxText("<br>The version of the NG-CHM File Viewer application that you are running ("+oldVersion+") has been superceded by a newer version ("+newVersion+"). You will be able to view all pre-existing heat maps with this new backward-compatible version. However, you may wish to download the latest version of the viewer.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>");
 	NgChm.UHM.setMessageBoxButton(1, "images/downloadViewer.png", "Download NG-CHM Viewer App", "NgChm.UHM.zipAppDownload");
-	NgChm.UHM.setMessageBoxButton(3, "images/closeButton.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.closeButton, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 }
 
@@ -650,7 +650,7 @@ NgChm.UHM.hamburgerLinkMissing = function() {
 	NgChm.UHM.initMessageBox();
 	NgChm.UHM.setMessageBoxHeader("NG-CHM Menu Link Error");
 	NgChm.UHM.setMessageBoxText("<br>No destination has been defined for the menu link.");
-	NgChm.UHM.setMessageBoxButton(1, "images/closeButton.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.closeButton, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 }
 
@@ -662,7 +662,7 @@ NgChm.UHM.systemMessage = function(header, message) {
 	NgChm.UHM.initMessageBox();
 	NgChm.UHM.setMessageBoxHeader(header);
 	NgChm.UHM.setMessageBoxText("<br>" + message);
-	NgChm.UHM.setMessageBoxButton(1, "images/closeButton.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(1, NgChm.UTIL.imageTable.closeButton, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 }
 
@@ -688,7 +688,7 @@ NgChm.UHM.noWebGlContext = function(isDisabled) {
 	} else {
 		NgChm.UHM.setMessageBoxText("<br>No WebGL context is available.  The NG-CHM Application requires the WebGL Javascript API in order to render images of Next Generation Clustered Heat Maps. Most web browsers and graphics processors support WebGL.<br><br>Please ensure that the browser that you are using and your computer's processor are WebGL compatible.");
 	}
-	NgChm.UHM.setMessageBoxButton(3, "images/prefCancel.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.prefCancel, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 }
 
@@ -700,7 +700,7 @@ NgChm.UHM.mapNotFound = function(heatMapName) {
 	NgChm.UHM.initMessageBox();
 	NgChm.UHM.setMessageBoxHeader("Requested Heat Map Not Found");
 	NgChm.UHM.setMessageBoxText("<br>The Heat Map (" + heatMapName + ") that you requested cannot be found OR connectivity to the Heat Map repository has been interrupted.<br><br>Please check the Heat Map name and try again.");
-	NgChm.UHM.setMessageBoxButton(3, "images/prefCancel.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.prefCancel, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 };
 
@@ -712,7 +712,7 @@ NgChm.UHM.mapLoadError = function(heatMapName, details) {
 	NgChm.UHM.initMessageBox();
 	NgChm.UHM.setMessageBoxHeader("Requested Heat Map Not Loaded");
 	NgChm.UHM.setMessageBoxText("<br>The Heat Map (" + heatMapName + ") that you selected cannot be loaded.<br><br>Reason: " + details);
-	NgChm.UHM.setMessageBoxButton(3, "images/prefCancel.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.prefCancel, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 };
 
@@ -723,7 +723,7 @@ NgChm.UHM.linkoutError = function(msgText) {
 	NgChm.UHM.initMessageBox();
 	NgChm.UHM.setMessageBoxHeader("Heat Map Linkout"); 
 	NgChm.UHM.setMessageBoxText(msgText);
-	NgChm.UHM.setMessageBoxButton(3, "images/prefCancel.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.prefCancel, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 }
 
@@ -736,7 +736,7 @@ NgChm.UHM.invalidFileFormat = function() {
 	NgChm.UHM.initMessageBox();
 	NgChm.UHM.setMessageBoxHeader("Invalid File Format");
 	NgChm.UHM.setMessageBoxText("<br>The file chosen is not an NG-CHM file.<br><br>Please select a .ngchm file and try again.");
-	NgChm.UHM.setMessageBoxButton(3, "images/prefCancel.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.prefCancel, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
 }
 
@@ -903,7 +903,7 @@ NgChm.UHM.displayStartupWarnings = function() {
 	}
 	NgChm.UHM.setMessageBoxHeader(headingText); 
 	NgChm.UHM.setMessageBoxText(warningText);
-	NgChm.UHM.setMessageBoxButton(3, "images/prefCancel.png", "Cancel button", "NgChm.UHM.messageBoxCancel");
+	NgChm.UHM.setMessageBoxButton(3, NgChm.UTIL.imageTable.prefCancel, "Cancel button", "NgChm.UHM.messageBoxCancel");
 	document.getElementById('msgBox').style.display = '';
     NgChm.UTIL.redrawCanvases();
 }


### PR DESCRIPTION
Commit 0592b50 introduced a simpler way of determining the correct image
to use for the zoom mode buttons in the normal, hover, and selected states.

However, that broke the Widgetizer.  The Widgetizer requires images to
have full pathnames, which it converts to 'data:' URLs that are included
in the widget javascript code to make it standalone.

This patch adds a simple table lookup to convert from image names to
image paths, thus allowing the Widgetizer to do its conversions, which
also achieving the goals of the original patch.

At the same time, I noticed that there are many URLs that are included multiple times in the source code.  Each duplication unnecessarily expands the size of the widget.  The additional commits address the worst of those duplications.

The minified widget from commit 1ac9ad54 (the last before the bug) was 1169189 bytes.
The minified widget from the last commit in this pull request is 1126076 bytes (nearly 3.7% smaller).
 