### PR TITLE
Re-add fix for issue 324.  Set to odd (development) version

### DIFF
--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -20,7 +20,7 @@ CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\": \"Y
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
-CM.version = "2.22.1";
+CM.version = "2.23.0";	// Please increment rightmost digit for each interim version
 CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 CM.viewerAppUrl = "https://bioinformatics.mdanderson.org/ngchm/ZipAppDownload";
 CM.classOrderStr = ".classifications_order";

--- a/NGCHM/src/mda/ngchm/util/NGCHM_Widgetizer.java
+++ b/NGCHM/src/mda/ngchm/util/NGCHM_Widgetizer.java
@@ -187,6 +187,7 @@ public class NGCHM_Widgetizer {
 
 		// Inject HTML.
 		String finalHtml = htmlString.replace("\"", "\\\"").replace("\\\\\"", "\\\"");
+		finalHtml = finalHtml.replace("</script>", "<\\/script>");	// fix to satisfy broken browser parsing
 		bw.write("(function() {\n");
     		bw.write("var htmlContent = \"" + finalHtml + "\"\n");
     		bw.write("var embedDiv = document.getElementById(\"NGCHMEmbed\");\n");


### PR DESCRIPTION
This re-adds the one-line fix that didn't get pulled from 2.22.2 to main.  (My mistake.)  The 2.22.2 commit could not be merged or cherry-picked without conflicts due to main's extensive changes.  

I also introduced version 2.23.0 indicating a development version, as we agreed to increment the number with each interim version.