### PR TITLE
Restructure part 3

### DIFF
--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -269,20 +269,16 @@
     // Load the user's custom.js file.
     CUST.addCustomJS = function() {
 	const heatMap = MMGR.getHeatMap();
-	if (heatMap.isInitialized()){
 		CUST.beforeLoadCustom(heatMap);
 	    var head = document.getElementsByTagName('head')[0];
 	    var script = document.createElement('script');
-	    head.appendChild(script);
 	    script.type = 'text/javascript';
 	    script.src = CFG.custom_script;
         // Most browsers:   NOTE: The next 2 lines of code are replaced when building ngchmApp.html and ngchmWidget-min.js (the "file mode" and "widget" versions of the application)
         script.onload = CUST.definePluginLinkouts;
         // Internet explorer:
         script.onreadystatechange = function() { if (this.readyState == 'complete') {     	CUST.definePluginLinkouts();   }   };  //Leave this as one line for filemode version app builder
-	} else {
-	    setTimeout(function(){ CUST.addCustomJS();}, 100);
-	}
+	head.appendChild(script);
     };
     
     // Interface accessible to embedded maps that specify a custom js file 

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -28,7 +28,6 @@ DET.maxLabelSize = 11;
 DET.redrawSelectionTimeout = 0;   // Drawing delay in ms after the view has changed.
 DET.redrawUpdateTimeout = 10;	// Drawing delay in ms after a tile update (if needed).
 DET.minPixelsForGrid = 20;	// minimum element size for grid lines to display
-DET.detailPoint = null;
 DET.animating = false;
 
 //We keep a copy of the last rendered detail heat map for each layer.

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -27,7 +27,6 @@
     const SUM = NgChm.importNS('NgChm.SUM');
     const DMM = NgChm.importNS('NgChm.DMM');
     const DET = NgChm.importNS('NgChm.DET');
-    const DEV = NgChm.importNS('NgChm.DEV');
     const SRCH = NgChm.importNS('NgChm.SRCH');
     const COMPAT = NgChm.importNS('NgChm.CM');
 
@@ -1322,7 +1321,6 @@ MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 			SEL.currentCol = Number(UTIL.getURLParameter("column"))
 		}
 	        SEL.setSelectionColors();
-		document.addEventListener("keydown", DEV.keyNavigate);
 
 		addDataLayers(mc);
 	}

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -675,7 +675,7 @@ MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 		UHM.initMessageBox();
 		if (fileSrc === MMGR.WEB_SOURCE) {
 			success = zipMapProperties(JSON.stringify(mapConfig)); 
-			UHM.zipSaveNotification(false);
+			zipSaveNotification(false);
 		} else {
 			let waitForPluginDataCount = 0;
 			let awaitingPluginData = setInterval(function() {
@@ -686,7 +686,7 @@ MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 					clearInterval(awaitingPluginData);
 				}
 			}, 1000);
-			UHM.zipSaveNotification(false);
+			zipSaveNotification(false);
 		}
 		MMGR.getHeatMap().setUnAppliedChanges(false);
 	}
@@ -699,7 +699,7 @@ MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 			if (fileSrc !== MMGR.FILE_SOURCE) {
 				success = webSaveMapProperties(JSON.stringify(mapConfig)); 
 			} else if (MMGR.embeddedMapName === null) {
-				UHM.zipSaveNotification(true);
+				zipSaveNotification(true);
 			}
 		}
 		return success;
@@ -1636,7 +1636,7 @@ MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 		        	var latestVersion = req.response;
 				// FIXME.
 				if ((latestVersion > COMPAT.version) && (typeof NgChm.galaxy === 'undefined') && (MMGR.embeddedMapName === null) && (fileSrc == MMGR.WEB_SOURCE)) {
-				    UHM.viewerAppVersionExpiredNotification(COMPAT.version, latestVersion);
+				    viewerAppVersionExpiredNotification(COMPAT.version, latestVersion);
 		        	}
 			    } 
 			}
@@ -1831,6 +1831,51 @@ MMGR.HeatMapData = function(heatMapName, level, jsonData, datalayers, lowerLevel
 	    return text;
     };
 
+    /**********************************************************************************
+     * FUNCTION - zipSaveNotification: This function handles all of the tasks necessary
+     * display a modal window whenever a zip file is being saved. The textId passed in
+     * instructs the code to display either the startup save OR preferences save message.
+     **********************************************************************************/
+    function zipSaveNotification (autoSave) {
+	    var text;
+	    UHM.initMessageBox();
+	    UHM.setMessageBoxHeader("NG-CHM File Viewer");
+	    if (autoSave) {
+		    text = "<br>This NG-CHM archive file contains an out dated heat map configuration that has been updated locally to be compatible with the latest version of the NG-CHM Viewer.<br><br>In order to upgrade the NG-CHM and avoid this notice in the future, you will want to replace your original file with the version now being displayed.<br><br>";
+		    UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save NG-CHM button", MMGR.getHeatMap().zipSaveNgchm);
+	    } else {
+		    text = "<br>You have just saved a heat map as a NG-CHM file.  In order to see your saved changes, you will want to open this new file using the NG-CHM File Viewer application.  If you have not already downloaded the application, press the Download Viewer button to get the latest version.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>" 
+		    UHM.setMessageBoxButton(1, "images/downloadViewer.png", "Download NG-CHM Viewer App", zipAppDownload);
+	    }
+	    UHM.setMessageBoxText(text);
+	    UHM.setMessageBoxButton(3, UTIL.imageTable.cancelSmall, "Cancel button", UHM.messageBoxCancel);
+	    UHM.displayMessageBox();
+    }
+
+    /**********************************************************************************
+     * FUNCTION - zipAppDownload: This function calls the Matrix Manager to initiate
+     * the download of the NG-CHM File Viewer application.
+     **********************************************************************************/
+    function zipAppDownload () {
+	    var dlButton = document.getElementById('msgBoxBtnImg_1');
+	    dlButton.style.display = 'none';
+	    MMGR.getHeatMap().downloadFileApplication();
+    }
+
+    /**********************************************************************************
+     * FUNCTION - viewerAppVersionExpiredNotification: This function handles all of the tasks
+     * necessary display a modal window whenever a user's version of the file application
+     * has been superceded and a new version of the file application should be downloaded.
+     **********************************************************************************/
+    function viewerAppVersionExpiredNotification (oldVersion, newVersion) {
+	    UHM.initMessageBox();
+	    UHM.setMessageBoxHeader("New NG-CHM File Viewer Version Available");
+	    UHM.setMessageBoxText("<br>The version of the NG-CHM File Viewer application that you are running ("+oldVersion+") has been superceded by a newer version ("+newVersion+"). You will be able to view all pre-existing heat maps with this new backward-compatible version. However, you may wish to download the latest version of the viewer.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>");
+	    UHM.setMessageBoxButton(1, "images/downloadViewer.png", "Download NG-CHM Viewer App", zipAppDownload);
+	    UHM.setMessageBoxButton(3, UTIL.imageTable.closeButton, "Cancel button", UHM.messageBoxCancel);
+	    UHM.displayMessageBox();
+    }
+
 /**********************************************************************************
  * Perform Early Initializations.
  *
@@ -1841,5 +1886,11 @@ MMGR.HeatMapData = function(heatMapName, level, jsonData, datalayers, lowerLevel
 if (MMGR.embeddedMapName === null && (UTIL.mapId !== '' || UTIL.mapNameRef !== '')) {
 	MMGR.createWebLoader(MMGR.WEB_SOURCE);
 }
+
+// Special tooltip with content populated from the loaded heat map.
+document.getElementById('mapName').addEventListener('mouseover', (ev) => {
+    const heatMap = MMGR.getHeatMap();
+    UHM.hlp(ev.target,"Map Name: " + (heatMap !== null ? heatMap.getMapInformation().name : "Not yet available") + "<br><br>Description: " + (heatMap !== null ? heatMap.getMapInformation().description : "N/A"),350);
+}, { passive: true });
 
 })();

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -30,7 +30,6 @@
     const DEV = NgChm.importNS('NgChm.DEV');
     const SRCH = NgChm.importNS('NgChm.SRCH');
     const COMPAT = NgChm.importNS('NgChm.CM');
-    const CUST = NgChm.importNS('NgChm.CUST');
 
 //For web-based NGCHMs, we will create a Worker process to overlap I/O and computation.
 MMGR.webLoader = null;
@@ -1312,8 +1311,6 @@ MMGR.HeatMap = function(heatMapName, updateCallbacks, fileSrc, chmFile) {
 		COMPAT.CompatibilityManager(mc);
 		mapConfig = mc;
 		sendCallBack(MMGR.Event_JSON);
-
-		CUST.addCustomJS();
 
 		// set the position to (1,1) so that the detail pane loads at the top left corner of the summary.
 		SEL.currentRow = 1;

--- a/NGCHM/WebContent/javascript/SearchManager.js
+++ b/NGCHM/WebContent/javascript/SearchManager.js
@@ -884,17 +884,17 @@
 	if (currentSearchItem.axis == "Row") {
 		mapItem.currentRow = currentSearchItem.index;
 		if ((mapItem.mode == 'RIBBONV') && mapItem.selectedStart!= 0 && (mapItem.currentRow < mapItem.selectedStart-1 || mapItem.selectedStop-1 < mapItem.currentRow)){
-			UHM.showSearchError(1);
+			showSearchError(1);
 		} else if (mapItem.mode == 'RIBBONV' && mapItem.selectedStart == 0){
-			UHM.showSearchError(2);
+			showSearchError(2);
 		} 
 		SEL.checkRow(mapItem);
 	} else if (currentSearchItem.axis == "Column"){
 		mapItem.currentCol = currentSearchItem.index;
 		if ((mapItem.mode == 'RIBBONH') && mapItem.selectedStart!= 0 && (mapItem.currentCol < mapItem.selectedStart-1 || mapItem.selectedStop-1 < mapItem.currentCol )){
-			UHM.showSearchError(1)
+			showSearchError(1)
 		} else if (mapItem.mode == 'RIBBONH' && mapItem.selectedStart == 0){
-			UHM.showSearchError(2);
+			showSearchError(2);
 		} 
 		SEL.checkCol(mapItem);
 	}
@@ -1066,6 +1066,25 @@
         const rowCount = SRCH.getAxisSearchResults("Row").length;
         const colCount = SRCH.getAxisSearchResults("Column").length;
 	return [ rowCount, colCount, rowCount+colCount ];
+    }
+
+    function showSearchError (type) {
+	    var searchError = UHM.getDivElement('searchError');
+	    searchError.style.display = 'inherit';
+	    var searchBar = document.getElementById('search_text');
+	    searchError.style.top = (searchBar.offsetTop + searchBar.offsetHeight) + 'px';
+	    searchError.style.left = (searchBar.offsetLeft + searchBar.offsetWidth) + 'px';
+	    const searchItem = SRCH.getCurrentSearchItem();
+	    switch (type){
+		    case 0: searchError.innerHTML = "No matching labels found"; break;
+		    case 1: searchError.innerHTML = "Exit dendrogram selection to go to " + searchItem.label;break;
+		    case 2: searchError.innerHTML = "All " + searchItem.axis +  " items are visible. Change the view mode to see " + searchItem.label;break;
+	    }
+	    UHM.hlpC();
+	    document.body.appendChild(searchError);
+	    setTimeout(function(){
+		    searchError.remove();
+	    }, 2000);
     }
 
 /***********************************************************

--- a/NGCHM/WebContent/javascript/SelectionManager.js
+++ b/NGCHM/WebContent/javascript/SelectionManager.js
@@ -437,4 +437,12 @@ SEL.flickInit = function() {
 	}
 }
 
+    document.getElementById('fileOpen_btn').onclick = () => {
+	SEL.openFileToggle();
+    };
+
+    document.getElementById('flickOff').onclick = () => {
+	SEL.flickToggleOn();
+    };
+
 })();

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -67,6 +67,7 @@
 		return;
 	    }
 	    CUST.addCustomJS();
+	    document.addEventListener ("keydown", DEV.keyNavigate);
 		if (MMGR.source === MMGR.FILE_SOURCE) {
 			firstTime = true;
 			if (SUM.chmElement) {

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -22,6 +22,7 @@
     const SRCH = NgChm.importNS('NgChm.SRCH');
     const DRAW = NgChm.importNS('NgChm.DRAW');
     const RECPANES = NgChm.importNS('NgChm.RecPanes');
+    const CUST = NgChm.importNS('NgChm.CUST');
 
     /**********************************************************************************
      * FUNCTION - redrawCanvases: The purpose of this function is to redraw the various
@@ -65,6 +66,7 @@
 	    if (event !== MMGR.Event_INITIALIZED) {
 		return;
 	    }
+	    CUST.addCustomJS();
 		if (MMGR.source === MMGR.FILE_SOURCE) {
 			firstTime = true;
 			if (SUM.chmElement) {

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -9,86 +9,22 @@
     //Define Namespace for NgChm UserHelpManager
     const UHM = NgChm.createNS('NgChm.UHM');
 
-    const MMGR = NgChm.importNS('NgChm.MMGR');
     const UTIL = NgChm.importNS('NgChm.UTIL');
-    const SEL = NgChm.importNS('NgChm.SEL');
-    const DET = NgChm.importNS('NgChm.DET');
-    const SUM = NgChm.importNS('NgChm.SUM');
-    const DMM = NgChm.importNS('NgChm.DMM');
-    const SRCH = NgChm.importNS('NgChm.SRCH');
-    const CUST = NgChm.importNS('NgChm.CUST');
-    const UIMGR = NgChm.importNS('NgChm.UI-Manager');
-    const COMPAT = NgChm.importNS('NgChm.CM');
 
     UHM.postMapDetails = false;	// Should we post map details to an enclosing document?
     UHM.postMapToWhom = null;		// Identity of the window to post map details to
     UHM.myNonce = 'N';			// Shared secret for vetting message sender
+
+    var popupTimeoutId = undefined;	// Timeout for displaying a pending popup window.
 
 // Define action handlers for static UHM UI elements.
 //
 (function () {
     let uiElement;
 
-    const aboutMenu = document.getElementById('aboutMenu_btn');
-    aboutMenu.onclick = (ev) => {
-	UHM.widgetHelp();
-    };
-
     uiElement = document.getElementById('messageOpen_btn');
     uiElement.onclick = () => {
 	UHM.displayStartupWarnings();
-    };
-
-    // Special tooltip with content populated from the loaded heat map.
-    uiElement = document.getElementById('mapName');
-    uiElement.addEventListener('mouseover', (ev) => {
-	const heatMap = MMGR.getHeatMap();
-	UHM.hlp(ev.target,"Map Name: " + (heatMap !== null ? heatMap.getMapInformation().name : "Not yet available") + "<br><br>Description: " + (heatMap !== null ? heatMap.getMapInformation().description : "N/A"),350);
-    }, { passive: true });
-
-    uiElement = document.getElementById('fileOpen_btn');
-    uiElement.onclick = () => {
-	SEL.openFileToggle();
-    };
-
-    uiElement = document.getElementById('flickOff');
-    uiElement.onclick = () => {
-	SEL.flickToggleOn();
-    };
-
-    uiElement = document.getElementById('mapLinks_btn');
-    uiElement.onclick = () => {
-	UHM.showMapPlugins();
-    };
-
-    uiElement = document.getElementById('allLinks_btn');
-    uiElement.onclick = () => {
-	UHM.showAllPlugins();
-    };
-
-    uiElement = document.getElementById('linkBoxFootCloseButton');
-    uiElement.onclick = () => {
-	UHM.linkBoxCancel();
-    };
-
-    uiElement = document.getElementById('menuSave');
-    uiElement.onclick = () => {
-	UHM.saveHeatMapChanges();
-    };
-
-    uiElement = document.getElementById('menuLink');
-    uiElement.onclick = () => {
-	UHM.openLinkoutHelp();
-    };
-
-    uiElement = document.getElementById('menuHelp');
-    uiElement.onclick = () => {
-	UHM.openHelp(this);
-    };
-
-    uiElement = document.getElementById('menuAbout');
-    uiElement.onclick = () => {
-	UHM.widgetHelp();
     };
 
 })();
@@ -200,339 +136,42 @@ UHM.formatMapDetails = function (helpContents, pixelInfo) {
 }
 
 /**********************************************************************************
- * FUNCTION - userHelpOpen: This function handles all of the tasks necessary to 
- * generate help pop-up panels for the detail heat map and the detail heat map 
- * classification bars.  
- *********************************************************************************/
-UHM.userHelpOpen = function(mapItem) {
-	const heatMap = MMGR.getHeatMap();
-	UHM.hlpC();
-    clearTimeout(DET.detailPoint);
-	var helpContents = document.createElement("TABLE");
-	helpContents.id = 'helpTable';
-    var orgW = window.innerWidth+window.pageXOffset;
-    var orgH = window.innerHeight+window.pageYOffset;
-    var helptext = UHM.getDivElement("helptext");
-    helptext.innerHTML=("<a align='left'>Copy To Clipboard</a><img id='redX_btn' src='images/redX.png' alt='Close Help' align='right'>");
-    helptext.children[0].onclick = pasteHelpContents;  // The <A> element.
-    helptext.onclick = function(event) { UHM.hlpC(); };
-    helptext.style.position = "absolute";
-    document.getElementsByTagName('body')[0].appendChild(helptext);
-    var rowElementSize = mapItem.dataBoxWidth * mapItem.canvas.clientWidth/mapItem.canvas.width; // px/Glpoint
-    var colElementSize = mapItem.dataBoxHeight * mapItem.canvas.clientHeight/mapItem.canvas.height;
-
-    // pixels
-    var rowClassWidthPx = DET.getRowClassPixelWidth(mapItem);
-    var colClassHeightPx = DET.getColClassPixelHeight(mapItem);
-	var mapLocY = mapItem.offsetY - colClassHeightPx;
-	var mapLocX = mapItem.offsetX - rowClassWidthPx;
-	var objectType = "none";
-    if (mapItem.offsetY > colClassHeightPx) { 
-    	if  (mapItem.offsetX > rowClassWidthPx) {
-    		objectType = "map";
-    	}
-    	if  (mapItem.offsetX < rowClassWidthPx) {
-    		objectType = "rowClass";
-    	}
-    } else {
-    	if  (mapItem.offsetX > rowClassWidthPx) {
-    		objectType = "colClass";
-    	}
-    }
-    if (objectType === "map") {
-	var row = Math.floor(mapItem.currentRow + (mapLocY/colElementSize)*SEL.getSamplingRatio('row'));
-	var col = Math.floor(mapItem.currentCol + (mapLocX/rowElementSize)*SEL.getSamplingRatio('col'));
-	if ((row <= heatMap.getNumRows('d')) && (col <= heatMap.getNumColumns('d'))) {
-		// Gather the information about the current pixel.
-		let matrixValue = heatMap.getValue(MMGR.DETAIL_LEVEL,row,col);
-		if (matrixValue >= MMGR.maxValues) {
-	    		matrixValue = "Missing Value";
-		} else if (matrixValue <= MMGR.minValues) {
-			return; // A gap.
-	    	} else {
-	    		matrixValue = matrixValue.toFixed(5);
-	    	}
-		if (DMM.primaryMap.mode === 'FULL_MAP') {
-	    		matrixValue = matrixValue + "<br>(summarized)";
-	    	}
-
-		const rowLabels = heatMap.getRowLabels().labels;
-		const colLabels = heatMap.getColLabels().labels;
-		const pixelInfo = {
-			value: matrixValue,
-			rowLabel: rowLabels[row-1],
-			colLabel: colLabels[col-1]
-		};
-		const rowClassBars = heatMap.getRowClassificationData();
-		const rowClassConfig = heatMap.getRowClassificationConfig();
-		pixelInfo.rowCovariates = heatMap
-			.getRowClassificationOrder()
-			.filter(key => rowClassConfig[key].show === 'Y')
-			.map(key => ({
-				name: key,
-				value: rowClassBars[key].values[row-1]
-			}));
-		const colClassBars = heatMap.getColClassificationData();
-		const colClassConfig = heatMap.getColClassificationConfig();
-		pixelInfo.colCovariates = heatMap
-			.getColClassificationOrder()
-			.filter(key => colClassConfig[key].show === 'Y')
-			.map(key => ({
-				name: key,
-				value: colClassBars[key].values[col-1]
-			}));
-
-		// If the enclosing window wants to display the pixel info, send it to them.
-		// Otherwise, display it ourselves.
-        if (UHM.postMapDetails) {
-			var msg = { nonce: UHM.myNonce, msg: 'ShowMapDetail', data: pixelInfo };
-			//If a unique identifier was provided, return it in the message.
-			if (UHM.postID != null) {
-				msg["id"] = UHM.postID;
-			} 
-
-			window.parent.postMessage (msg, UHM.postMapToWhom);
-        } else {
-			UHM.formatMapDetails (helpContents, pixelInfo);
-			helptext.style.display="inline";
-			helptext.appendChild(helpContents);
-			UHM.locateHelpBox(helptext,mapItem);
-		}
-    	}
-    } else if ((objectType === "rowClass") || (objectType === "colClass")) {
-    	var pos, value, label;
-	var hoveredBar, hoveredBarColorScheme, hoveredBarValues;
-    	if (objectType === "colClass") {
-		var col = Math.floor(mapItem.currentCol + (mapLocX/rowElementSize)*SEL.getSamplingRatio('col'));
-		var colLabels = heatMap.getColLabels().labels;
-        	label = colLabels[col-1];
-    		var coveredHeight = 0;
-    		pos = Math.floor(mapItem.currentCol + (mapLocX/rowElementSize));
-		var classBarsConfig = heatMap.getColClassificationConfig();
-		var classBarsConfigOrder = heatMap.getColClassificationOrder();
-			for (var i = 0; i <  classBarsConfigOrder.length; i++) {
-				var key = classBarsConfigOrder[i];
-    			var currentBar = classBarsConfig[key];
-    			if (currentBar.show === 'Y') {
-	        		coveredHeight += mapItem.canvas.clientHeight*currentBar.height/mapItem.canvas.height;
-	        		if (coveredHeight >= mapItem.offsetY) {
-	        			hoveredBar = key;
-					hoveredBarValues = heatMap.getColClassificationData()[key].values;
-	        			break;
-	        		}
-    			}
-    		}
-		var colorMap = heatMap.getColorMapManager().getColorMap("col",hoveredBar);
-    	} else {
-		var row = Math.floor(mapItem.currentRow + (mapLocY/colElementSize)*SEL.getSamplingRatio('row'));
-		var rowLabels = heatMap.getRowLabels().labels;
-        	label = rowLabels[row-1];
-    		var coveredWidth = 0;
-    		pos = Math.floor(mapItem.currentRow + (mapLocY/colElementSize));
-		var classBarsConfig = heatMap.getRowClassificationConfig();
-		var classBarsConfigOrder = heatMap.getRowClassificationOrder();
-			for (var i = 0; i <  classBarsConfigOrder.length; i++) {
-				var key = classBarsConfigOrder[i];
-				var currentBar = classBarsConfig[key];
-    			if (currentBar.show === 'Y') {
-	        		coveredWidth += mapItem.canvas.clientWidth*currentBar.height/mapItem.canvas.width;
-	        		if (coveredWidth >= mapItem.offsetX){
-	        			hoveredBar = key;
-					hoveredBarValues = heatMap.getRowClassificationData()[key].values;
-	        			break;
-	        		}
-    			}
-    		}
-		var colorMap = heatMap.getColorMapManager().getColorMap("row",hoveredBar);
-    	}
-    	var value = hoveredBarValues[pos-1];
-    	//No help popup when clicking on a gap in the class bar
-    	if (value === '!CUT!') {
-    		return;
-    	}
-    	var colors = colorMap.getColors();
-    	var classType = colorMap.getType();
-    	if ((value === 'null') || (value === 'NA')) {
-        	value = "Missing Value";
-    	}
-    	var thresholds = colorMap.getThresholds();
-    	var thresholdSize = 0;
-    	// For Continuous Classifications: 
-    	// 1. Retrieve continuous threshold array from colorMapManager
-    	// 2. Retrieve threshold range size divided by 2 (1/2 range size)
-    	// 3. If remainder of half range > .75 set threshold value up to next value, Else use floor value.
-    	if (classType == 'continuous') {
-    		thresholds = colorMap.getContinuousThresholdKeys();
-    		var threshSize = colorMap.getContinuousThresholdKeySize()/2;
-    		if ((threshSize%1) > .5) {
-    			// Used to calculate modified threshold size for all but first and last threshold
-    			// This modified value will be used for color and display later.
-    			thresholdSize = Math.floor(threshSize)+1;
-    		} else {
-    			thresholdSize = Math.floor(threshSize);
-    		}
-    	}
-    	
-    	// Build TABLE HTML for contents of help box
-		var displayName = hoveredBar;
-		if (hoveredBar.length > 20){
-			displayName = displayName.substring(0,20) + "...";
-		}
-		UHM.setTableRow(helpContents, ["Label: ", "&nbsp;"+label]);
-		UHM.setTableRow(helpContents, ["Covariate: ", "&nbsp;"+displayName]);
-		UHM.setTableRow(helpContents, ["Value: ", "&nbsp;"+value]);
-		helpContents.insertRow().innerHTML = UHM.formatBlankRow();
-    	var rowCtr = 3 + thresholds.length;
-    	var prevThresh = currThresh;
-    	for (var i = 0; i < thresholds.length; i++){ // generate the color scheme diagram
-        	var color = colors[i];
-        	var valSelected = 0;
-        	var valTotal = hoveredBarValues.length;
-        	var currThresh = thresholds[i];
-        	var modThresh = currThresh;
-        	if (classType == 'continuous') {
-        		// IF threshold not first or last, the modified threshold is set to the threshold value 
-        		// less 1/2 of the threshold range ELSE the modified threshold is set to the threshold value.
-        		if ((i != 0) &&  (i != thresholds.length - 1)) {
-        			modThresh = currThresh - thresholdSize;
-        		}
-				color = colorMap.getRgbToHex(colorMap.getClassificationColor(modThresh));
-        	}
-        	
-        	//Count classification value occurrences within each breakpoint.
-        	for (var j = 0; j < valTotal; j++) {
-			let classBarVal = hoveredBarValues[j];
-        		if (classType == 'continuous') {
-            		// Count based upon location in threshold array
-            		// 1. For first threshhold, count those values <= threshold.
-            		// 2. For second threshold, count those values >= threshold.
-            		// 3. For penultimate threshhold, count those values > previous threshold AND values < final threshold.
-            		// 3. For all others, count those values > previous threshold AND values <= final threshold.
-        			if (i == 0) {
-						if (classBarVal <= currThresh) {
-       						valSelected++;
-						}
-        			} else if (i == thresholds.length - 1) {
-        				if (classBarVal >= currThresh) {
-        					valSelected++;
-        				}
-        			} else if (i == thresholds.length - 2) {
-		        		if ((classBarVal > prevThresh) && (classBarVal < currThresh)) {
-		        			valSelected++;
-		        		}
-        			} else {
-		        		if ((classBarVal > prevThresh) && (classBarVal <= currThresh)) {
-		        			valSelected++;
-		        		}
-        			}
-        		} else {
-                	var value = thresholds[i];
-	        		if (classBarVal == value) {
-	        			valSelected++;
-	        		}
-        		}
-        	}
-        	var selPct = Math.round(((valSelected / valTotal) * 100) * 100) / 100;  //new line
-        	if (currentBar.bar_type === 'color_plot') {
-		    UHM.setTableRow(helpContents, ["<div class='input-color'><div class='color-box' style='background-color: " + color + ";'></div></div>", modThresh + " (n = " + valSelected + ", " + selPct+ "%)"]);
-        	} else {
-		    UHM.setTableRow(helpContents, ["<div> </div></div>", modThresh + " (n = " + valSelected + ", " + selPct+ "%)"]);
-        	}
-        	prevThresh = currThresh;
-    	}
-    	var valSelected = 0;  
-    	var valTotal = hoveredBarValues.length; 
-    	for (var j = 0; j < valTotal; j++) { 
-    		if ((hoveredBarValues[j] == "null") || (hoveredBarValues[j] == "NA")) { 
-    			valSelected++;  
-    		} 
-    	} 
-    	var selPct = Math.round(((valSelected / valTotal) * 100) * 100) / 100;  //new line
-    	if (currentBar.bar_type === 'color_plot') {
-			UHM.setTableRow(helpContents, ["<div class='input-color'><div class='color-box' style='background-color: " +  colorMap.getMissingColor() + ";'></div></div>", "Missing Color (n = " + valSelected + ", " + selPct+ "%)"]);
-    	} else {
-			UHM.setTableRow(helpContents, ["<div> </div></div>", "Missing Color (n = " + valSelected + ", " + selPct+ "%)"]);
-    	}
-    	
-		// If the enclosing window wants to display the covarate info, send it to them.
-		// Otherwise, display it ourselves.
-        if (UHM.postMapDetails) {
-			var msg = { nonce: UHM.myNonce, msg: 'ShowCovarDetail', data: helpContents.innerHTML };
-			//If a unique identifier was provided, return it in the message.
-			if (UHM.postID != null) {
-				msg["id"] = UHM.postID;
-			} 
-
-			window.parent.postMessage (msg, UHM.postMapToWhom);
-        } else {
-        	helptext.style.display="inline";
-        	helptext.appendChild(helpContents);
-		UHM.locateHelpBox(helptext,mapItem);
-        }	
-    } else {  
-    	// on the blank area in the top left corner
-    }
-    UIMGR.redrawCanvases();
-}
-
-/**********************************************************************************
  * FUNCTION - pasteHelpContents: This function opens a browser window and pastes
  * the contents of the user help panel into the window.  
  **********************************************************************************/
+UHM.pasteHelpContents = pasteHelpContents;
 function pasteHelpContents() {
     var el = document.getElementById('helpTable')
     window.open("","",'width=500,height=330,resizable=1').document.write(el.innerText.replace(/(\r\n|\n|\r)/gm, "<br>"));
 }
 
-/**********************************************************************************
- * FUNCTION - locateHelpBox: This function determines and sets the location of a
- * popup help box.  
- **********************************************************************************/
-UHM.locateHelpBox = function(helptext,mapItem) {
-    var rowClassWidthPx = DET.getRowClassPixelWidth(mapItem);
-    var colClassHeightPx = DET.getColClassPixelHeight(mapItem);
-	var mapLocY = mapItem.offsetY - colClassHeightPx;
-	var mapLocX = mapItem.offsetX - rowClassWidthPx;
-	var mapH = mapItem.canvas.clientHeight - colClassHeightPx;
-	var mapW = mapItem.canvas.clientWidth - rowClassWidthPx;
-	var boxLeft = mapItem.pageX;
-	if (mapLocX > (mapW / 2)) {
-		boxLeft = mapItem.pageX - helptext.clientWidth - 10;
-	}
-	helptext.style.left = boxLeft + 'px';
-	var boxTop = mapItem.pageY;
-	if ((boxTop+helptext.clientHeight) > mapItem.canvas.clientHeight + 90) {
-		if (helptext.clientHeight > mapItem.pageY) {
-			boxTop = mapItem.pageY - (helptext.clientHeight/2);
-		} else {
-			boxTop = mapItem.pageY - helptext.clientHeight;
-		}
-	}
-	//Keep box from going off top of screen so data values always visible.
-	if (boxTop < 0) {
-		boxTop = 0;
-	}
-	helptext.style.top = boxTop + 'px';
-}
-
 
 /**********************************************************************************
  * FUNCTION - hlp: The purpose of this function is to generate a 
- * pop-up help panel for the tool buttons at the top of the detail pane. It receives
- * text from chm.html. 
+ * pop-up help panel (tooltip) for the specified user interface element.
+ * The popup title, if any, will be obtained from the element's title dataset property.
+ * The popup text will be obtained from the element's intro dataset property,
+ * if it exists, or from the text parameter.
+ * Normally the tooltip is displayed just below the top-left corner of the element.
+ * If reverse is specified, the tooltip will be positioned width pixels to the
+ * left of the default position.
+ * The tooltip will appear delay milliseconds after this function is called unless
+ * the user does something to clear the pending popup (e.g. move the mouse, press a key).
  **********************************************************************************/
-UHM.hlp = function(e, text, width, reverse, delay=1500) {
+UHM.hlp = function(element, text, width, reverse, delay=1500) {
 	UHM.hlpC();
-	UHM.detailPoint = setTimeout(function(){
+	popupTimeoutId = setTimeout(function(){
 		const bodyElem = document.querySelector('body');
 		if (!bodyElem) return;
 
-		const elemPos = UHM.getElemPosition(e);
-		const title = UTIL.newElement('span.title', {}, [UTIL.newTxt(e.dataset.title || "")]);
-		const content = UTIL.newElement('span.intro', {}, [e.dataset.intro || text]);
+		const elemPos = UHM.getElemPosition(element);
+		const title = UTIL.newElement('span.title', {}, [UTIL.newTxt(element.dataset.title || "")]);
+		const content = UTIL.newElement('span.intro', {}, [element.dataset.intro || text]);
 		const helptext = UTIL.newElement('div#bubbleHelp', {}, [title,content]);
 		if (reverse !== undefined) {
-			helptext.style.left = (elemPos.left - width) + 'px';
+			let popupPosn = elemPos.left - width;
+			if (popupPosn < 0) popupPosn = 0;
+			helptext.style.left = popupPosn + 'px';
 		} else {
 			helptext.style.left = elemPos.left + 'px';
 		}
@@ -541,7 +180,7 @@ UHM.hlp = function(e, text, width, reverse, delay=1500) {
 		helptext.style.display = "inherit";
 		bodyElem.appendChild(helptext);
 	}, delay);
-}
+};
 
 /**********************************************************************************
  * FUNCTION - getElemPosition: This function finds the help element selected's 
@@ -565,27 +204,18 @@ UHM.getElemPosition = function(el) {
  * FUNCTION - hlpC: This function clears any bubble help box displayed on the screen.
  **********************************************************************************/
 UHM.hlpC = function() {
-	clearTimeout(UHM.detailPoint);
-	var helptext = document.getElementById('bubbleHelp');
-	if (helptext === null) {
-		var helptext = document.getElementById('helptext');
-	}
-	if (helptext){
-		helptext.remove();
-	}
-}
-
-/**********************************************************************************
- * FUNCTION - userHelpClose: The purpose of this function is to close any open 
- * user help pop-ups and any active timeouts associated with those pop-up panels.
- **********************************************************************************/
-UHM.userHelpClose = function() {
-	clearTimeout(DET.detailPoint);
-	var helptext = document.getElementById('helptext');
-	if (helptext){
-		helptext.remove();
-	}
-}
+    if (popupTimeoutId !== undefined) {
+	clearTimeout(popupTimeoutId);
+	popupTimeoutId = undefined;
+    }
+    let helptext = document.getElementById('bubbleHelp');
+    if (helptext === null) {
+	helptext = document.getElementById('helptext');
+    }
+    if (helptext){
+	helptext.remove();
+    }
+};
 
 /**********************************************************************************
  * FUNCTION - getDivElement: The purpose of this function is to create and 
@@ -648,130 +278,6 @@ UHM.addBlankRow = function(addDiv, rowCnt) {
 	return;
 }
 
-UHM.showSearchError = function(type) {
-	var searchError = UHM.getDivElement('searchError');
-	searchError.style.display = 'inherit';
-	var searchBar = document.getElementById('search_text');
-	searchError.style.top = (searchBar.offsetTop + searchBar.offsetHeight) + 'px';
-	searchError.style.left = (searchBar.offsetLeft + searchBar.offsetWidth) + 'px';
-	const searchItem = SRCH.getCurrentSearchItem();
-	switch (type){
-		case 0: searchError.innerHTML = "No matching labels found"; break;
-		case 1: searchError.innerHTML = "Exit dendrogram selection to go to " + searchItem.label;break;
-		case 2: searchError.innerHTML = "All " + searchItem.axis +  " items are visible. Change the view mode to see " + searchItem.label;break;
-	}
-	UHM.hlpC();
-	document.body.appendChild(searchError);
-	setTimeout(function(){
-		searchError.remove();
-	}, 2000);
-	
-}
-
-/**********************************************************************************
- * FUNCTION - saveHeatMapChanges: This function handles all of the tasks necessary 
- * display a modal window whenever the user requests to save heat map changes.  
- **********************************************************************************/
-UHM.saveHeatMapChanges = function() {
-	const heatMap = MMGR.getHeatMap();
-	var text;
-	UHM.closeMenu();
-	UHM.initMessageBox();
-	UHM.setMessageBoxHeader("Save Heat Map");
-	//Have changes been made?
-	if (heatMap.getUnAppliedChanges()) {
-		if ((heatMap.isFileMode()) || (typeof NgChm.galaxy !== "undefined")) {  // FIXME: BMB.  Improve Galaxy detection.
-			if (typeof NgChm.galaxy !== "undefined") {
-				text = "<br>Changes to the heatmap cannot be saved in the Galaxy history.  Your modifications to the heatmap may be written to a downloaded NG-CHM file.";
-			} else {
-				text = "<br>You have elected to save changes made to this NG-CHM heat map file.<br><br>You may save them to a new NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
-			}
-			UHM.setMessageBoxText(text);
-			UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save To NG-CHM File", heatMap.saveHeatMapToNgchm);
-			UHM.setMessageBoxButton(4, UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
-		} else {
-			// If so, is read only?
-			if (heatMap.isReadOnly()) {
-				text = "<br>You have elected to save changes made to this READ-ONLY heat map. READ-ONLY heat maps cannot be updated.<br><br>However, you may save these changes to an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
-				UHM.setMessageBoxText(text);
-				UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save To NG-CHM File", heatMap.saveHeatMapToNgchm);
-				UHM.setMessageBoxButton(4, UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
-			} else {
-				text = "<br>You have elected to save changes made to this heat map.<br><br>You have the option to save these changes to the original map OR to save them to an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
-				UHM.setMessageBoxText(text);
-				UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save To NG-CHM File", heatMap.saveHeatMapToNgchm);
-				UHM.setMessageBoxButton(2, "images/saveOriginal.png", "Save Original Heat Map", heatMap.saveHeatMapToServer);
-				UHM.setMessageBoxButton(3, UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
-			}
-		}
-	} else {
-		text = "<br>There are no changes to save to this heat map at this time.<br><br>However, you may save the map as an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
-		UHM.setMessageBoxText(text);
-		UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save To NG-CHM File", heatMap.saveHeatMapToNgchm);
-		UHM.setMessageBoxButton(4, UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
-	}
-	UHM.displayMessageBox();
-}
-
-/**********************************************************************************
- * FUNCTION - widgetHelp: This function displays a special help popup box for
- * the widgetized version of the NG-CHM embedded viewer.  
- **********************************************************************************/
-UHM.widgetHelp = function() {
-	const heatMap = MMGR.getHeatMap();
-	const logos = document.getElementById('ngchmLogos');
-	// Logos are not included in the widgetized version.
-	if (logos) { logos.style.display = ''; }
-	UHM.initMessageBox();
-	UHM.setMessageBoxHeader("About NG-CHM Viewer");
-	var mapVersion = ((heatMap !== null) && heatMap.isMapLoaded()) === true ? heatMap.getMapInformation().version_id : "N/A";
-	var text = "<p>The NG-CHM Heat Map Viewer is a dynamic, graphical environment for exploration of clustered or non-clustered heat map data in a web browser. It supports zooming, panning, searching, covariate bars, and link-outs that enable deep exploration of patterns and associations in heat maps.</p>";
-	text = text + "<p><a href='https://bioinformatics.mdanderson.org/public-software/ngchm/' target='_blank'>Additional NG-CHM Information and Help</a></p>";
-	text = text + "<p><b>Software Version: </b>" + COMPAT.version+"</p>";
-	text = text + "<p><b>Linkouts Version: </b>" + linkouts.getVersion()+"</p>";
-	text = text + "<p><b>Map Version: </b>" +mapVersion+"</p>";
-	text = text + "<p><b>Citation:</b> Bradley M. Broom, Michael C. Ryan, Robert E. Brown, Futa Ikeda, Mark Stucky, David W. Kane, James Melott, Chris Wakefield, Tod D. Casasent, Rehan Akbani and John N. Weinstein, A Galaxy Implementation of Next-Generation Clustered Heatmaps for Interactive Exploration of Molecular Profiling Data. Cancer Research 77(21): e23-e26 (2017): <a href='http://cancerres.aacrjournals.org/content/77/21/e23' target='_blank'>http://cancerres.aacrjournals.org/content/77/21/e23</a></p>";
-	text = text + "<p>The NG-CHM Viewer is also available for a variety of other platforms.</p>";
-	UHM.setMessageBoxText(text);
-	UHM.setMessageBoxButton(3, UTIL.imageTable.closeButton, "Close button", UHM.messageBoxCancel);
-	UHM.displayMessageBox();
-}
-
-/**********************************************************************************
- * FUNCTION - zipSaveNotification: This function handles all of the tasks necessary 
- * display a modal window whenever a zip file is being saved. The textId passed in
- * instructs the code to display either the startup save OR preferences save message.  
- **********************************************************************************/
-UHM.zipSaveNotification = function(autoSave) {
-	var text;
-	UHM.initMessageBox();
-	UHM.setMessageBoxHeader("NG-CHM File Viewer");
-	if (autoSave) {
-		text = "<br>This NG-CHM archive file contains an out dated heat map configuration that has been updated locally to be compatible with the latest version of the NG-CHM Viewer.<br><br>In order to upgrade the NG-CHM and avoid this notice in the future, you will want to replace your original file with the version now being displayed.<br><br>";
-		UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save NG-CHM button", MMGR.getHeatMap().zipSaveNgchm);
-	} else {
-		text = "<br>You have just saved a heat map as a NG-CHM file.  In order to see your saved changes, you will want to open this new file using the NG-CHM File Viewer application.  If you have not already downloaded the application, press the Download Viewer button to get the latest version.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>" 
-		UHM.setMessageBoxButton(1, "images/downloadViewer.png", "Download NG-CHM Viewer App", UHM.zipAppDownload);
-	}
-	UHM.setMessageBoxText(text);
-	UHM.setMessageBoxButton(3, UTIL.imageTable.cancelSmall, "Cancel button", UHM.messageBoxCancel);
-	UHM.displayMessageBox();
-}
-
-/**********************************************************************************
- * FUNCTION - viewerAppVersionExpiredNotification: This function handles all of the tasks 
- * necessary display a modal window whenever a user's version of the file application 
- * has been superceded and a new version of the file application should be downloaded. 
- **********************************************************************************/
-UHM.viewerAppVersionExpiredNotification = function(oldVersion, newVersion) {
-	UHM.initMessageBox();
-	UHM.setMessageBoxHeader("New NG-CHM File Viewer Version Available");
-	UHM.setMessageBoxText("<br>The version of the NG-CHM File Viewer application that you are running ("+oldVersion+") has been superceded by a newer version ("+newVersion+"). You will be able to view all pre-existing heat maps with this new backward-compatible version. However, you may wish to download the latest version of the viewer.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>");
-	UHM.setMessageBoxButton(1, "images/downloadViewer.png", "Download NG-CHM Viewer App", UHM.zipAppDownload);
-	UHM.setMessageBoxButton(3, UTIL.imageTable.closeButton, "Cancel button", UHM.messageBoxCancel);
-	UHM.displayMessageBox();
-}
-
 /**********************************************************************************
  * FUNCTION - hamburgerLinkMissing: This function handles all of the tasks 
  * necessary display a modal window whenever a user's clicks on a hamburger menu
@@ -795,16 +301,6 @@ UHM.systemMessage = function(header, message) {
 	UHM.setMessageBoxText("<br>" + message);
 	UHM.setMessageBoxButton(1, UTIL.imageTable.closeButton, "Cancel button", UHM.messageBoxCancel);
 	UHM.displayMessageBox();
-}
-
-/**********************************************************************************
- * FUNCTION - zipAppDownload: This function calls the Matrix Manager to initiate
- * the download of the NG-CHM File Viewer application. 
- **********************************************************************************/
-UHM.zipAppDownload = function() {
-	var dlButton = document.getElementById('msgBoxBtnImg_1');
-	dlButton.style.display = 'none';
-	MMGR.getHeatMap().downloadFileApplication();
 }
 
 /**********************************************************************************
@@ -897,9 +393,6 @@ UHM.initMessageBox = function() {
 	document.getElementById('msgBoxBtnImg_4')['onclick'] = null;
 	var msgButton = document.getElementById('messageOpen_btn');
     msgButton.style.display = 'none'; 
-    if (SUM.texHmProgram !== undefined) {
-        UIMGR.redrawCanvases();
-    }
 }
 
 UHM.setMessageBoxHeader = function(headerText) {
@@ -934,17 +427,6 @@ UHM.setMessageBoxButton = function(buttonId, imageSrc, altText, onClick) {
 
 UHM.messageBoxCancel = function() {
 	UHM.initMessageBox();
-}
-
-UHM.openHelp = function() {
-	UHM.closeMenu();
-	if (MMGR.source !== MMGR.WEB_SOURCE) {
-		UHM.widgetHelp();
-	} else {
-		var url = location.origin+location.pathname;
-		window.open(url.replace("chm.html", "chmHelp.html"),'_blank');
-	}
-    UIMGR.redrawCanvases();
 }
 
 UHM.closeMenu = function() {
@@ -1013,235 +495,6 @@ UHM.displayStartupWarnings = function() {
 	UHM.setMessageBoxText(warningText);
 	UHM.setMessageBoxButton(3, UTIL.imageTable.prefCancel, "Cancel button", UHM.messageBoxCancel);
 	UHM.displayMessageBox();
-    UIMGR.redrawCanvases();
-}
-
-/*===========================================================
- * 
- * LINKOUT HELP MENU ITEM FUNCTIONS
- * 
- *===========================================================*/
-
-/**********************************************************************************
- * FUNCTION - openLinkoutHelp: The purpose of this function is to construct an 
- * HTML tables for plugins associated with the current heat map AND plugins 
- * installed for the NG-CHM instance. Then the logic to display the linkout 
- * help box is called. 
- **********************************************************************************/
-UHM.openLinkoutHelp = function() {
-	UHM.closeMenu();
-	var mapLinksTbl = UHM.openMapLinkoutsHelp();
-	var allLinksTbl = UHM.openAllLinkoutsHelp();
-	UHM.linkoutHelp(mapLinksTbl,allLinksTbl);
-    UIMGR.redrawCanvases();
-}
-
-/**********************************************************************************
- * FUNCTION - openMapLinkoutsHelp: The purpose of this function is to construct an 
- * HTML table object containing all of the linkout plugins that apply to a 
- * particular heat map. The table is created and then passed on to a linkout
- * popup help window.
- **********************************************************************************/
-UHM.openMapLinkoutsHelp = function() {
-	const heatMap = MMGR.getHeatMap();
-	var validPluginCtr = 0;
-	var pluginTbl = document.createElement("TABLE");
-	var rowLabels = heatMap.getRowLabels().label_type;
-	var colLabels = heatMap.getColLabels().label_type;
-	pluginTbl.insertRow().innerHTML = UHM.formatBlankRow();
-	var tr = pluginTbl.insertRow();
-	var tr = pluginTbl.insertRow();
-	for (var i=0;i<CUST.customPlugins.length;i++) {
-		var plugin = CUST.customPlugins[i];
-		var rowPluginFound = UHM.isPluginFound(plugin, rowLabels);
-		var colPluginFound = UHM.isPluginFound(plugin, colLabels);
-		var matrixPluginFound = UHM.isPluginMatrix(plugin);
-		var axesFound = matrixPluginFound && rowPluginFound && colPluginFound ? "Row, Column, Matrix" : rowPluginFound && colPluginFound ? "Row, Column" : rowPluginFound ? "Row" : colPluginFound ? "Column" : "None";
-		//If there is at least one available plugin, fill table with plugin rows containing 5 cells
-		if (rowPluginFound || colPluginFound) {
-			//If first plugin being written to table, write header row.
-			if (validPluginCtr === 0) {
-				tr.className = "chmHdrRow";
-				let td = tr.insertCell(0);
-				td.innerHTML = "<b>Plug-in Axes</b>";
-				td = tr.insertCell(0);
-				td.innerHTML = "<b>Description</b>";
-				td = tr.insertCell(0);
-				td.innerHTML = "<b>Plug-in Name and Website</b>";
-				td.setAttribute("colspan", 2);
-			}
-			validPluginCtr++;
-			//If there is no plugin logo, replace it with hyperlink using plugin name
-			var logoImage = typeof plugin.logo !== 'undefined' ? "<img src='"+ plugin.logo+"' onerror='this.onerror=null; this.remove();' width='100px'>" : "<b>" + plugin.name + "</b>";
-			var hrefSite = typeof plugin.site !== 'undefined' ? "<a href='"+plugin.site+"' target='_blank'> " : "<a>";
-			var logo = hrefSite + logoImage + "</a>";
-			var tr = pluginTbl.insertRow();
-			tr.className = "chmTblRow";
-			var tdLogo = tr.insertCell(0);
-			tdLogo.className = "chmTblCell";
-			tdLogo.innerHTML = logo;
-			var tdName = tr.insertCell(1);
-			tdName.className = "chmTblCell";
-			tdName.style.fontWeight="bold";
-			tdName.innerHTML = typeof plugin.site !== 'undefined' ? "<a href='" + plugin.site + "' target='_blank'>" + plugin.name + "</a>" : plugin.name;
-			var tdDesc = tr.insertCell(2);
-			tdDesc.className = "chmTblCell";
-			tdDesc.innerHTML = plugin.description;
-			var tdAxes = tr.insertCell(3);
-			tdAxes.className = "chmTblCell";
-			tdAxes.innerHTML = axesFound;
-		} 
-	}
-	if (validPluginCtr === 0) {
-		var tr = pluginTbl.insertRow();
-		tr.className = "chmTblRow";
-		var tdLogo = tr.insertCell(0);
-		tdLogo.className = "chmTblCell";
-		tdLogo.innerHTML = "<B>NO AVAILABLE PLUGINS WERE FOUND FOR THIS HEATMAP</B>";
-
-	}
-	return pluginTbl;
-}
-
-/**********************************************************************************
- * FUNCTION - openAllLinkoutsHelp: The purpose of this function is to construct an 
- * HTML table object containing all of the linkout plugins that are installed for
- * the NG-CHM instance. The table is created and then passed on to a linkout
- * popup help window.
- **********************************************************************************/
-UHM.openAllLinkoutsHelp = function() {
-	var validPluginCtr = 0;
-	var pluginTbl = document.createElement("TABLE");
-	pluginTbl.id = 'allPlugins';
-	pluginTbl.insertRow().innerHTML = UHM.formatBlankRow();
-	var tr = pluginTbl.insertRow();
-	var tr = pluginTbl.insertRow();
-	for (var i=0;i<CUST.customPlugins.length;i++) {
-		var plugin = CUST.customPlugins[i];
-			//If first plugin being written to table, write header row.
-			if (validPluginCtr === 0) {
-				tr.className = "chmHdrRow";
-				let td = tr.insertCell(0);
-				td.innerHTML = "<b>Description</b>";
-				td = tr.insertCell(0);
-				td.innerHTML = "<b>Plug-in Name and Website</b>";
-				td.setAttribute('colspan', 2);
-			}
-			validPluginCtr++;
-			//If there is no plugin logo, replace it with hyperlink using plugin name
-			var logoImage = typeof plugin.logo !== 'undefined' ? "<img src='"+ plugin.logo+"' onerror='this.onerror=null; this.remove();' width='100px'>" : "<b>" + plugin.name + "</b>";
-			var hrefSite = typeof plugin.site !== 'undefined' ? "<a href='"+plugin.site+"' target='_blank'> " : "<a>";
-			var logo = hrefSite + logoImage + "</a>";
-			var tr = pluginTbl.insertRow();
-			tr.className = "chmTblRow";
-			var tdLogo = tr.insertCell(0);
-			tdLogo.className = "chmTblCell";
-			tdLogo.innerHTML = logo;
-			var tdName = tr.insertCell(1);
-			tdName.className = "chmTblCell";
-			tdName.style.fontWeight="bold";
-			tdName.innerHTML = typeof plugin.site !== 'undefined' ? "<a href='" + plugin.site + "' target='_blank'>" + plugin.name + "</a>" : plugin.name;
-			var tdDesc = tr.insertCell(2);
-			tdDesc.className = "chmTblCell";
-			tdDesc.innerHTML = plugin.description;
-	}
-	return pluginTbl;
-}
-
-/**********************************************************************************
- * FUNCTION - isPluginFound: The purpose of this function is to check to see if 
- * a given plugin is applicable for the current map based upon the label types.
- * Row or column label types are passed into this function.
- **********************************************************************************/
-UHM.isPluginFound = function(plugin,labels) {
-	var pluginFound = false;
-	if (plugin.name === "TCGA") {
-		for (var l=0;l<labels.length;l++) {
-			var tcgaBase = "bio.tcga.barcode.sample";
-			if (labels[l] === tcgaBase) {
-				pluginFound = true;
-			}
-			if (typeof CUST.subTypes[tcgaBase] !== 'undefined') {
-				for(var m=0;m<CUST.subTypes[tcgaBase].length;m++) {
-					var subVal = CUST.subTypes[tcgaBase][m];
-					if (labels[l] === subVal) {
-						pluginFound = true;
-					}
-				}
-			}
-		}
-	} else {
-		for (var k=0;k<plugin.linkouts.length;k++) {
-			var typeN = plugin.linkouts[k].typeName;
-			for (var l=0;l<labels.length;l++) {
-				var labelVal = labels[l];
-				if (labelVal === typeN) {
-					pluginFound = true;
-				}
-				if (typeof CUST.superTypes[labelVal] !== 'undefined') {
-					for(var m=0;m<CUST.superTypes[labelVal].length;m++) {
-						var superVal = CUST.superTypes[labelVal][m];
-						if (superVal === typeN) {
-							pluginFound = true;
-						}
-					}
-				}
-			}
-		}
-	}
-	return pluginFound;
-}
-
-/**********************************************************************************
- * FUNCTION - isPluginMatrix: The purpose of this function is to determine whether
- * a given plugin is also a Matrix plugin.
- **********************************************************************************/
-UHM.isPluginMatrix = function(plugin) {
-	var pluginMatrix = false;
-	if (typeof plugin.linkouts !== 'undefined') {
-	for (var k=0;k<plugin.linkouts.length;k++) {
-		var pluginName = plugin.linkouts[k].menuEntry;
-		for (var l=0;l<linkouts.Matrix.length;l++) {
-			var matrixName = linkouts.Matrix[l].title;
-			if (pluginName === matrixName) {
-				pluginMatrix = true;
-			}
-		}
-	}
-	}
-	return pluginMatrix;
-}
-
-/**********************************************************************************
- * FUNCTION - linkoutHelp: The purpose of this function is to load and make visible
- * the linkout help popup window.
- **********************************************************************************/
-UHM.linkoutHelp = function(mapLinksTbl, allLinksTbl) {
-	var linkBox = document.getElementById('linkBox');
-	var linkBoxHdr = document.getElementById('linkBoxHdr');
-	var linkBoxTxt = document.getElementById('linkBoxTxt');
-	var linkBoxAllTxt = document.getElementById('linkBoxAllTxt');
-	var pluginCtr = allLinksTbl.rows.length;
-	var headerpanel = document.getElementById('mdaServiceHeader');
-	UTIL.hideLoader();
-	linkBox.classList.add ('hide');
-	linkBox.style.top = (headerpanel.offsetTop + 15) + 'px';
-	linkBox.style.right = "5%";
-	linkBoxHdr.innerHTML = "NG-CHM Plug-in Information";
-	if (linkBoxHdr.querySelector(".closeX")) { linkBoxHdr.querySelector(".closeX").remove();}
-	linkBoxHdr.appendChild(UHM.createCloseX(UHM.linkBoxCancel));
-	linkBoxTxt.innerHTML = "";
-	linkBoxTxt.appendChild(mapLinksTbl);
-	mapLinksTbl.style.width = '100%';
-	linkBoxAllTxt.innerHTML = "";
-	linkBoxAllTxt.appendChild(allLinksTbl);
-	allLinksTbl.style.width = '100%';
-	UHM.linkBoxSizing();
-	UHM.hideAllLinks();
-	UHM.showMapPlugins();
-	linkBox.classList.remove ('hide');
-	linkBox.style.left = ((window.innerWidth - linkBox.offsetWidth) / 2) + 'px';
-//	UTIL.dragElement(document.getElementById("linkBox"));
 }
 
 /*
@@ -1253,103 +506,6 @@ UHM.createCloseX = function(closeFunction) {
 	closeX.innerHTML = "&#x2715;"; // multiplication x 
 	closeX.onclick = closeFunction;
 	return closeX
-}
-
-/**********************************************************************************
- * FUNCTION - linkBoxCancel: The purpose of this function is to hide the linkout
- * help popup window.
- **********************************************************************************/
-UHM.linkBoxCancel = function() {
-	var linkBox = document.getElementById('linkBox');
-	linkBox.classList.add ('hide');
-}
-
-/**********************************************************************************
- * FUNCTION - showMapPlugins: The purpose of this function is to show the map specific
- * plugins panel within the linkout help screen and toggle the appropriate
- * tab button.
- **********************************************************************************/
-UHM.showMapPlugins = function() {
-	//Turn off all tabs
-	UHM.hideAllLinks();
-	//Turn on map links div
-	var linkBoxTxt = document.getElementById('linkBoxTxt');
-	var mapLinksBtn = document.getElementById("mapLinks_btn");
-	mapLinksBtn.setAttribute('src', 'images/mapLinksOn.png');
-	linkBoxTxt.classList.remove('hide');
-}
-
-/**********************************************************************************
- * FUNCTION - showAllPlugins: The purpose of this function is to show the all
- * plugins installed panel within the linkout help screen and toggle the appropriate
- * tab button.
- **********************************************************************************/
-UHM.showAllPlugins = function() {
-	//Turn off all tabs
-	UHM.hideAllLinks();
-	//Turn on all links div
-	var linkBoxAllTxt = document.getElementById('linkBoxAllTxt');
-	var allLinksBtn = document.getElementById("allLinks_btn");
-	allLinksBtn.setAttribute('src', 'images/allLinksOn.png');
-	linkBoxAllTxt.classList.remove ('hide');
-}
-
-/**********************************************************************************
- * FUNCTION - hideAllLinks: The purpose of this function is to hide the linkout
- * help boxes and reset the tabs associated with them.
- **********************************************************************************/
-UHM.hideAllLinks = function() {
-	var linkBoxTxt = document.getElementById('linkBoxTxt');
-	var linkBoxAllTxt = document.getElementById('linkBoxAllTxt');
-	var mapLinksBtn = document.getElementById("mapLinks_btn");
-	var allLinksBtn = document.getElementById("allLinks_btn");
-	mapLinksBtn.setAttribute('src', 'images/mapLinksOff.png');
-	linkBoxTxt.classList.add ('hide');
-	allLinksBtn.setAttribute('src', 'images/allLinksOff.png');
-	linkBoxAllTxt.classList.add ('hide');
-}
-
-/**********************************************************************************
- * FUNCTION - linkBoxSizing: The purpose of this function is to size the height
- * of the linkout help popup window depending on the number of plugins to be 
- * listed.
- **********************************************************************************/
-UHM.linkBoxSizing = function() {
-	var linkBox = document.getElementById('linkBox');
-	var pluginCtr = 0;
-	if (document.getElementById('allPlugins') !== null) {
-		pluginCtr = document.getElementById('allPlugins').rows.length;
-	}
-	var linkBoxTxt = document.getElementById('linkBoxTxt');
-	var linkBoxAllTxt = document.getElementById('linkBoxAllTxt');
-	var container = document.getElementById('ngChmContainer');
-	var contHeight = container.offsetHeight;
-	if (pluginCtr === 0) {
-		var boxHeight = contHeight *.30;
-		var boxTextHeight = boxHeight * .40;
-		if (boxHeight < 150) {
-			boxHeight = contHeight *.35;
-			boxTextHeight = boxHeight * .20;
-		}
-		linkBox.style.height = boxHeight;
-		linkBoxTxt.style.height = boxTextHeight;
-	} else {
-		var boxHeight = contHeight *.92;
-		linkBox.style.height = boxHeight;
-		var boxTextHeight = boxHeight * .80;
-		if (MMGR.embeddedMapName !== null) {
-			boxTextHeight = boxHeight *.60;
-		}
-		if (boxHeight < 400) {
-			if (MMGR.embeddedMapName !== null) {
-				boxTextHeight = boxHeight *.60;
-			} else {
-				boxTextHeight = boxHeight * .70;
-			}
-		}
-		linkBoxTxt.style.height = boxTextHeight;
-		linkBoxAllTxt.style.height = boxTextHeight;
-	}
 }
 
 })();


### PR DESCRIPTION
Third set of restructure changes.  This set comprises two very small rearrangements and a larger one.  The first two involve moving heat map initialization code from immediately after the mapConfig JSON structure is received, inside MatrixManager, which may happen before the map is fully initialized, to within an Event_INITIALIZED handler in UI-Manager.  The event is handled as soon as it should be.

The third involves leaving all the generic code for help dialogs etc. in UserHelpManager but moving the code for creating dialogs for specific areas into the modules for those areas.  E.g. moving the code for creating the detail map popups into the detail map modules.  Currently, there are many circular dependencies between the modules for the specific areas, the UHM, and all the modules for the specific areas.

This patch removes all those circular dependencies.