### PR TITLE
Compile time changes

### DIFF
--- a/NGCHM/WebContent/javascript/NgChm.js
+++ b/NGCHM/WebContent/javascript/NgChm.js
@@ -14,9 +14,7 @@ const NgChm = {};
     NgChm['exportToNS'] = exportToNS;
     NgChm['createNS'] = exportToNS;
     NgChm['importNS'] = importNS;
-    NgChm['markFile'] = markFile;
-    NgChm['getLog'] = getLog;
-    NgChm['dracula'] = dracula;
+    NgChm['markFile'] = () => {};  // No-op in compiled code. Dev mode version defined below.
     
     var lastFile = 'n/a';
 
@@ -42,6 +40,8 @@ const NgChm = {};
 	    nsparts = nsparts.slice(1);
 	}
 
+	// BEGIN EXCLUDE from production code.
+	//
 	// Determine javascript file name by creating an Error object
 	// and extracting the file name from the stack trace.
 	const err = new Error ("Defining namespace " + namespace);
@@ -62,6 +62,7 @@ const NgChm = {};
 	    trace.splice(1,1);
 	    console.log (trace.join(''));
 	}
+	// END EXCLUDE
 
 	let parent = NgChm;
 	// loop through the parts and create a nested namespace if necessary
@@ -82,6 +83,11 @@ const NgChm = {};
 	return parent;
     }
 
+    // BEGIN EXCLUDE from production code.
+    //
+    // The code from this comment block until the matching end block is removed
+    // by the compiler.
+    NgChm['getLog'] = getLog;
     function getLog () {
 	return log.slice(0);
     }
@@ -109,6 +115,7 @@ const NgChm = {};
     const moduleColor = '#eeeeff';      // Use slight blue color for modules.
 
     // Mark the current file.  Marked files are displayed in a distinct color.
+    NgChm['markFile'] = markFile;
     function markFile () {
 	const err = new Error ("Source file done");
 	const trace = err.stack.split('\n');
@@ -125,6 +132,7 @@ const NgChm = {};
 	}
     }
 
+    NgChm['dracula'] = dracula;
     function dracula () {
 	if (scriptLoaded) {
 	    drawGraph();
@@ -296,4 +304,7 @@ const NgChm = {};
 	    }
 	}
     }
+    // End of the code removed from the system by the compiler.
+    //
+    // END EXCLUDE
 })();

--- a/NGCHM/src/mda/ngchm/util/NGCHM_Minimizer.java
+++ b/NGCHM/src/mda/ngchm/util/NGCHM_Minimizer.java
@@ -103,7 +103,7 @@ public class NGCHM_Minimizer {
 	 *
 	 * This method is the driver for the js minimizer process. It reads
 	 * in the chm.html file and writes out the contents of all JS files
-	 * included therein into the output file (ngchm.js)
+	 * included therein, except those marked by PRESERVE, into the output file (ngchm.js)
 	 ******************************************************************/
 	public static void main(String[] args) {
 		System.out.println("BEGIN NGCHM_Minimizer  " + new Date());
@@ -117,13 +117,11 @@ public class NGCHM_Minimizer {
 
 			String line = br.readLine();
 			while (line != null) {
-				if (line.contains("src=\"javascript")) {
+				if (line.contains("src=\"javascript") && !line.contains("PRESERVE")) {
 					String jsFile = CompilerUtilities.getJavascriptFileName (line);
-					if (!jsFile.equals("javascript/lib/jspdf.min.js")) {
-						bw.write("/* BEGIN Javascript file: " + jsFile + " */ \n");
-						writeJSFile(args[0], jsFile, bw);
-						bw.write("/* END Javascript file: " + jsFile + " */ \n\n");
-					}
+					bw.write("/* BEGIN Javascript file: " + jsFile + " */ \n");
+					writeJSFile(args[0], jsFile, bw);
+					bw.write("/* END Javascript file: " + jsFile + " */ \n\n");
 				}
 				line = br.readLine();
 			}

--- a/NGCHM/src/mda/ngchm/util/NGCHM_Minimizer.java
+++ b/NGCHM/src/mda/ngchm/util/NGCHM_Minimizer.java
@@ -41,8 +41,18 @@ public class NGCHM_Minimizer {
     private static void writeJSFile(String webDir, String jsFile, BufferedWriter combinedWidget) throws Exception {
 		BufferedReader br = new BufferedReader(new FileReader(webDir + "/" + jsFile ));
 		String line = br.readLine();
+		Boolean inExcludedRegion = false;
 		while (line != null) {
-			if (line.contains("images/")) {
+			if (line.contains("BEGIN EXCLUDE")) {
+			    inExcludedRegion = true; // Exclude this and following lines.
+			}
+			else if (line.contains("END EXCLUDE")) {
+			    inExcludedRegion = false; // Include following lines.
+			}
+			else if (inExcludedRegion) {
+			    // Ignore excluded lines.
+			}
+			else if (line.contains("images/")) {
 				String toks[] = line.split(" ");
 				for (String tok : toks) {
 					if (tok.contains("images/")) {

--- a/NGCHM/src/mda/ngchm/util/NGCHM_Widgetizer.java
+++ b/NGCHM/src/mda/ngchm/util/NGCHM_Widgetizer.java
@@ -193,10 +193,34 @@ public class NGCHM_Widgetizer {
     		bw.write("if (embedDiv !== null) {embedDiv.innerHTML = htmlContent;}\n");
 		bw.write("})()\n");
 
-		// Inject scripts.
+		// Inject preserved scripts.
+		try {
+			BufferedReader br2 = new BufferedReader(new FileReader(args[0] + "/chm.html" ));
+
+			String line2 = br2.readLine();
+			while (line2 != null) {
+				if (line2.contains("src=\"javascript") && line2.contains("PRESERVE")) {
+					String jsFile = CompilerUtilities.getJavascriptFileName (line2);
+					bw.write("/* BEGIN Javascript file: " + jsFile + " */ \n");
+					BufferedReader br3 = new BufferedReader(new FileReader(args[0] + "/" + jsFile ));
+					String line3 = br3.readLine();
+					while (line3 != null) {
+					    bw.write (line3);
+					    line3 = br3.readLine();
+					}
+					br3.close();
+					bw.write("/* END Javascript file: " + jsFile + " */ \n\n");
+				}
+				line2 = br2.readLine();
+			}
+			br2.close();
+		} catch (Exception e) {
+		    // TODO Auto-generated catch block
+		    e.printStackTrace();
+		}
+		// Inject widget scripts.
 		bw.write("var ngChmWidgetMode = '" + mode + "';\n");
 		copyToFile (args[0] + "javascript/ngchm-min.js", bw);
-		copyToFile (args[0] + "javascript/lib/jspdf.min.js", bw);
     		bw.write("document.body.addEventListener('click', NgChm.UHM.closeMenu,true);\n");
     		bw.write(scriptedLines.toString());
 


### PR DESCRIPTION
Remove hard-coding of jspdf.min.js from Widgetizer/Minimizer in favor of existing <!-- PRESERVE --> comment.

Add ability to remove code between BEGIN EXCLUDE and END EXCLUDE comments in javascript code.

Use that ability to remove development tools from NgChm.js from compiled code (widget, standalone viewer, etc.)
