### PR TITLE
Plugin help table links

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -341,7 +341,7 @@
 				<div id="linkBoxTxt"></div>
 				<div id="linkBoxAllTxt" class="hide"></div>
 				<div id="linkBoxFoot">
-				    <img src="images/closeButton.png" alt='close button icon'>
+				    <img src="images/closeButton.png" alt='close button icon' id="linkBoxFootCloseButton">
 				</div>
 			</div>
 		

--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -335,13 +335,13 @@
 				<div id="linkBoxHdr" class="msgBoxHdr"></div>
 				<p class='boxCaption'>This screen contains a listing of all plug-ins that are active in the current heat map and a listing all plug-ins installed in this Ng-Chm system.</p>
 				<div id="linkTabButtons">
-				    <img id="mapLinks_btn" src="images/mapLinksOn.png" alt="Plugins available for this map">
-                                    <img id="allLinks_btn" src="images/allLinksOff.png" alt="Plugins Installed">
+				    <img id="mapLinks_btn" src="images/mapLinksOn.png" alt="Plugins available for this map" class="clickableItem">
+                                    <img id="allLinks_btn" src="images/allLinksOff.png" alt="Plugins Installed" class="clickableItem">
 				</div>
 				<div id="linkBoxTxt"></div>
 				<div id="linkBoxAllTxt" class="hide"></div>
 				<div id="linkBoxFoot">
-				    <img src="images/closeButton.png" alt='close button icon' id="linkBoxFootCloseButton">
+				    <img src="images/closeButton.png" alt='close button icon' id="linkBoxFootCloseButton" class="clickableItem">
 				</div>
 			</div>
 		

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -571,6 +571,16 @@ span.button.negative {
     text-align: left;
 }
 
+/* Style plugin help table links same color/font as table text.
+   Links will still be underlined.
+*/
+.chmTblCell>a {
+	color: #0843c1; /* blue */
+}
+.chmTblCell>a:visited {
+	color: #7525c1; /* purple */
+}
+
 .chmHdrRow tr {
 	display: none;
     height: 0px;

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -815,6 +815,10 @@ th.breakpointContainer {
 	width: 100%; /* so that top border goes all the way accross #linkBox */
 }
 
+.clickableItem:hover {
+	cursor: pointer;
+}
+
 #linkBoxHdr {
 	position: absolute; /* keep fixed to top of parent */
 }

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -1074,7 +1074,7 @@ NgChm.UHM.openMapLinkoutsHelp = function() {
 			if (validPluginCtr === 0) {
 				tr.className = "chmHdrRow";
 				let td = tr.insertCell(0);
-				td.innerHTML = "<b>Plugin Axes</b>";
+				td.innerHTML = "<b>Plug-in Axes</b>";
 				td = tr.insertCell(0);
 				td.innerHTML = "<b>Description</b>";
 				td = tr.insertCell(0);

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -1078,10 +1078,8 @@ NgChm.UHM.openMapLinkoutsHelp = function() {
 				td = tr.insertCell(0);
 				td.innerHTML = "<b>Description</b>";
 				td = tr.insertCell(0);
-				td.innerHTML = "<b>Name</b>";
-				td = tr.insertCell(0);
-				td.className = "chmHdrRow";
-				td.innerHTML = "Website";
+				td.innerHTML = "<b>Plug-in Name and Website</b>";
+				td.setAttribute("colspan", 2);
 			}
 			validPluginCtr++;
 			//If there is no plugin logo, replace it with hyperlink using plugin name
@@ -1137,10 +1135,8 @@ NgChm.UHM.openAllLinkoutsHelp = function() {
 				let td = tr.insertCell(0);
 				td.innerHTML = "<b>Description</b>";
 				td = tr.insertCell(0);
-				td.innerHTML = "<b>Name</b>";
-				td = tr.insertCell(0);
-				td.className = "chmHdrRow";
-				td.innerHTML = "Website";
+				td.innerHTML = "<b>Plug-in Name and Website</b>";
+				td.setAttribute('colspan', 2);
 			}
 			validPluginCtr++;
 			//If there is no plugin logo, replace it with hyperlink using plugin name

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -56,7 +56,7 @@ NgChm.UHM.myNonce = 'N';			// Shared secret for vetting message sender
 	NgChm.UHM.showAllPlugins();
     };
 
-    uiElement = document.getElementById('linkBoxFoot');
+    uiElement = document.getElementById('linkBoxFootCloseButton');
     uiElement.onclick = () => {
 	NgChm.UHM.linkBoxCancel();
     };

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -1096,7 +1096,7 @@ NgChm.UHM.openMapLinkoutsHelp = function() {
 			var tdName = tr.insertCell(1);
 			tdName.className = "chmTblCell";
 			tdName.style.fontWeight="bold";
-			tdName.innerHTML = plugin.name;
+			tdName.innerHTML = typeof plugin.site !== 'undefined' ? "<a href='" + plugin.site + "' target='_blank'>" + plugin.name + "</a>" : plugin.name;
 			var tdDesc = tr.insertCell(2);
 			tdDesc.className = "chmTblCell";
 			tdDesc.innerHTML = plugin.description;
@@ -1155,7 +1155,7 @@ NgChm.UHM.openAllLinkoutsHelp = function() {
 			var tdName = tr.insertCell(1);
 			tdName.className = "chmTblCell";
 			tdName.style.fontWeight="bold";
-			tdName.innerHTML = plugin.name;
+			tdName.innerHTML = typeof plugin.site !== 'undefined' ? "<a href='" + plugin.site + "' target='_blank'>" + plugin.name + "</a>" : plugin.name;
 			var tdDesc = tr.insertCell(2);
 			tdDesc.className = "chmTblCell";
 			tdDesc.innerHTML = plugin.description;


### PR DESCRIPTION
This pull request makes the following changes to the 'NG-CHM Plug-in Information' ('Plug-in Help...') dialog:

- Make plug-in name link to website
- Make corresponding change to table header text
- Make only the close button in the footer clickable to close dialog (instead of whole footer)
- Change cursor to pointer on hover over close button and tabs in table