### PR TITLE
Fix restoration of detail panels including dendrogram zoom levels

### DIFF
--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -104,6 +104,10 @@ div.collapsed div.icon_group.client_icons {
 	display: none;
 }
 
+div.pane.collapsed {
+    overflow: visible;
+}
+
 div.ngChmContainer {
 	position: relative;
 	display: flex;

--- a/NGCHM/WebContent/javascript/Dendrogram.js
+++ b/NGCHM/WebContent/javascript/Dendrogram.js
@@ -756,7 +756,11 @@ NgChm.DDR.DetailDendrogram = function(summaryDendrogram) {
 	const PPL = this.summaryDendrogram.getPointsPerLeaf(); 
 	
 	this.isVisible = function() {
-		return this.dendroConfig.show === "ALL";
+		if (this.dendroConfig.show !== "ALL" || !this.dendroCanvas) {
+		    return false;
+		}
+		const loc = NgChm.Pane.findPaneLocation (this.dendroCanvas);
+		return !loc.pane.classList.contains('collapsed');
 	};
 
 	// Return the local index of the bar with index globalIdx.

--- a/NGCHM/WebContent/javascript/Dendrogram.js
+++ b/NGCHM/WebContent/javascript/Dendrogram.js
@@ -814,10 +814,18 @@ NgChm.DDR.DetailDendrogram = function(summaryDendrogram) {
 
 	// Current zoom level.
 	this.zoomLevel = 1;
+	this.zoomInitialized = false;
 
 	// Bars that are at least partially within the window.
 	this.bars = [];
 	this.barsMaxHeight = -1;
+
+	this.setZoomLevel = function (zoomLevel) {
+	    if (zoomLevel != undefined) {
+		this.zoomLevel = +zoomLevel;
+		this.zoomInitialized = true;
+	    }
+	};
 
 	this.buildView = function () {
 		// Step 1: select bars between the left and right edges of the window.
@@ -852,10 +860,12 @@ NgChm.DDR.DetailDendrogram = function(summaryDendrogram) {
 				});
 				this.barsMaxHeight = maxHeight;
 				this.scaledView = null;		// Force scaled view recalculation.
+			} else {
+				visBars = this.bars.length;
 			}
 	        // Done if initialized or if at least 75% of the
 	        // bars spanning the view are visible.
-	        if (NgChm.DET.initialized || (visBars/this.windowBars.length) > 0.75) {
+	        if (this.zoomInitialized || (visBars/this.windowBars.length) > 0.75) {
 	        	break;
 	        }
 			// Guaranteed stop. Really expect to stop before this becomes true.
@@ -866,6 +876,7 @@ NgChm.DDR.DetailDendrogram = function(summaryDendrogram) {
 	        this.zoomLevel *= 0.75;
 		}
 		this.dendroViewHeight = maxHeight;
+		this.zoomInitialized = true;
 	};
 
 	// Create a scaled view of the detail window as bars within the unit square [0..1) x [0..1).

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -2392,19 +2392,8 @@ NgChm.DET.drawScatterBarPlotRowClassBar = function(mapItem, pixels, pos, start, 
 		NgChm.Pane.emptyPaneLocation (loc);
 		if (!restoreInfo) { NgChm.DMM.nextMapNumber++; }
 
-		/* Get DIV#detail_chm from DIV#templates. */
-		let chm;
-		if (mapNumber == 1) {
-		    chm = document.querySelector('#templates #detail_chm');
-		    /* Uses DIV#detail_chm, which should be in DIV#templates. */
-		    /* Because if not, mapNumber 1 would already be displayed. */
-		    if (!chm) {
-			console.error ("Cannot find #detail_chm in #templates");
-			return;
-		    }
-		} else {
-		    chm = cloneDetailChm (mapNumber);
-		}
+		/* Clone DIV#detail_chm from DIV#templates. */
+		let chm = cloneDetailChm (mapNumber);
 		loc.pane.appendChild (chm);
 		NgChm.Pane.setPaneClientIcons(loc, [
 		    zoomButton ('primary_btn'+mapNumber, 'images/primary.png', 'images/primaryHover.png', 'Set to Primary', 75, NgChm.DMM.switchToPrimary.bind('chm', loc.pane.children[1])),
@@ -2485,10 +2474,6 @@ NgChm.DET.drawScatterBarPlotRowClassBar = function(mapItem, pixels, pos, start, 
 
 
 	function cloneDetailChm (mapNumber) {
-		if (mapNumber == 1) {
-		    console.error ('Cannot assign clone id #1');
-		    return null;
-		}
 		const tmp = document.querySelector('#detail_chm');
 		const pClone = tmp.cloneNode(true);
 		pClone.id = 'detail_chm' + mapNumber;
@@ -2603,13 +2588,6 @@ NgChm.DET.drawScatterBarPlotRowClassBar = function(mapItem, pixels, pos, start, 
 	}
 
 	function emptyDetailPane (loc, elements) {
-		const templates = document.getElementById('templates');
-		[...elements].forEach(el => {
-		    if (el.id === 'detail_chm') {
-			// If the 'template' detail chm, put it back into DIV#templates
-			templates.appendChild(el);
-		    }
-		});
 		NgChm.DMM.RemoveDetailMap(loc.pane.id); 
 		NgChm.SUM.drawLeftCanvasBox ();
 	}

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -62,13 +62,13 @@ NgChm.DET.setDrawDetailsTimeout = function (ms, noResize) {
  * the resize routine will be skipped on the next redraw.
  *********************************************************************************************/
 NgChm.DET.setDrawDetailTimeout = function (mapItem, ms, noResize) {
-	if (!NgChm.DMM.isDetailMapDisplayed()) { return false }
 	if (mapItem.drawEventTimer) {
 		clearTimeout (mapItem.drawEventTimer);
 	}
-	const drawWin = NgChm.SEL.getDetailWindow(mapItem);
-
 	if (!noResize) mapItem.resizeOnNextDraw = true;
+	if (!NgChm.DMM.isVisible(mapItem)) { return false }
+
+	const drawWin = NgChm.SEL.getDetailWindow(mapItem);
 	mapItem.drawEventTimer = setTimeout(function drawDetailTimeout () {
 		if (mapItem.chm) {
 			NgChm.DET.drawDetailHeatMap(mapItem, drawWin);
@@ -1245,6 +1245,9 @@ NgChm.DET.getColLabelFontSize = function (mapItem) {
 NgChm.DET.updateDisplayedLabels = function () {
 	for (let i=0; i<NgChm.DMM.DetailMaps.length;i++ ) {
 		const mapItem = NgChm.DMM.DetailMaps[i];
+		if (!NgChm.DMM.isVisible(mapItem)) {
+		    continue;
+		}
 		const debug = false;
 	
 		const prevNumLabels = Object.keys(mapItem.labelElements).length;

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -145,6 +145,7 @@ NgChm.DET.setDetailMapDisplay = function (mapItem, restoreInfo) {
 		mapItem.colDendro.setZoomLevel(restoreInfo.colZoomLevel || 1);
 	    }
 	}
+	NgChm.DET.setButtons(mapItem);
 }
 
 /*********************************************************************************************

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -871,35 +871,37 @@ NgChm.DEV.clearModeHistory = function (mapItem) {
  * the processing necessary to return a heat map panel to normal mode.
  * mapItem is the detail view map item.
  **********************************************************************************/
-NgChm.DEV.detailNormal = function (mapItem) {
+NgChm.DEV.detailNormal = function (mapItem, restoreInfo) {
 	NgChm.UHM.hlpC();	
 	const previousMode = mapItem.mode;
 	NgChm.SEL.setMode(mapItem,'NORMAL');
 	NgChm.DET.setButtons(mapItem);
-	mapItem.dataViewHeight = NgChm.DET.SIZE_NORMAL_MODE;
-	mapItem.dataViewWidth = NgChm.DET.SIZE_NORMAL_MODE;
-	if ((previousMode=='RIBBONV') || (previousMode=='RIBBONV_DETAIL')) {
+	if (!restoreInfo) {
+	    mapItem.dataViewHeight = NgChm.DET.SIZE_NORMAL_MODE;
+	    mapItem.dataViewWidth = NgChm.DET.SIZE_NORMAL_MODE;
+	    if ((previousMode=='RIBBONV') || (previousMode=='RIBBONV_DETAIL')) {
 		NgChm.DET.setDetailDataSize(mapItem, mapItem.dataBoxWidth);
-	} else if ((previousMode=='RIBBONH') || (previousMode=='RIBBONH_DETAIL')) {
+	    } else if ((previousMode=='RIBBONH') || (previousMode=='RIBBONH_DETAIL')) {
 		NgChm.DET.setDetailDataSize(mapItem,mapItem.dataBoxHeight);
-	} else if (previousMode=='FULL_MAP') {
+	    } else if (previousMode=='FULL_MAP') {
 		NgChm.DET.setDetailDataSize(mapItem,NgChm.DET.zoomBoxSizes[0]);
-	}	
+	    }
 
-	//On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
-	while ((Math.floor((mapItem.dataViewHeight-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxHeight)]) > NgChm.heatMap.getNumRows(NgChm.MMGR.DETAIL_LEVEL)) ||
-           (Math.floor((mapItem.dataViewWidth-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth)]) > NgChm.heatMap.getNumColumns(NgChm.MMGR.DETAIL_LEVEL))) {
+	    //On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
+	    while ((Math.floor((mapItem.dataViewHeight-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxHeight)]) > NgChm.heatMap.getNumRows(NgChm.MMGR.DETAIL_LEVEL)) ||
+	       (Math.floor((mapItem.dataViewWidth-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth)]) > NgChm.heatMap.getNumColumns(NgChm.MMGR.DETAIL_LEVEL))) {
 		NgChm.DET.setDetailDataSize(mapItem, NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth)+1]);
-	}	
+	    }
 	
-	if ((previousMode=='RIBBONV') || (previousMode=='RIBBONV_DETAIL')) {
+	    if ((previousMode=='RIBBONV') || (previousMode=='RIBBONV_DETAIL')) {
 		mapItem.currentRow = mapItem.saveRow;
-	} else if ((previousMode=='RIBBONH') || (previousMode=='RIBBONH_DETAIL')) {
+	    } else if ((previousMode=='RIBBONH') || (previousMode=='RIBBONH_DETAIL')) {
 		mapItem.currentCol = mapItem.saveCol;
-	} else if (previousMode=='FULL_MAP') {
+	    } else if (previousMode=='FULL_MAP') {
 		mapItem.currentRow = mapItem.saveRow;
 		mapItem.currentCol = mapItem.saveCol;		
-	}	
+	    }
+	}
 	
 	NgChm.SEL.checkRow(mapItem);
 	NgChm.SEL.checkCol(mapItem);
@@ -910,7 +912,7 @@ NgChm.DEV.detailNormal = function (mapItem) {
 	NgChm.DDR.clearDendroSelection();
 	NgChm.SEL.updateSelection(mapItem);
 	document.getElementById("viewport").setAttribute("content", "height=device-height");
-    document.getElementById("viewport").setAttribute("content", "");
+	document.getElementById("viewport").setAttribute("content", "");
 }
 
 /**********************************************************************************
@@ -957,19 +959,21 @@ NgChm.DEV.detailHRibbonButton = function (mapItem) {
  * ribbon view and also a sub-selection ribbon view if the user clicks on the dendrogram.  
  * If a dendrogram selection is in effect, then selectedStart and selectedStop will be set.
  **********************************************************************************/
-NgChm.DEV.detailHRibbon = function (mapItem) {
+NgChm.DEV.detailHRibbon = function (mapItem, restoreInfo) {
 	NgChm.UHM.hlpC();	
 	const previousMode = mapItem.mode;
 	const prevWidth = mapItem.dataBoxWidth;
 	mapItem.saveCol = mapItem.currentCol;
 	NgChm.SEL.setMode(mapItem,'RIBBONH');
 	NgChm.DET.setButtons(mapItem);
-	if (previousMode=='FULL_MAP') {
+
+	if (!restoreInfo) {
+	    if (previousMode=='FULL_MAP') {
 		NgChm.DET.setDetailDataHeight(mapItem, NgChm.DET.zoomBoxSizes[0]);
-	}
-	// If normal (full) ribbon, set the width of the detail display to the size of the horizontal ribbon view
-	// and data size to 1.
-	if (mapItem.selectedStart == null || mapItem.selectedStart == 0) {
+	    }
+	    // If normal (full) ribbon, set the width of the detail display to the size of the horizontal ribbon view
+	    // and data size to 1.
+	    if (mapItem.selectedStart == null || mapItem.selectedStart == 0) {
 		mapItem.dataViewWidth = NgChm.heatMap.getNumColumns(NgChm.MMGR.RIBBON_HOR_LEVEL) + NgChm.DET.dataViewBorder;
 		let ddw = 1;
 		while(2*mapItem.dataViewWidth < 500){ // make the width wider to prevent blurry/big dendros for smaller maps
@@ -978,7 +982,7 @@ NgChm.DEV.detailHRibbon = function (mapItem) {
 		}
 		NgChm.DET.setDetailDataWidth(mapItem,ddw);
 		mapItem.currentCol = 1;
-	} else {
+	    } else {
 		mapItem.saveCol = mapItem.selectedStart;
 		let selectionSize = mapItem.selectedStop - mapItem.selectedStart + 1;
 		NgChm.DEV.clearModeHistory (mapItem);
@@ -987,23 +991,24 @@ NgChm.DEV.detailHRibbon = function (mapItem) {
 		mapItem.dataViewWidth = (selectionSize * width) + NgChm.DET.dataViewBorder;
 		NgChm.DET.setDetailDataWidth(mapItem,width);	
 		mapItem.currentCol = mapItem.selectedStart;
-	}
+	    }
 	
-	mapItem.dataViewHeight = NgChm.DET.SIZE_NORMAL_MODE;
-	if ((previousMode=='RIBBONV') || (previousMode == 'RIBBONV_DETAIL') || (previousMode == 'FULL_MAP')) {
-		if (previousMode != 'FULL_MAP') {
-			NgChm.DET.setDetailDataHeight(mapItem,prevWidth);
+	    mapItem.dataViewHeight = NgChm.DET.SIZE_NORMAL_MODE;
+	    if ((previousMode=='RIBBONV') || (previousMode == 'RIBBONV_DETAIL') || (previousMode == 'FULL_MAP')) {
+		if (previousMode == 'FULL_MAP') {
+		    NgChm.DET.setDetailDataHeight(mapItem,NgChm.DET.zoomBoxSizes[0]);
 		} else {
-            NgChm.DET.setDetailDataHeight(mapItem,NgChm.DET.zoomBoxSizes[0]);
-        }	
+		    NgChm.DET.setDetailDataHeight(mapItem,prevWidth);
+		}
 		mapItem.currentRow = mapItem.saveRow;
-	}	
+	    }
 
-	//On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
-	while (Math.floor((mapItem.dataViewHeight-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxHeight)]) > NgChm.heatMap.getNumRows(NgChm.MMGR.DETAIL_LEVEL)) {
+	    //On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
+	    while (Math.floor((mapItem.dataViewHeight-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxHeight)]) > NgChm.heatMap.getNumRows(NgChm.MMGR.DETAIL_LEVEL)) {
 		NgChm.DET.setDetailDataHeight(mapItem,NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxHeight)+1]);
-	}	
-	
+	    }
+	}
+
 	mapItem.canvas.width =  (mapItem.dataViewWidth + NgChm.DET.calculateTotalClassBarHeight("row"));
 	mapItem.canvas.height = (mapItem.dataViewHeight + NgChm.DET.calculateTotalClassBarHeight("column"));
 	NgChm.DET.detInitGl(mapItem);
@@ -1025,7 +1030,7 @@ NgChm.DEV.detailVRibbonButton = function (mapItem) {
  * ribbon view and also a sub-selection ribbon view if the user clicks on the dendrogram.  
  * If a dendrogram selection is in effect, then selectedStart and selectedStop will be set.
  **********************************************************************************/
-NgChm.DEV.detailVRibbon = function (mapItem) {
+NgChm.DEV.detailVRibbon = function (mapItem, restoreInfo) {
 	NgChm.UHM.hlpC();	
 	const previousMode = mapItem.mode;
 	const prevHeight = mapItem.dataBoxHeight;
@@ -1061,27 +1066,29 @@ NgChm.DEV.detailVRibbon = function (mapItem) {
 		mapItem.currentRow = mapItem.selectedStart;
 	}
 	
-	mapItem.dataViewWidth = NgChm.DET.SIZE_NORMAL_MODE;
-	if ((previousMode=='RIBBONH') || (previousMode=='RIBBONH_DETAIL') || (previousMode == 'FULL_MAP')) {
-		if (previousMode != 'FULL_MAP') {
-			NgChm.DET.setDetailDataWidth(mapItem,prevHeight);
+	if (!restoreInfo) {
+	    mapItem.dataViewWidth = NgChm.DET.SIZE_NORMAL_MODE;
+	    if ((previousMode=='RIBBONH') || (previousMode=='RIBBONH_DETAIL') || (previousMode == 'FULL_MAP')) {
+		if (previousMode == 'FULL_MAP') {
+			NgChm.DET.setDetailDataWidth(mapItem, NgChm.DET.zoomBoxSizes[0]);
 		} else {
- 		    NgChm.DET.setDetailDataWidth(mapItem,NgChm.DET.zoomBoxSizes[0]);
-        }
+			NgChm.DET.setDetailDataWidth(mapItem, prevHeight);
+		}
 		mapItem.currentCol = mapItem.saveCol;
-	}
+	    }
 	
-	//On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
-	while (Math.floor((mapItem.dataViewWidth-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth)]) > NgChm.heatMap.getNumColumns(NgChm.MMGR.DETAIL_LEVEL)) {
+	    //On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
+	    while (Math.floor((mapItem.dataViewWidth-NgChm.DET.dataViewBorder)/NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth)]) > NgChm.heatMap.getNumColumns(NgChm.MMGR.DETAIL_LEVEL)) {
 		NgChm.DET.setDetailDataWidth(mapItem,NgChm.DET.zoomBoxSizes[NgChm.DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth)+1]);
-	}	
-		
+	    }
+	}
+
 	mapItem.canvas.width =  (mapItem.dataViewWidth + NgChm.DET.calculateTotalClassBarHeight("row"));
 	mapItem.canvas.height = (mapItem.dataViewHeight + NgChm.DET.calculateTotalClassBarHeight("column"));
 	NgChm.DET.detInitGl(mapItem);
 	NgChm.SEL.updateSelection(mapItem);
 	document.getElementById("viewport").setAttribute("content", "height=device-height");
-    document.getElementById("viewport").setAttribute("content", "");
+	document.getElementById("viewport").setAttribute("content", "");
 }
 
 /**********************************************************************************

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -995,12 +995,12 @@ NgChm.DEV.detailHRibbon = function (mapItem, restoreInfo) {
 	
 	    mapItem.dataViewHeight = NgChm.DET.SIZE_NORMAL_MODE;
 	    if ((previousMode=='RIBBONV') || (previousMode == 'RIBBONV_DETAIL') || (previousMode == 'FULL_MAP')) {
+		mapItem.currentRow = mapItem.saveRow;
 		if (previousMode == 'FULL_MAP') {
 		    NgChm.DET.setDetailDataHeight(mapItem,NgChm.DET.zoomBoxSizes[0]);
 		} else {
 		    NgChm.DET.setDetailDataHeight(mapItem,prevWidth);
 		}
-		mapItem.currentRow = mapItem.saveRow;
 	    }
 
 	    //On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
@@ -1069,12 +1069,12 @@ NgChm.DEV.detailVRibbon = function (mapItem, restoreInfo) {
 	if (!restoreInfo) {
 	    mapItem.dataViewWidth = NgChm.DET.SIZE_NORMAL_MODE;
 	    if ((previousMode=='RIBBONH') || (previousMode=='RIBBONH_DETAIL') || (previousMode == 'FULL_MAP')) {
+		mapItem.currentCol = mapItem.saveCol;
 		if (previousMode == 'FULL_MAP') {
 			NgChm.DET.setDetailDataWidth(mapItem, NgChm.DET.zoomBoxSizes[0]);
 		} else {
 			NgChm.DET.setDetailDataWidth(mapItem, prevHeight);
 		}
-		mapItem.currentCol = mapItem.saveCol;
 	    }
 	
 	    //On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -132,7 +132,7 @@ NgChm.DEV.addEvents = function (paneId) {
 NgChm.DEV.handleScroll = function(evt) {
 	evt.preventDefault();
 	let parentElement = evt.target.parentElement;
-	if (!parentElement.id.includes('detail_chm')) { 
+	if (!parentElement.classList.contains('detail_chm')) {
 	        if (!NgChm.DMM.primaryMap) return;
 		parentElement = NgChm.DMM.primaryMap.chm;
 	}

--- a/NGCHM/WebContent/javascript/DetailHeatMapManager.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapManager.js
@@ -237,20 +237,24 @@ NgChm.DMM.getMapItemFromDendro = function (dendro) {
 }
 
 /*********************************************************************************************
- * FUNCTION:  isVisible - The purpose of this function is to return true if the Detail View 
- * is visible (i.e. contained in a visible pane).
+ * FUNCTION:  isVisible - Return true if mapItem is visible (i.e. contained in a visible pane).
  *********************************************************************************************/
-NgChm.DMM.isVisible = function isVisible () {
-	let isViz = false
+NgChm.DMM.isVisible = function isVisible (mapItem) {
+	const loc = NgChm.Pane.findPaneLocation (mapItem.chm);
+	return (!loc.pane.classList.contains('collapsed')) && (loc.pane.style.display !== 'none');
+};
+
+/*********************************************************************************************
+ * FUNCTION:  anyVisible - Return true if any Detail View is visible.
+ *********************************************************************************************/
+NgChm.DMM.anyVisible = function anyVisible () {
 	for (let i=0; i<NgChm.DMM.DetailMaps.length;i++ ) {
-		const mapItem = NgChm.DMM.DetailMaps[i];
-		const loc = NgChm.Pane.findPaneLocation (mapItem.chm);
-		if ((!loc.pane.classList.contains('collapsed')) && (loc.pane.style.display !== 'none')){
-			isViz = true;
-		}
+		if (isVisible(NgChm.DMM.DetailMaps[i])) {
+		    return true;
+		};
 	}
-	return isViz;
-}
+	return false;
+};
 
 /************************************************************************************************
  * FUNCTION - detailResize: This function calls all of the functions necessary to resize all 
@@ -273,13 +277,3 @@ NgChm.DMM.detailResize = function () {
 	    NgChm.DET.colDendroResize(mapItem);
 	});
 }
-
-NgChm.DMM.isDetailMapDisplayed = function() {
-	if (NgChm.DMM.DetailMaps.length > 0) {
-		return true;
-	} else {
-		return false;
-	}
-}
-
-

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2826,6 +2826,7 @@ NgChm.createNS('NgChm.LNK');
 		if (Object.entries(instance.params).length === 0) {
 		        NgChm.LNK.sendMessageToPlugin ({ nonce: msg.nonce, op: 'none' }); // Let plugin know we heard it.
 			NgChm.Pane.switchToPlugin (loc, instance.plugin.name);
+			NgChm.MMGR.saveDataSentToPluginToMapConfig(msg.nonce, instance.plugin.config, null);
 		} else {
 			loc.paneTitle.innerText = instance.plugin.name;
 			NgChm.LNK.initializePanePlugin (msg.nonce, instance.params);

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -2403,6 +2403,8 @@ NgChm.createNS('NgChm.LNK');
 
 			if (config.axes[axisId].coco == null) config.axes[axisId].coco = [];
 			const pa = params.axes && axisId < params.axes.length ? params.axes[axisId] : { cocos:[], groups: [] };
+			pa.cocos = pa.cocos || {};
+			pa.groups = pa.groups || {};
 			// create UI for choosing coordiantes / covariates 
 			for (let cocoidx = 0; cocoidx < config.axes[axisId].coco.length; cocoidx++) {
 				const coco = config.axes[axisId].coco[cocoidx];
@@ -2826,7 +2828,7 @@ NgChm.createNS('NgChm.LNK');
 		if (Object.entries(instance.params).length === 0) {
 		        NgChm.LNK.sendMessageToPlugin ({ nonce: msg.nonce, op: 'none' }); // Let plugin know we heard it.
 			NgChm.Pane.switchToPlugin (loc, instance.plugin.name);
-			NgChm.MMGR.saveDataSentToPluginToMapConfig(msg.nonce, instance.plugin.config, null);
+			NgChm.MMGR.saveDataSentToPluginToMapConfig(msg.nonce, null, null);
 		} else {
 			loc.paneTitle.innerText = instance.plugin.name;
 			NgChm.LNK.initializePanePlugin (msg.nonce, instance.params);

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -1067,8 +1067,8 @@ NgChm.MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 		if (!mapConfig.panel_configuration.hasOwnProperty(paneId) || mapConfig.panel_configuration[paneId] == null) { 
 			mapConfig.panel_configuration[paneId] = {} 
 		}
-		mapConfig.panel_configuration[paneId].config = postedConfig;
-		mapConfig.panel_configuration[paneId].data = postedData;
+		if (postedConfig) mapConfig.panel_configuration[paneId].config = postedConfig;
+		if (postedData) mapConfig.panel_configuration[paneId].data = postedData;
 		mapConfig.panel_configuration[paneId].type = 'plugin';
 		mapConfig.panel_configuration[paneId].pluginName = pane.dataset.pluginName;
 	}

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -520,7 +520,7 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 				if (debug) console.log ('container resize');
 				const verticalContainer = e.target.classList.contains('vertical');
 				const verticalChange = e.detail.what === 'height';
-				const children = [...e.target.children].filter(ch => !ch.classList.contains('resizerHelper'));
+				const children = [...e.target.children].filter(ch => !ch.classList.contains('resizerHelper') && !ch.classList.contains('collapsed'));
 				if (verticalContainer !== verticalChange) {
 					children.forEach(ch => {
 						const newEv = new CustomEvent('paneresize', { detail: e.detail });

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -25,6 +25,7 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 	NgChm.Pane.resetPaneCounter = resetPaneCounter;
 	NgChm.Pane.toggleScreenMode = toggleScreenMode;
 	NgChm.Pane.collapsePane = collapsePane;
+	NgChm.Pane.isCollapsedPane = isCollapsedPane;
 
 	// function findPaneLocation(el) - return PaneLocation containing element el
 	NgChm.Pane.findPaneLocation = findPaneLocation;
@@ -738,10 +739,21 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 
 	const collapsedPanes = [];
 
+	function isCollapsedPane (paneLoc) {
+		return collapsedPanes.indexOf(paneLoc.pane) != -1;
+	}
+
+	/* Called to collapse a pane or to re-collapse an already collapsed pane.
+	 * The re-collapse case is used when reloading from saved state:
+	 * once after recreating the pane structure and once after filling the
+	 * pane's contents.
+	 */
 	function collapsePane (paneLoc) {
-		if (debug) console.log ('collapsePane');
+		if (debug) console.log ('collapsePane', paneLoc);
 		paneLoc.pane.classList.add('collapsed');
-		collapsedPanes.push (paneLoc.pane);
+		if (collapsedPanes.indexOf(paneLoc.pane) === -1) {
+		    collapsedPanes.push (paneLoc.pane);
+		}
 		let p = paneLoc.pane.firstElementChild;
 		while (p) {
 			if (p !== paneLoc.paneHeader) p.style.display = 'none';
@@ -756,9 +768,9 @@ NgChm.Pane.ngchmContainerHeight = 100;	// Percent of window height to use for NG
 		}
 	}
 
-	function expandPane (loc) {
-		if (debug) console.log ('expandPane');
-		loc.pane.classList.remove('collapsed');
+	function expandPane (paneLoc) {
+		if (debug) console.log ('expandPane', paneLoc);
+		paneLoc.pane.classList.remove('collapsed');
 	}
 
 	const paneContentOptions = [];

--- a/NGCHM/WebContent/javascript/PdfGenerator.js
+++ b/NGCHM/WebContent/javascript/PdfGenerator.js
@@ -15,7 +15,7 @@ NgChm.PDF.isGenerating = false;
  * button on the menu bar.  The PDF preferences panel is then launched
  **********************************************************************************/
 NgChm.PDF.canGeneratePdf = function() {
-	return NgChm.SUM.isVisible() || NgChm.DMM.isVisible();
+	return NgChm.SUM.isVisible() || NgChm.DMM.anyVisible();
 };
 
 NgChm.PDF.openPdfPrefs = function(e) {
@@ -31,17 +31,17 @@ NgChm.PDF.openPdfPrefs = function(e) {
 	const sumButton = document.getElementById ('pdfInputSummaryMap');
 	const detButton = document.getElementById ('pdfInputDetailMap');
 	const bothButton = document.getElementById ('pdfInputBothMaps');
-	if (NgChm.SUM.isVisible() && !NgChm.DMM.isVisible()) {
+	if (NgChm.SUM.isVisible() && !NgChm.DMM.anyVisible()) {
 		sumButton.checked = true;
 		sumButton.disabled = false;
 		detButton.disabled = true;
 		bothButton.disabled = true;
-	} else if (NgChm.DMM.isVisible() && !NgChm.SUM.isVisible()) {
+	} else if (NgChm.DMM.anyVisible() && !NgChm.SUM.isVisible()) {
 		detButton.checked = true;
 		sumButton.disabled = true;
 		detButton.disabled = false;
 		bothButton.disabled = true;
-	} else if (NgChm.SUM.isVisible() && NgChm.DMM.isVisible()) {
+	} else if (NgChm.SUM.isVisible() && NgChm.DMM.anyVisible()) {
 		bothButton.checked = true;
 		sumButton.disabled = false;
 		detButton.disabled = false;

--- a/NGCHM/WebContent/javascript/RecreatePanes.js
+++ b/NGCHM/WebContent/javascript/RecreatePanes.js
@@ -335,13 +335,16 @@ NgChm.createNS('NgChm.RecPanes');
 			let nonce = pluginInstance.nonce;
 			let config = paneInfo.config;
 			let data = paneInfo.data;
-			let selectedLabels = getSelectedLabels(config.axes[0].axisName);
-			data.axes[0].selectedLabels = selectedLabels;
+			config.axes.forEach (ax => {
+			    if (ax.axisName) {
+				ax.selectedLabels = getSelectedLabels(ax.axisName);
+			    }
+			});
 			pluginInstance.params = config;
-			NgChm.LNK.sendMessageToPlugin({nonce, op: 'plot', config, data});
+			if (data) NgChm.LNK.sendMessageToPlugin({nonce, op: 'plot', config, data});
 			let dataFromPlugin = paneInfo.dataFromPlugin;
-			NgChm.LNK.sendMessageToPlugin({nonce, op: 'savedPluginData', dataFromPlugin});
-			NgChm.Pane.removePopupNearIcon(document.getElementById(paneId+'Gear'), document.getElementById(paneId+'Icon'));
+			if (dataFromPlugin) NgChm.LNK.sendMessageToPlugin({nonce, op: 'savedPluginData', dataFromPlugin});
+			if (data) NgChm.Pane.removePopupNearIcon(document.getElementById(paneId+'Gear'), document.getElementById(paneId+'Icon'));
 			delete NgChm.RecPanes.mapConfigPanelConfiguration[paneId];
 		} else {
 			return false;
@@ -371,6 +374,10 @@ NgChm.createNS('NgChm.RecPanes');
 	function getPaneInfoFromMapConfig(paneId) {
 		try {
 			let paneInfo = NgChm.RecPanes.mapConfigPanelConfiguration[paneId];
+			if (!paneInfo) {
+			    console.warn ('Panel ' + paneId + ' has nosaved configuration');
+			    paneInfo = {};
+			}
 			return paneInfo;
 		} catch (error) {
 			if (error instanceof TypeError) {

--- a/NGCHM/WebContent/javascript/RecreatePanes.js
+++ b/NGCHM/WebContent/javascript/RecreatePanes.js
@@ -335,16 +335,20 @@ NgChm.createNS('NgChm.RecPanes');
 			let nonce = pluginInstance.nonce;
 			let config = paneInfo.config;
 			let data = paneInfo.data;
-			config.axes.forEach (ax => {
-			    if (ax.axisName) {
-				ax.selectedLabels = getSelectedLabels(ax.axisName);
+			if (config) {
+			    config.axes.forEach (ax => {
+				if (ax.axisName) {
+				    ax.selectedLabels = getSelectedLabels(ax.axisName);
+				}
+			    });
+			    pluginInstance.params = config;
+			    if (data) {
+				NgChm.LNK.sendMessageToPlugin({nonce, op: 'plot', config, data});
+				let dataFromPlugin = paneInfo.dataFromPlugin;
+				if (dataFromPlugin) NgChm.LNK.sendMessageToPlugin({nonce, op: 'savedPluginData', dataFromPlugin});
+				NgChm.Pane.removePopupNearIcon(document.getElementById(paneId+'Gear'), document.getElementById(paneId+'Icon'));
 			    }
-			});
-			pluginInstance.params = config;
-			if (data) NgChm.LNK.sendMessageToPlugin({nonce, op: 'plot', config, data});
-			let dataFromPlugin = paneInfo.dataFromPlugin;
-			if (dataFromPlugin) NgChm.LNK.sendMessageToPlugin({nonce, op: 'savedPluginData', dataFromPlugin});
-			if (data) NgChm.Pane.removePopupNearIcon(document.getElementById(paneId+'Gear'), document.getElementById(paneId+'Icon'));
+			}
 			delete NgChm.RecPanes.mapConfigPanelConfiguration[paneId];
 		} else {
 			return false;

--- a/NGCHM/WebContent/javascript/RecreatePanes.js
+++ b/NGCHM/WebContent/javascript/RecreatePanes.js
@@ -231,8 +231,8 @@ NgChm.createNS('NgChm.RecPanes');
 			let paneInfo = getPaneInfoFromMapConfig(paneid);
 			const isPrimary = paneInfo.version == 'P';
 			let mapNumber = paneInfo.versionNumber == "" ? getUnusedVersionNumber() : parseInt(paneInfo.versionNumber);
-                        if (mapNumber > NgChm.DMM.nextMapNumber) {
-                            NgChm.DMM.nextMapNumber = mapNumber;
+                        if (mapNumber >= NgChm.DMM.nextMapNumber) {
+                            NgChm.DMM.nextMapNumber = mapNumber+1;
                         }
                         NgChm.DET.switchPaneToDetail(NgChm.Pane.findPaneLocation(pane), { isPrimary, mapNumber, paneInfo });
 

--- a/NGCHM/WebContent/javascript/RecreatePanes.js
+++ b/NGCHM/WebContent/javascript/RecreatePanes.js
@@ -217,7 +217,8 @@ NgChm.createNS('NgChm.RecPanes');
 	 *	Set a pane's content based on 'config.type' attribute.
 	 */
 	function setPaneContent(paneid) {
-		let pane = document.getElementById(paneid);
+		const pane = document.getElementById(paneid);
+		const paneLoc = NgChm.Pane.findPaneLocation(pane);
 		const config = NgChm.RecPanes.mapConfigPanelConfiguration[paneid];
 		if (!config) {
 		    // Probably an empty pane.
@@ -272,6 +273,10 @@ NgChm.createNS('NgChm.RecPanes');
 			}
 		} else {
 			console.error ("Unrecognized pane type - " + config.type);
+		}
+		if (NgChm.Pane.isCollapsedPane (paneLoc)) {
+		    // Ensures that any added/modified pane components are collapsed properly.
+		    NgChm.Pane.collapsePane (paneLoc);
 		}
 	}
 


### PR DESCRIPTION
Save dendrogram zoom levels and restore them on reload.
Make per-detail-map versions of several variables that were global across
all detail panels. Specifically:
- dendrogram zoom initialization status,
- whether a detail map should be resized on next redraw, and
- timeout to detail map redraw event.

Avoid using NgChm.DMM.primaryMap to access properties that are really
global across all detail maps (e.g. current data layer).