### PR TITLE
Count and trace modules imported before they are defined

### DIFF
--- a/NGCHM/WebContent/javascript/NgChm.js
+++ b/NGCHM/WebContent/javascript/NgChm.js
@@ -6,6 +6,7 @@ const NgChm = {};
 
     const debug = false;
     const log = [];
+    const definedNamespaces = [];
 
     // Function: exportToNS
     // This function is called from other JS files to define their individual namespaces.
@@ -17,6 +18,7 @@ const NgChm = {};
     NgChm['markFile'] = () => {};  // No-op in compiled code. Dev mode version defined below.
     
     var lastFile = 'n/a';
+    var importsBeforeDefinition = 0;
 
     function importNS (namespace) {
 	return getNS (namespace, 'import');
@@ -61,6 +63,17 @@ const NgChm = {};
 	if (debug) {
 	    trace.splice(1,1);
 	    console.log (trace.join(''));
+	}
+	if (op === 'export') {
+	    if (definedNamespaces.indexOf(namespace) < 0) {
+		definedNamespaces.push(namespace);
+	    }
+	}
+	if (op == 'import') {
+	    if (definedNamespaces.indexOf(namespace) < 0) {
+		importsBeforeDefinition++;
+		console.log ('Namespace imported before definition #' + importsBeforeDefinition + ': ' + namespace + ' in ' + lastFile);
+	    }
 	}
 	// END EXCLUDE
 


### PR DESCRIPTION
If, and it is a big if, the modules are imported in the order that minimizes the number of such out-of-order imports, this is equivalent to determining the minimum number of edges that must be removed to convert the module graph into an acyclic graph.

In general, this is the minimum feedback arc set problem in graph theory and it is NP-hard.  However, all the complexity involved is in determining the optimal order of imports (there are also other approaches).

I think we can assume that the import order is already at least a very good approximation to the best order and good enough for our needs.  And a lot simpler to implement.

The code is included in a region of NgChm.js that will be excluded from the production code by the compiler.