### PR TITLE
Update ribbon mode dendrogram selection when changing detail maps

### DIFF
--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -480,6 +480,7 @@ DET.getDetailSaveState = function (dm) {
 	    'subDendroMode': dm.subDendroMode,
 	    'selectedStart': dm.selectedStart,
 	    'selectedStop': dm.selectedStop,
+	    'selectedIsDendrogram': dm.selectedIsDendrogram,
 	};
 };
 
@@ -826,6 +827,7 @@ DET.setDetailDataHeight = function (mapItem, size) {
 	if (mapItem.selectedStart != 0) {
 	    mapItem.selectedStart = 0;
 	    mapItem.selectedStop = 0;
+	    mapItem.selectedIsDendrogram = false;
 	    if (mapItem == DVW.primaryMap) {
 		SUM.rowDendro.clearSelectedRegion();
 		SUM.colDendro.clearSelectedRegion();
@@ -858,6 +860,7 @@ DET.setDetailDataHeight = function (mapItem, size) {
 	mapItem.subDendroMode = savedState.subDendroMode || "none";
 	mapItem.selectedStart = savedState.selectedStart || 0;
 	mapItem.selectedStop = savedState.selectedStop || 0;
+	mapItem.selectedIsDendrogram = savedState.selectedIsDendrogram || false;
 	// RESTORE CANVAS SIZE
 	let zoomBoxSizeIdx = DET.zoomBoxSizes.indexOf(savedState.dataBoxWidth);
 	switch (savedState.mode) {

--- a/NGCHM/WebContent/javascript/DetailHeatMapManager.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapManager.js
@@ -31,7 +31,8 @@ DMM.nextMapNumber = 1;
 	  saveRow: null, saveCol: null, dataBoxHeight: null, dataBoxWidth: null, rowDendro: null, colDendro: null, dendroHeight: 105, dendroWidth: 105, dataViewHeight: 506,
 	  dataViewWidth: 506, minLabelSize: 5, labelLastClicked: {}, dragOffsetX: null, dragOffsetY: null, rowLabelLen: 0, colLabelLen: 0,
 	  rowLabelFont: 0, colLabelFont: 0,colClassLabelFont: 0, rowClassLabelFont: 0, labelElements: {}, oldLabelElements: {}, tmpLabelSizeElements: [], 
-	  labelSizeWidthCalcPool: [], labelSizeCache: {},zoomOutNormal: null, zoomOutPos: null, subDendroMode: 'none'
+	  labelSizeWidthCalcPool: [], labelSizeCache: {},zoomOutNormal: null, zoomOutPos: null, subDendroMode: 'none',
+	  selectedIsDendrogram: false
     };
 
     class DetailHeatMapView {
@@ -220,6 +221,18 @@ DMM.setPrimaryDetailMap = function (mapItem) {
 	DVW.primaryMap = mapItem;
 	document.getElementById('primary_btn'+mapItem.panelNbr).style.display = 'none';
 	SUM.drawLeftCanvasBox ();
+	if (SUM.rowDendro) {
+	    SUM.rowDendro.clearSelectedRegion();
+	    if (mapItem.selectedIsDendrogram && mapItem.mode.startsWith('RIBBONV')) {
+		SUM.rowDendro.setRibbonModeBar (mapItem.selectedStart, mapItem.selectedStop);
+	    }
+	}
+	if (SUM.colDendro) {
+	    SUM.colDendro.clearSelectedRegion();
+	    if (mapItem.selectedIsDendrogram && mapItem.mode.startsWith('RIBBONH')) {
+		SUM.colDendro.setRibbonModeBar (mapItem.selectedStart, mapItem.selectedStop);
+	    }
+	}
 }
 
 /*********************************************************************************************

--- a/NGCHM/WebContent/javascript/SummaryDendrogram.js
+++ b/NGCHM/WebContent/javascript/SummaryDendrogram.js
@@ -154,6 +154,27 @@
 	    this.draw();
 	};
 
+	// Set ribbon mode
+	this.setRibbonModeBar = function setRibbonModeBar (start, stop) {
+	    if (this.ribbonModeBar != -1) {
+		console.error ('Setting ribbon mode bar when it is already set');
+		return;
+	    }
+	    for (let idx = 0; idx < this.bars.length; idx++) {
+		const regionStart = Math.round(this.bars[idx].leftBoundary / pointsPerLeaf);
+		if (start != regionStart) {
+		    continue;
+		}
+		const regionStop = Math.round(this.bars[idx].rightBoundary / pointsPerLeaf);
+		if (stop == regionStop) {
+		    this.ribbonModeBar = idx;
+		    this.draw();
+		    return;
+		}
+	    }
+	    console.warn ('Unable to set ribbon bar');
+	};
+
 	// Enter/leave ribbon mode.  Called when the user has clicked near
 	// a bar in the dendrogram.
 	this.setSelectedBar = function (barIndex) {

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -120,6 +120,7 @@ SUM.initSummaryData = function(callbacks) {
 		    DVW.primaryMap.subDendroMode = axis;
 		    DVW.primaryMap.selectedStart = regionStart;
 		    DVW.primaryMap.selectedStop = regionStop;
+		    DVW.primaryMap.selectedIsDendrogram = true;
 		}
 		callbacks.showSearchResults();
 		callbacks.callDetailDrawFunction(axis === 'Row' ? 'RIBBONV' : 'RIBBONH');
@@ -777,16 +778,15 @@ SUM.drawLeftCanvasBox = function() {
         if (!SUM.chmElement) return;
 	// Reset the canvas (drawing borders and sub-dendro selections)
 	const ctx = SUM.resetBoxCanvas(SUM.boxCanvas);
+	const heatMap = MMGR.getHeatMap();
+	const dataLayers = heatMap.getDataLayers();
 	DVW.detailMaps.forEach(mapItem => {
 		// Draw the View Box using user-defined defined selection color 
 		const boxX = ((((DVW.getCurrentSumCol(mapItem)-1) * SUM.widthScale) / SUM.canvas.width) * SUM.boxCanvas.width);
 		const boxY = ((((DVW.getCurrentSumRow(mapItem)-1) * SUM.heightScale) / SUM.canvas.height) * SUM.boxCanvas.height);
 		const boxW = (DVW.getCurrentSumDataPerRow(mapItem)*SUM.widthScale / SUM.canvas.width) * SUM.boxCanvas.width - 2;
 		const boxH = (DVW.getCurrentSumDataPerCol(mapItem)*SUM.heightScale / SUM.canvas.height) * SUM.boxCanvas.height - 2;
-		const heatMap = MMGR.getHeatMap();
-		const dataLayers = heatMap.getDataLayers();
 		const dataLayer = dataLayers[mapItem.currentDl];
-		ctx.strokeStyle=dataLayer.selection_color;
 		ctx.strokeStyle=dataLayer.selection_color;
 		if (mapItem.version === 'P') {
 			ctx.lineWidth=4;

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -1144,7 +1144,7 @@
 	if (mapItem.selectedIsDendrogram) {
 	    mapItem.selectedIsDendrogram = false;
 	    if (mapItem == DVW.primaryMap) {
-		const dendro = restoreInfo.mode.startsWith('RIBBONV') ? SUM.rowDendro : SUM.colDendro;
+		const dendro = mapItem.mode.startsWith('RIBBONV') ? SUM.rowDendro : SUM.colDendro;
 		if (dendro) {
 		    dendro.clearSelectedRegion();
 		}

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -1194,8 +1194,9 @@
 	const mapItem = DVW.primaryMap;
 	UHM.hlpC();
 	if (e.target.type != "text" && e.target.type != "textarea") {
-		switch(e.keyCode){ // prevent default added redundantly to each case so that other key inputs won't get ignored
-			case 37: // left key
+		// console.log ({ m: 'KeyPress', keyCode: e.keyCode, key: e.key, ctrl: e.ctrlKey, shift: e.shiftKey, alt: e.altKey, meta: e.metaKey, e });
+		switch(e.key){ // prevent default added redundantly to each case so that other key inputs won't get ignored
+			case 'ArrowLeft': // left key
 				if (document.activeElement.id !== "search_text"){
 					e.preventDefault();
 					if (e.shiftKey) {
@@ -1211,7 +1212,7 @@
 					}
 				}
 				break;
-			case 38: // up key
+			case 'ArrowUp': // up key
 				if (document.activeElement.id !== "search_text"){
 					e.preventDefault();
 					if (e.shiftKey) {
@@ -1225,7 +1226,7 @@
 					}
 				}
 				break;
-			case 39: // right key
+			case 'ArrowRight': // right key
 				if (document.activeElement.id !== "search_text"){
 					e.preventDefault();
 					if (e.shiftKey) {
@@ -1241,7 +1242,7 @@
 					}
 				}
 				break;
-			case 40: // down key
+			case 'ArrowDown': // down key
 				if (document.activeElement.id !== "search_text"){
 					e.preventDefault();
 					if (e.shiftKey) {
@@ -1255,7 +1256,7 @@
 					}
 				}
 				break;
-			case 33: // page up
+			case 'PageUp': // page up
 				e.preventDefault();
 				if (e.shiftKey){
 					let newMode;
@@ -1270,7 +1271,7 @@
 					DEV.zoomAnimation(mapItem.chm);
 				}
 				break;
-			case 34: // page down
+			case 'PageDown': // page down
 				e.preventDefault();
 				if (e.shiftKey){
 					let newMode;
@@ -1285,7 +1286,7 @@
 					DEV.detailDataZoomOut(mapItem.chm);
 				}
 				break;
-			case 113: // F2 key
+			case 'F2': // F2 key
 				if (FLICK.flickIsOn()) {
 				    UIMGR.flickChange (FLICK.isFlickUp() ? "toggle2" : "toggle1");
 				}
@@ -1297,7 +1298,7 @@
 		DVW.checkCol(mapItem);
 	    mapItem.updateSelection();
 	} else {
-	    if ((document.activeElement.id === "search_text") && (e.keyCode === 13)) {
+	    if ((document.activeElement.id === "search_text") && (e.key === 'Enter')) {
 		    SRCH.detailSearch();
 	    }
 	}

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -1291,6 +1291,12 @@
 				    UIMGR.flickChange (FLICK.isFlickUp() ? "toggle2" : "toggle1");
 				}
 				break;
+			case 'Enter':
+				if (UHM.messageBoxIsVisible()) {
+				    e.preventDefault();
+				    UHM.messageBoxCancel();
+				}
+				break;
 			default:
 				return;
 		}

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -1140,6 +1140,51 @@
 	DET.setDrawDetailsTimeout(DET.redrawSelectionTimeout);
     }
 
+    function clearSelectedDendrogram (mapItem) {
+	if (mapItem.selectedIsDendrogram) {
+	    mapItem.selectedIsDendrogram = false;
+	    if (mapItem == DVW.primaryMap) {
+		const dendro = restoreInfo.mode.startsWith('RIBBONV') ? SUM.rowDendro : SUM.colDendro;
+		if (dendro) {
+		    dendro.clearSelectedRegion();
+		}
+	    }
+	    showRestoreDendrogramMessage(mapItem);
+	}
+    }
+
+    function showRestoreDendrogramMessage (mapItem) {
+	const debug = false;
+
+	UHM.initMessageBox();
+	UHM.setMessageBoxHeader("Dendrogram selection lost");
+	UHM.setMessageBoxText("<br>" + "The summary panel dendrogram selection was lost due to keyboard movement of the focus region. " +
+		"Click CANCEL to undo the keyboard movement and restore the dendrogram selection. " +
+		"Otherwise, click CLOSE to just close this dialog." );
+	const undoFunction = function undoFunction (restoreInfo) {
+	    if (debug) console.log ("Undoing keyboard movement and dendrogram selection loss.", restoreInfo);
+	    UHM.messageBoxCancel();
+	    restoreInfo.mapItem.selectedIsDendrogram = true;
+	    restoreInfo.mapItem.selectedStart = restoreInfo.selectedStart;
+	    restoreInfo.mapItem.selectedStop = restoreInfo.selectedStop;
+	    DET.callDetailDrawFunction(restoreInfo.mode, restoreInfo.mapItem);
+	    if (restoreInfo.mapItem == DVW.primaryMap) {
+		const dendro = restoreInfo.mode.startsWith('RIBBONV') ? SUM.rowDendro : SUM.colDendro;
+		if (dendro) {
+		    dendro.setRibbonModeBar(restoreInfo.selectedStart, restoreInfo.selectedStop);
+		}
+	    }
+	}.bind (null, {
+	    mapItem: mapItem,
+	    mode: mapItem.mode,
+	    selectedStart: mapItem.selectedStart,
+	    selectedStop: mapItem.selectedStop
+	});
+	UHM.setMessageBoxButton(1, UTIL.imageTable.prefCancel, "Cancel button", undoFunction);
+	UHM.setMessageBoxButton(3, UTIL.imageTable.closeButton, "Close button", UHM.messageBoxCancel);
+	UHM.displayMessageBox();
+    }
+
     /*********************************************************************************************
      * FUNCTION:  keyNavigate - The purpose of this function is to handle a user key press event.
      * As key presses are received at the document level, their detail processing will be routed to
@@ -1153,33 +1198,61 @@
 			case 37: // left key
 				if (document.activeElement.id !== "search_text"){
 					e.preventDefault();
-					if (e.shiftKey){mapItem.currentCol -= mapItem.dataPerRow;}
-					else if (e.ctrlKey){mapItem.currentCol -= 1;mapItem.selectedStart -= 1;mapItem.selectedStop -= 1; DET.callDetailDrawFunction(mapItem.mode);}
-					else {mapItem.currentCol--;}
+					if (e.shiftKey) {
+					    mapItem.currentCol -= mapItem.dataPerRow;
+					} else if (e.ctrlKey) {
+					    mapItem.currentCol -= 1;
+					    clearSelectedDendrogram (mapItem);
+					    mapItem.selectedStart -= 1;
+					    mapItem.selectedStop -= 1;
+					    DET.callDetailDrawFunction(mapItem.mode);
+					} else {
+					    mapItem.currentCol--;
+					}
 				}
 				break;
 			case 38: // up key
 				if (document.activeElement.id !== "search_text"){
 					e.preventDefault();
-					if (e.shiftKey){mapItem.currentRow -= mapItem.dataPerCol;}
-					else if (e.ctrlKey){mapItem.selectedStop += 1; DET.callDetailDrawFunction(mapItem.mode);}
-					else {mapItem.currentRow--;}
+					if (e.shiftKey) {
+					    mapItem.currentRow -= mapItem.dataPerCol;
+					} else if (e.ctrlKey) {
+					    clearSelectedDendrogram (mapItem);
+					    mapItem.selectedStop += 1;
+					    DET.callDetailDrawFunction(mapItem.mode);
+					} else {
+					    mapItem.currentRow--;
+					}
 				}
 				break;
 			case 39: // right key
 				if (document.activeElement.id !== "search_text"){
 					e.preventDefault();
-					if (e.shiftKey){mapItem.currentCol += mapItem.dataPerRow;}
-					else if (e.ctrlKey){mapItem.currentCol += 1;mapItem.selectedStart += 1;mapItem.selectedStop += 1; DET.callDetailDrawFunction(mapItem.mode);}
-					else {mapItem.currentCol++;}
+					if (e.shiftKey) {
+					    mapItem.currentCol += mapItem.dataPerRow;
+					} else if (e.ctrlKey) {
+					    mapItem.currentCol += 1;
+					    clearSelectedDendrogram (mapItem);
+					    mapItem.selectedStart += 1;
+					    mapItem.selectedStop += 1;
+					    DET.callDetailDrawFunction(mapItem.mode);
+					} else {
+					    mapItem.currentCol++;
+					}
 				}
 				break;
 			case 40: // down key
 				if (document.activeElement.id !== "search_text"){
 					e.preventDefault();
-					if (e.shiftKey){mapItem.currentRow += mapItem.dataPerCol;}
-					else if (e.ctrlKey){mapItem.selectedStop -= 1; DET.callDetailDrawFunction(mapItem.mode);}
-					else {mapItem.currentRow++;}
+					if (e.shiftKey) {
+					    mapItem.currentRow += mapItem.dataPerCol;
+					} else if (e.ctrlKey) {
+					    clearSelectedDendrogram (mapItem);
+					    mapItem.selectedStop -= 1;
+					    DET.callDetailDrawFunction(mapItem.mode);
+					} else {
+					    mapItem.currentRow++;
+					}
 				}
 				break;
 			case 33: // page up

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -392,6 +392,11 @@ UHM.initMessageBox = function() {
 	document.getElementById('messageOpen_btn').style.display = 'none';
 }
 
+UHM.messageBoxIsVisible = function () {
+	const messageBox = document.getElementById('msgBox');
+	return messageBox && messageBox.style.display != 'none';
+};
+
 UHM.setMessageBoxHeader = function(headerText) {
 	var msgBoxHdr = document.getElementById('msgBoxHdr');
 	msgBoxHdr.innerHTML = headerText;


### PR DESCRIPTION
Updates the behavior of the ribbon mode dendrogram selection as we discussed.

Tracks whether each detail view's ribbon mode focus area is a dendrogram selection. Initially false. Set to true if the user selects a dendrogram branch on the summary map.  Cleared if the user uses keyboard navigation to change the focus area (and displays a popup allowing the user to reset the focus region if desired).

Also used to update dendrogram ribbon mode highlight when switching between detail maps or when restoring saved maps.

Fixes issue #372.