### PR TITLE
Fix two typos setting the onclick handlers in PdfGenerator.js

### DIFF
--- a/NGCHM/WebContent/javascript/PdfGenerator.js
+++ b/NGCHM/WebContent/javascript/PdfGenerator.js
@@ -1592,10 +1592,10 @@ document.getElementById('pdfInputFont').onchange = function (event) {
 document.getElementById('prefCancel_btn').onclick = function (event) {
     PDF.pdfCancelButton();
 };
-document.getElementById('prefCreate_btn').onlick = function (event) {
+document.getElementById('prefCreate_btn').onclick = function (event) {
     PDF.callViewerHeatmapPDF();
 };
-document.getElementById('menuPdf').onlick = function (event) {
+document.getElementById('menuPdf').onclick = function (event) {
     PDF.openPdfPrefs(event.target, null);
 };
 


### PR DESCRIPTION
I made these in the first restructure patch.