### PR TITLE
BUGFIX: Detect subDendroMode again

### DIFF
--- a/NGCHM/WebContent/javascript/Dendrogram.js
+++ b/NGCHM/WebContent/javascript/Dendrogram.js
@@ -545,6 +545,7 @@ DDR.SummaryDendrogram = function(config, data, numLeaves) {
 	this.clearRibbonMode = function() {
 		this.ribbonModeBar = -1;
 		if (DMM.primaryMap) {
+		    DMM.primaryMap.subDendroMode = 'none';
 		    DMM.primaryMap.selectedStart = 0;
 		    DMM.primaryMap.selectedStop = 0;
 		}
@@ -563,6 +564,8 @@ DDR.SummaryDendrogram = function(config, data, numLeaves) {
 			// Clear any previous ribbon mode on either axis.
 			SUM.rowDendro.clearRibbonMode();
 			SUM.colDendro.clearRibbonMode();
+
+			if (DMM.primaryMap) DMM.primaryMap.subDendroMode = this.axis;
 
 			this.clearSelectionMarks();
 			SRCH.clearSearchItems(this.axis);

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -768,7 +768,19 @@ DEV.detailDataZoomIn = function (mapItem) {
 			DEV.detailNormal (mapItem);
 		} else {
 			let current = DET.zoomBoxSizes.indexOf(mapItem.dataBoxHeight);
-			if (current < DET.zoomBoxSizes.length - 1) {
+			if (current == -1) {
+			    //On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
+			    const heatMap = MMGR.getHeatMap();
+			    mapItem.dataBoxHeight = DET.zoomBoxSizes[0];
+			    mapItem.dataViewHeight = DET.SIZE_NORMAL_MODE;
+			    while (Math.floor((mapItem.dataViewHeight-DET.dataViewBorder)/DET.zoomBoxSizes[DET.zoomBoxSizes.indexOf(mapItem.dataBoxHeight)]) >= heatMap.getNumRows(MMGR.DETAIL_LEVEL)) {
+				DET.setDetailDataHeight(mapItem,DET.zoomBoxSizes[DET.zoomBoxSizes.indexOf(mapItem.dataBoxHeight)+1]);
+			    }
+			    mapItem.canvas.width =  (mapItem.dataViewWidth + DET.calculateTotalClassBarHeight("row"));
+			    mapItem.canvas.height = (mapItem.dataViewHeight + DET.calculateTotalClassBarHeight("column"));
+
+			    DET.detInitGl(mapItem);
+			} else if (current < DET.zoomBoxSizes.length - 1) {
 				DET.setDetailDataHeight (mapItem,DET.zoomBoxSizes[current+1]);
 			}
 			SEL.updateSelection(mapItem, false);
@@ -786,8 +798,20 @@ DEV.detailDataZoomIn = function (mapItem) {
 			DEV.detailNormal (mapItem);
 		} else {
 			let current = DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth);
-			if (current < DET.zoomBoxSizes.length - 1) {
-				DET.setDetailDataWidth(mapItem,DET.zoomBoxSizes[current+1]);
+			if (current == -1) {
+			    //On some maps, one view (e.g. ribbon view) can show bigger data areas than will fit for other view modes.  If so, zoom back out to find a workable zoom level.
+			    const heatMap = MMGR.getHeatMap();
+			    mapItem.dataBoxWidth = DET.zoomBoxSizes[0];
+			    mapItem.dataViewWidth = DET.SIZE_NORMAL_MODE;
+			    while (Math.floor((mapItem.dataViewWidth-DET.dataViewBorder)/DET.zoomBoxSizes[DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth)]) >= heatMap.getNumColumns(MMGR.DETAIL_LEVEL)) {
+				DET.setDetailDataWidth(mapItem,DET.zoomBoxSizes[DET.zoomBoxSizes.indexOf(mapItem.dataBoxWidth)+1]);
+			    }
+			    mapItem.canvas.width =  (mapItem.dataViewWidth + DET.calculateTotalClassBarHeight("row"));
+			    mapItem.canvas.height = (mapItem.dataViewHeight + DET.calculateTotalClassBarHeight("column"));
+
+			    DET.detInitGl(mapItem);
+			} else if (current < DET.zoomBoxSizes.length - 1) {
+			    DET.setDetailDataWidth(mapItem,DET.zoomBoxSizes[current+1]);
 			}
 			SEL.updateSelection(mapItem, false);
 		}

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -947,9 +947,9 @@ DEV.detailFullMap = function (mapItem) {
 	
 	//For maps that have less rows/columns than the size of the detail panel, matrix elements get height / width more 
 	//than 1 pixel, scale calculates the appropriate height/width.
-	if (DDR.subDendroView === 'column') {
+	if (mapItem.subDendroMode === 'Column') {
 	    DET.scaleViewHeight(mapItem);
-	} else if (DDR.subDendroView === 'row') {
+	} else if (mapItem.subDendroMode === 'Row') {
 	    DET.scaleViewWidth(mapItem);
 	} else {
 	    SEL.setMode(mapItem, 'FULL_MAP');

--- a/NGCHM/WebContent/javascript/DetailHeatMapManager.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapManager.js
@@ -27,7 +27,7 @@ DMM.mapTemplate = {
 	  saveRow: null, saveCol: null, dataBoxHeight: null, dataBoxWidth: null, rowDendro: null, colDendro: null, dendroHeight: 105, dendroWidth: 105, dataViewHeight: 506,
 	  dataViewWidth: 506, minLabelSize: 5, labelLastClicked: {}, dragOffsetX: null, dragOffsetY: null, rowLabelLen: 0, colLabelLen: 0,
 	  rowLabelFont: 0, colLabelFont: 0,colClassLabelFont: 0, rowClassLabelFont: 0, labelElements: {}, oldLabelElements: {}, tmpLabelSizeElements: [], 
-	  labelSizeWidthCalcPool: [], labelSizeCache: {},zoomOutNormal: null, zoomOutPos: null
+	  labelSizeWidthCalcPool: [], labelSizeCache: {},zoomOutNormal: null, zoomOutPos: null, subDendroMode: 'none'
 } 
 
 /*********************************************************************************************


### PR DESCRIPTION
This is a start towards fixing a bug that was made in commit c5f05b5bcca9a on 2019-07-11.  The code was committed by Mark Stucky but it was my code. (At this time, Mark was collecting all the patches etc. and then committing them to github in batches.)

The commit concerned was when I totally rewrote the dendrogram code.

The previous code was setting the 'DDR.subDendroMode' global variable to row or column if the user clicked on a summary view dendrogram branch. The replacement code never set the variable.

The variable has been tested in DetailHeatMapDisplay ever since, failing every time.  The test is supposed to select row or column scaling on one axis only when the user zooms all the way out in subDendro mode. It wasn't. (Both axes were being scaled, as when zooming all the way out in normal mode.)

This patch does reenable that feature.  However, it does not properly reset the scaling when the user subsequently zooms in again.