### PR TITLE
Feedback fixups

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -317,24 +317,7 @@
 							        </div>
 							        <!-- WIDGET INCLUDE -->
 								<div id="msgBoxTxt" style="display: inherit;font-size: 12px; background-color: rgb(230, 240, 255); width: 400px; height: 80px;"></div>
-								<table>
-									<tbody>
-										<tr>
-											<td style="text-align: left;">
-													<img id="msgBoxBtnImg_1" class='msgBoxButton' alt='message box button 1 icon'>
-											</td>
-											<td style="text-align: left;">
-													<img id="msgBoxBtnImg_2" class='msgBoxButton' alt='message box button 2 icon'>
-											</td>
-											<td style="text-align:right;">
-													<img id="msgBoxBtnImg_3" class='msgBoxButton' alt='message box button 3 icon'>
-											</td>
-											<td style="text-align: right;">
-													<img id="msgBoxBtnImg_4" class='msgBoxButton' alt='message box button 4 icon'>
-											</td>
-										</tr>
-									</tbody>
-								</table>
+								<div id="msgBoxButtons" class='buttonBox'></div>
 							</td>
 						</tr>
 					</tbody>

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -353,6 +353,15 @@ div.paneHeader img {
 	display: contents;
 }
 
+.buttonBox {
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+}
+
+#msgBoxButtons .default {
+    filter: brightness(1.5) hue-rotate(310deg);
+}
+
 .gearPanel .buttonBox {
 	display: flex;
 	margin-bottom: 1em;
@@ -896,6 +905,13 @@ th.breakpointContainer {
     box-sizing: border-box;
     text-align: left;
 }
+
+#msgBoxButtons button {
+    border: none;
+    vertical-align: top;
+    background: transparent;
+}
+
 #msgBoxTxt {
     box-sizing: border-box
 }

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -358,8 +358,25 @@ div.paneHeader img {
     margin-bottom: 0.5em;
 }
 
-#msgBoxButtons .default {
-    filter: brightness(1.5) hue-rotate(310deg);
+#msgBoxButtons img {
+    padding: 0.2em;
+    border: 2px solid #e6f0ff;
+    border-radius: 1em;
+}
+
+.spanbuttonwrapper {
+    padding: 0.4em 0.2em;
+    margin-left: 1em;
+}
+
+#msgBoxButtons .default img {
+    border: 2px solid #3377b4;
+    border-radius: 1em;
+}
+
+#msgBoxButtons .default > span {
+    border: 2px solid #3757be;
+    border-radius: 1em;
 }
 
 .gearPanel .buttonBox {
@@ -405,7 +422,6 @@ span.button {
 	border-radius: 1em;
 	font-weight: bold;
 	font-size: 0.8rem;
-	margin-left: 1em;
 	cursor: pointer;
 }
 span.button.positive {

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -1693,8 +1693,6 @@ MMGR.HeatMapData = function(heatMapName, level, jsonData, datalayers, lowerLevel
      **********************************************************************************/
     MMGR.zipAppDownload = zipAppDownload;
     function zipAppDownload () {
-	const dlButton = document.getElementById('msgBoxBtnImg_1');
-	dlButton.style.display = 'none';
 	downloadFileApplication();
     }
 

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -49,7 +49,7 @@ UTIL.capitalize = function capitalize (str) {
 // Load the dynamic script file.
 UTIL.addScript = function(src, callback) {
 	const head = document.getElementsByTagName('head')[0];
-	const script = UTIL.newEl('script', { type: 'text/javascript', src });
+	const script = UTIL.newElement('script', { type: 'text/javascript', src });
 	head.appendChild(script);
 	// Most browsers:   NOTE: The next 2 lines of code are replaced when building ngchmApp.html and ngchmWidget-min.js (the "file mode" and "widget" versions of the application)
 	script.onload = callback;

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -613,36 +613,29 @@
 				This function was created to warn user about resetting the PathwayMapper pane.
 			*/
 			function promisePrompt(vertical, loc) {
-				let dialog = document.getElementById('msgBox')
+			    return new Promise(function(resolve, reject) {
 				UHM.initMessageBox();
 				UHM.setMessageBoxHeader('PathwayMapper Pane Reset Warning');
 				UHM.setMessageBoxText('This action will delete all the information in PathwayMapper. Would you like to continue?')
-				UHM.setMessageBoxButton(1, UTIL.imageTable.cancelSmall, 'Cancel Button')
-				UHM.setMessageBoxButton(2, UTIL.imageTable.okButton, 'OK Button')
-				dialog.style.display = '';
-				return new Promise(function(resolve, reject) {
-					let okButton = dialog.querySelector('#msgBoxBtnImg_2')
-					let cancelButton = dialog.querySelector('#msgBoxBtnImg_1')
-					dialog.addEventListener('click', function handleButtonClick(e) {
-						if (e.target.tagName !== 'IMG') {return;}
-						dialog.removeEventListener('click', handleButtonClick)
-						if (e.target === okButton) {
-							resolve();
-						} else {
-							reject();
-						}
-					})
-				})
+				UHM.setMessageBoxButton(1, UTIL.imageTable.cancelSmall, 'Cancel Button', () => {
+				    reject(false);
+				});
+				UHM.setMessageBoxButton(2, UTIL.imageTable.okButton, 'OK Button', () => {
+				    resolve();
+				});
+				UHM.displayMessageBox();
+			    });
 			}
 			promisePrompt(vertical, loc)
 				.then(function() {  // promise resolved, split pane
-					UHM.messageBoxCancel();
-					splitPane(vertical, loc)
+				    splitPane(vertical, loc)
 				})
-				.catch(function() {  // promise rejected, do not split pane
-					UHM.messageBoxCancel();
-					return;
+				.catch(function(error) {  // promise rejected, do not split pane
+				    if (error) console.log (error);
 				})
+				.finally(() => {
+				    UHM.messageBoxCancel();
+				});
 		} else { // pane division can proceed w/o any loss of PathwayMapper state
 			splitPane(vertical, loc)
 		}
@@ -1040,44 +1033,40 @@
 						This function was created to warn user about resetting the PathwayMapper pane.
 					*/
 					function promisePrompt(paneLoc) {
-						let dialog = document.getElementById('msgBox');
+					    return new Promise(function(resolve, reject) {
 						UHM.initMessageBox();
 						UHM.setMessageBoxHeader('PathwayMapper Pane Reset Warning');
 						UHM.setMessageBoxText('This action will delete all information in PathwayMapper. Would you like to continue?')
-						UHM.setMessageBoxButton(1, UTIL.imageTable.cancelSmall, 'Cancel Button')
-						UHM.setMessageBoxButton(2, UTIL.imageTable.okButton, 'OK Button')
-						dialog.style.display = '';
-						return new Promise(function(resolve, reject) {
-							let okButton = dialog.querySelector('#msgBoxBtnImg_2')
-							let cancelButton = dialog.querySelector('#msgBoxBtnImg_1')
-							dialog.addEventListener('click', function handleButtonClick(e) {
-								if (e.target.tagName !== 'IMG') {return;}
-								dialog.removeEventListener('click', handleButtonClick)
-								if (e.target === okButton) {
-									resolve();
-								} else { 
-									reject();
-								}
-							})
-						})
+						UHM.setMessageBoxButton(1, UTIL.imageTable.cancelSmall, 'Cancel Button', () => {
+						    reject(false);
+						});
+						UHM.setMessageBoxButton(2, UTIL.imageTable.okButton, 'OK Button', () => {
+						    resolve();
+						});
+						UHM.displayMessageBox();
+					    });
 					}  // end function promisePrompt
+
 					// If user is attempting to close a pane that will result in resetting PathwayMapper, offer them the chance to cancel:
 					if (paneLoc.container.textContent.indexOf('PathwayMapper') > -1 && c.length < 4) {
 						promisePrompt(paneLoc)
-							.then(function() { // promise resolved, continue pane manipulation
-								UHM.messageBoxCancel()
-								removePaneAndAdjacentDivider();
-								if (paneLoc.container.children.length === 1) {
-									replaceContainerWithOnlyChild()
-								} else {
-									// Redistribute space among remaining children.
-									if (target) redistributeContainer (paneLoc.container, target);
-								}
-							})
-		       				.catch(function() { // promise rejected, do NOT continue pane manipulation
-								UHM.messageBoxCancel()
-								return;
-							})
+						.then(function() { // promise resolved, continue pane manipulation
+						    removePaneAndAdjacentDivider();
+						    if (paneLoc.container.children.length === 1) {
+							replaceContainerWithOnlyChild()
+						    } else {
+							// Redistribute space among remaining children.
+							if (target) redistributeContainer (paneLoc.container, target);
+						    }
+						})
+						.catch(function(error) { // promise rejected, do NOT continue pane manipulation
+						    if (error) {
+							console.error (error);
+						    }
+						})
+						.finally(() => {
+						    UHM.messageBoxCancel()
+						});
 					} else { // PathwayMapper pane unaffected, OK to close
 						removePaneAndAdjacentDivider();
 						if (paneLoc.container.children.length === 1) {

--- a/NGCHM/WebContent/javascript/PluginInstanceManager.js
+++ b/NGCHM/WebContent/javascript/PluginInstanceManager.js
@@ -143,11 +143,6 @@
 	UHM.setMessageBoxText(warningText);
 	UHM.setMessageBoxButton(1, UTIL.imageTable.okButton, 'OK Button');
 	UHM.displayMessageBox();
-	let okButton = dialog.querySelector('#msgBoxBtnImg_1');
-	okButton.addEventListener('click', function handleOkClick(e) {
-		okButton.removeEventListener('click', handleOkClick);
-		UHM.messageBoxCancel();
-	})
     };
 
     // Send a Vanodi message to all plugin instances except the one identified by srcNonce.

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -166,7 +166,10 @@
 		    });
 	    } else {
 		    text = "<br>You have just saved a heat map as a NG-CHM file.  In order to see your saved changes, you will want to open this new file using the NG-CHM File Viewer application.  If you have not already downloaded the application, press the Download Viewer button to get the latest version.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>";
-		    UHM.setMessageBoxButton(1, "images/downloadViewer.png", "Download NG-CHM Viewer App", MMGR.zipAppDownload);
+		    UHM.setMessageBoxButton(1, "images/downloadViewer.png", "Download NG-CHM Viewer App", () => {
+			MMGR.zipAppDownload();
+			UHM.messageBoxCancel();
+		    });
 	    }
 	    UHM.setMessageBoxText(text);
 	    UHM.setMessageBoxButton(3, UTIL.imageTable.cancelSmall, "Cancel button", UHM.messageBoxCancel);
@@ -1159,8 +1162,8 @@
 	UHM.initMessageBox();
 	UHM.setMessageBoxHeader("Dendrogram selection lost");
 	UHM.setMessageBoxText("<br>" + "The summary panel dendrogram selection was lost due to keyboard movement of the focus region. " +
-		"Click CANCEL to undo the keyboard movement and restore the dendrogram selection. " +
-		"Otherwise, click CLOSE to just close this dialog." );
+		"Click UNDO to undo the keyboard movement and restore the dendrogram selection. " +
+		"Otherwise, hit Enter or click OK to just close this dialog." );
 	const undoFunction = function undoFunction (restoreInfo) {
 	    if (debug) console.log ("Undoing keyboard movement and dendrogram selection loss.", restoreInfo);
 	    UHM.messageBoxCancel();
@@ -1180,8 +1183,8 @@
 	    selectedStart: mapItem.selectedStart,
 	    selectedStop: mapItem.selectedStop
 	});
-	UHM.setMessageBoxButton(1, UTIL.imageTable.prefCancel, "Cancel button", undoFunction);
-	UHM.setMessageBoxButton(3, UTIL.imageTable.closeButton, "Close button", UHM.messageBoxCancel);
+	UHM.setMessageBoxButton('undo', { type: 'text', text: 'Undo' }, "Undo button", undoFunction);
+	UHM.setMessageBoxButton('ok', { type: 'text', text: 'OK', default: true }, "OK button", UHM.messageBoxCancel);
 	UHM.displayMessageBox();
     }
 

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -172,7 +172,11 @@
 		    });
 	    }
 	    UHM.setMessageBoxText(text);
-	    UHM.setMessageBoxButton(3, UTIL.imageTable.cancelSmall, "Cancel button", UHM.messageBoxCancel);
+	    UHM.setMessageBoxButton(
+		'cancel',
+		{ type: 'image', src: UTIL.imageTable.cancelSmall, default: true },
+		"Cancel button",
+		UHM.messageBoxCancel);
 	    UHM.displayMessageBox();
     }
 
@@ -706,30 +710,42 @@
 				    text = "<br>You have elected to save changes made to this NG-CHM heat map file.<br><br>You may save them to a new NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
 			    }
 			    UHM.setMessageBoxText(text);
-			    UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save To NG-CHM File", saveHeatMapToNgchm);
-			    UHM.setMessageBoxButton(4, UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
+			    addSaveToNgchmButton();
+			    addCancelSaveButton();
 		    } else {
 			    // If so, is read only?
 			    if (heatMap.isReadOnly()) {
 				    text = "<br>You have elected to save changes made to this READ-ONLY heat map. READ-ONLY heat maps cannot be updated.<br><br>However, you may save these changes to an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
 				    UHM.setMessageBoxText(text);
-				    UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save To NG-CHM File", saveHeatMapToNgchm);
-				    UHM.setMessageBoxButton(4, UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
+				    addSaveToNgchmButton();
+				    addCancelSaveButton();
 			    } else {
 				    text = "<br>You have elected to save changes made to this heat map.<br><br>You have the option to save these changes to the original map OR to save them to an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
 				    UHM.setMessageBoxText(text);
-				    UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save To NG-CHM File", saveHeatMapToNgchm);
+				    addSaveToNgchmButton();
 				    UHM.setMessageBoxButton(2, "images/saveOriginal.png", "Save Original Heat Map", saveHeatMapToServer);
-				    UHM.setMessageBoxButton(3, UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
+				    addCancelSaveButton();
 			    }
 		    }
 	    } else {
 		    text = "<br>There are no changes to save to this heat map at this time.<br><br>However, you may save the map as an NG-CHM file that may be opened using the NG-CHM File Viewer application.<br><br>";
 		    UHM.setMessageBoxText(text);
-		    UHM.setMessageBoxButton(1, UTIL.imageTable.saveNgchm, "Save To NG-CHM File", saveHeatMapToNgchm);
-		    UHM.setMessageBoxButton(4, UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
+		    addSaveToNgchmButton();
+		    addCancelSaveButton();
 	    }
 	    UHM.displayMessageBox();
+
+	    function addSaveToNgchmButton() {
+		UHM.setMessageBoxButton(
+		    'saveToNgchm',
+		    { type: 'image', src: UTIL.imageTable.saveNgchm, default: true },
+		    "Save To NG-CHM File",
+		    saveHeatMapToNgchm);
+	    }
+
+	    function addCancelSaveButton() {
+		UHM.setMessageBoxButton('cancelSave', UTIL.imageTable.closeButton, "Cancel Save", UHM.messageBoxCancel);
+	    }
     }
 
     const hamburgerButton = document.getElementById('barMenu_btn');
@@ -1297,7 +1313,12 @@
 			case 'Enter':
 				if (UHM.messageBoxIsVisible()) {
 				    e.preventDefault();
-				    UHM.messageBoxCancel();
+				    const defaultButton = document.querySelector('#msgBoxButtons button.default');
+				    if (defaultButton) {
+					defaultButton.onclick();
+				    } else {
+					UHM.messageBoxCancel();
+				    }
 				}
 				break;
 			default:

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -381,14 +381,10 @@ UHM.invalidFileFormat = function() {
  **********************************************************************************/
 UHM.initMessageBox = function() {
 	document.getElementById('msgBox').style.display = 'none';
-	document.getElementById('msgBoxBtnImg_1').style.display = 'none';
-	document.getElementById('msgBoxBtnImg_2').style.display = 'none';
-	document.getElementById('msgBoxBtnImg_3').style.display = 'none';
-	document.getElementById('msgBoxBtnImg_4').style.display = 'none';
-	document.getElementById('msgBoxBtnImg_1')['onclick'] = null;
-	document.getElementById('msgBoxBtnImg_2')['onclick'] = null;
-	document.getElementById('msgBoxBtnImg_3')['onclick'] = null;
-	document.getElementById('msgBoxBtnImg_4')['onclick'] = null;
+	const msgBoxButtons = document.getElementById ('msgBoxButtons');
+	while (msgBoxButtons.firstChild) {
+	    msgBoxButtons.removeChild (msgBoxButtons.firstChild);
+	}
 	document.getElementById('messageOpen_btn').style.display = 'none';
 }
 
@@ -417,15 +413,56 @@ UHM.displayMessageBox = function() {
 	msgBox.style.top = (headerpanel.offsetTop + 15) + 'px';
 }
 
-UHM.setMessageBoxButton = function(buttonId, imageSrc, altText, onClick) {
-	var buttonImg = document.getElementById('msgBoxBtnImg_'+buttonId);
-	buttonImg.style.display = '';
-	buttonImg.src = imageSrc;
-	buttonImg.alt = altText;
-	if (onClick != undefined) {
-		buttonImg.onclick = function() { onClick(); };
+/* Add a button to the message box.
+ *
+ * buttonId is an id specific to this button within the message box.
+ * Note: on initialization/finalization all buttons are removed from
+ * the message box.
+ *
+ * buttonSpec describes the button to insert.
+ * Deprecated usage: a string that identifies the image source of the button.
+ * New usage: an object that describes the button.  Fields are:
+ * - type: 'image' or 'text'
+ * - src: if type == 'image' source of the button image
+ * - text: if type == 'text' content of the button
+ * - default: if true class default added to the button element.
+ *
+ * altText: added to 'alt' attribute of img buttons.
+ *
+ * onClick: function called when the user clicks on the button.  Defaults
+ * to UHM.messageBoxCancel.
+ */
+UHM.setMessageBoxButton = function(buttonId, buttonSpec, altText, onClick) {
+	const msgBoxButtons = document.getElementById ('msgBoxButtons');
+	const newButton = document.createElement('button');
+	newButton.id = 'msgBoxBtn_'+buttonId;
+	if (typeof buttonSpec != 'object') {
+	    buttonSpec = {
+		type: 'image',
+		src: buttonSpec,
+	    };
 	}
-}
+	if (buttonSpec.type == 'image') {
+	    const newImage = document.createElement('img');
+	    newImage.src = buttonSpec.src;
+	    newImage.alt = altText;
+	    newButton.appendChild (newImage);
+	} else {
+	    const newText = document.createElement('span');
+	    newText.classList.add('button');
+	    newText.innerText = buttonSpec.text;
+	    newButton.appendChild (newText);
+	}
+	if (buttonSpec.default) {
+	    newButton.classList.add('default');
+	}
+	if (onClick == undefined) {
+	    newButton.onclick = UHM.messageBoxCancel;
+	} else {
+	    newButton.onclick = function() { onClick(); };
+	}
+	msgBoxButtons.appendChild (newButton);
+};
 
 UHM.messageBoxCancel = function() {
 	UHM.initMessageBox();

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -448,10 +448,11 @@ UHM.setMessageBoxButton = function(buttonId, buttonSpec, altText, onClick) {
 	    newImage.alt = altText;
 	    newButton.appendChild (newImage);
 	} else {
-	    const newText = document.createElement('span');
-	    newText.classList.add('button');
+	    const newText = UTIL.newElement('span.button');
 	    newText.innerText = buttonSpec.text;
-	    newButton.appendChild (newText);
+	    const newWrapper = UTIL.newElement('span.spanbuttonwrapper');
+	    newWrapper.appendChild (newText);
+	    newButton.appendChild (newWrapper);
 	}
 	if (buttonSpec.default) {
 	    newButton.classList.add('default');


### PR DESCRIPTION
This pull request implements changes to the button appearance and behavior I promised when discussing the 'dendrogram selection lost dialog' we discussed recently.

Specifically, it:
- changes the buttons on that dialog from Cancel and Close to Undo and OK, with OK being the default,
- makes the "Save to .NGCHM" button the default when saving a NGCHM,
- makes pressing the Enter key execute the default button if it exists, otherwise it just cancels the dialog
- renders the default button, if any, differently from the others.
