### PR TITLE
Create Build Tag w/ GitHub Actions

### DIFF
--- a/.github/workflows/create-build-tag.yml
+++ b/.github/workflows/create-build-tag.yml
@@ -40,6 +40,6 @@ jobs:
         id: make_build_tag
         uses: marohrdanz/build-number-tag@v1.0.0
         with:
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.DQS_DEV_BCB_ACTIONS_TOKEN }}
           prefix: '-build-'
           version_prefix: ${{ steps.get_version_number.outputs.version_number }}

--- a/.github/workflows/create-build-tag.yml
+++ b/.github/workflows/create-build-tag.yml
@@ -1,0 +1,45 @@
+##
+## GitHub action workflow to add a incremental build tag to the repo based on
+##
+##  - Version number in CompatibilityManager.js
+##  - Existing '-build-' tags in repo
+##
+##  For example, if there are exiting tags in the repo:
+##
+##  - 2.22.1-build-4
+##  - 2.21.0-build-3
+##  - 2.20.1-build-2
+##
+##  and the version from CompatibilityManager.js is '2.22.1', the new tag
+##  will be: 2.22.1-build-5.
+##
+on:
+  push:
+    branches:
+      main
+
+jobs:
+  make_build_tag:
+    runs-on: ubuntu-latest
+    name: Creating build number tag based on version
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.sha }}
+      # https://github.com/marohrdanz/extract-version-from-file
+      - name: Get version number
+        id: get_version_number
+        uses: marohrdanz/extract-version-from-file@v1.0.0
+        with:
+          file_path: 'NGCHM/WebContent/javascript/CompatibilityManager.js'
+          start_string: 'CM.version = '
+      # https://github.com/marohrdanz/build-number-tag
+      - name: Create Build Number Tag
+        id: make_build_tag
+        uses: marohrdanz/build-number-tag@v1.0.0
+        with:
+          token: ${{ secrets.TOKEN }}
+          prefix: '-build-'
+          version_prefix: ${{ steps.get_version_number.outputs.version_number }}

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -19,6 +19,8 @@ CM.jsonConfigStr = "{\"row_configuration\": {\"classifications\": {\"show\": \"Y
 		    "Full length description of this heatmap\",\"summary_width\": \"50\",\"builder_version\": \"NA\",\"summary_height\": \"100\",\"detail_width\": \"50\",\"detail_height\": \"100\",\"read_only\": \"N\",\"version_id\": \"1.0.0\",\"map_cut_rows\": \"0\",\"map_cut_cols\": \"0\"}}}";
 
 // CURRENT VERSION NUMBER
+// WARNING: The line starting with 'CM.version = ' is used by .github/workflows/create-build-tag.yml for creating build tags
+// If making changes to the string 'CM.version = ', make corresponding changes to the 'start_string' in that action.
 CM.version = "2.23.1";	// Please increment rightmost digit for each interim version
 CM.versionCheckUrl = "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
 CM.viewerAppUrl = "https://bioinformatics.mdanderson.org/ngchm/ZipAppDownload";


### PR DESCRIPTION
This PR adds a GitHub Action Workflow that will add a new tag to the repo upon pushes to the 'main' branch. This tag will be based on the version number in CompatibilityManager.js and existing build tags in the repo. See example below.

**GitHub Actions included in this workflow** 

This workflow includes three GitHub Actions:

1. [actions/checkout](https://github.com/marketplace/actions/checkout)
   This is for checking out the code in order to extract the version number from CompatibilityManager.js
2. [marohrdanz/extract-version-from-file](https://github.com/marohrdanz/extract-version-from-file)
   This is a quick-and-dirty action created to extract the version number from CompatibilityManager.js. There **has** to be a better way to do this. We added the requirement for a version number prefix in our meeting yesterday, and I made it a separate action because 1) it's really fragile, and 2) to allow for better modularity among our actions.
3. [marohrdanz/build-number-tag](https://github.com/marohrdanz/build-number-tag)
   This action creates the tag based on the output from step 2 and the existing build tags in the repo.

**For Example**

If the current version in CompatibilityManager.js is 2.22.1, the first tag created will be `2.22.1-build-1`.

With the next push to main, if the CompatibilityManager.js version is unchanged, the tag will be `2.22.1-build-2`.

With the next push to main, if the CompatibilityManager.js version is bumped to 2.22.2, the tag will be `2.22.2-build-3`.

I.e. the build number always increases by 1, regardless of the version number from CompatibilityManager.js.