### PR TITLE
Three fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN apt-get update && apt-get install -y rsync zip
 COPY NGCHM /NGCHM/
 
 ENV VIEWER=/artifacts/viewer
+ENV WC=/NGCHM/WebContent
 RUN mkdir -p ${VIEWER} &&\
-    rsync -a --delete --exclude WEB-INF --exclude META-INF NGCHM/WebContent/ ${VIEWER}/ &&\
+    rsync -a ${WC}/chm.html ${WC}/chmHelp.html ${WC}/icons.svg ${WC}/css ${WC}/images ${WC}/javascript ${VIEWER}/ &&\
     (cd ${VIEWER}/ && zip -q -r -9 NGCHM_FileApp.zip .)
 
 

--- a/NGCHM/WebContent/javascript/API.js
+++ b/NGCHM/WebContent/javascript/API.js
@@ -249,6 +249,9 @@
 	    if (options.indexOf('noBuilderUploads') !== -1) {
 		LNK.enableBuilderUploads = false;
 	    }
+	    if (options.indexOf('requireFocus') !== -1) {
+		UTIL.setKeyData ('require-focus', true);
+	    }
     }
 
     /**********************************************************************************

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -841,8 +841,12 @@ DET.setDetailDataHeight = function (mapItem, size) {
 	DET.detInitGl(mapItem);
 	mapItem.updateSelection();
 	try {
-	    document.getElementById("viewport").setAttribute("content", "height=device-height");
-	    document.getElementById("viewport").setAttribute("content", "");
+	    const viewport = document.getElementById ("viewport");
+	    if (viewport) {
+		// In case viewport element is missing in widgetized applications.
+		viewport.setAttribute("content", "height=device-height");
+		viewport.setAttribute("content", "");
+	    }
 	} catch(err) {
 	    console.error("Unable to adjust viewport content attribute");
 	}
@@ -895,8 +899,12 @@ DET.setDetailDataHeight = function (mapItem, size) {
 	clearDendroSelection(mapItem);
 	mapItem.updateSelection();
 	try {
-	    document.getElementById("viewport").setAttribute("content", "height=device-height");
-	    document.getElementById("viewport").setAttribute("content", "");
+	    const viewport = document.getElementById ("viewport");
+	    if (viewport) {
+		// In case viewport element is missing in widgetized applications.
+		viewport.setAttribute("content", "height=device-height");
+		viewport.setAttribute("content", "");
+	    }
 	} catch(err) {
 	    console.error("Unable to adjust viewport content attribute");
 	}

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -1546,7 +1546,8 @@
 	]);
 
 	UTIL.setKeyData ('keyActions', [ keyToAction, actions ]);
-	document.addEventListener ("keydown", keyNavigate);
+	const navElement = document.getElementById('NGCHMEmbed') || document;
+	navElement.addEventListener ("keydown", keyNavigate);
 
 	function keyNavigate (e) {
 	    const debug = false;

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -450,6 +450,7 @@
 		    }
 	    }
 	    document.getElementById("summary_canvas").addEventListener('wheel', DEV.handleScroll, UTIL.passiveCompat({capture: false, passive: false}));
+	    initializeKeyNavigation();
     };
 
     /**********************************************************************************
@@ -1316,7 +1317,7 @@
      * Handle user key press events received at the document level.
      *
      *********************************************************************************************/
-    {
+    function initializeKeyNavigation() {
 	// Table of all available keyboard actions.
 	const actions = new Map();
 
@@ -1546,7 +1547,10 @@
 	]);
 
 	UTIL.setKeyData ('keyActions', [ keyToAction, actions ]);
-	const navElement = document.getElementById('NGCHMEmbed') || document;
+	let navElement = document;
+	if (UTIL.getKeyData ('require-focus')) {
+	    navElement = document.getElementById('NGCHMEmbed');
+	}
 	navElement.addEventListener ("keydown", keyNavigate);
 
 	function keyNavigate (e) {
@@ -1648,9 +1652,9 @@
 		default: true,
 	    });
 	    UHM.displayNewMessageBox(msgBox);
-	};
-
+	}
     }
+
     /*********************************************************************************************/
 
 	/*


### PR DESCRIPTION
Three small fixes to NG-CHM:

- one I had in my queue (explicitly specify viewer artifacts to include: without it extraneous files in my environment were being included),
- one was inspired by the view port element missing bug in the builder (for other embedded maps), and
- one required by fixes to the builder (not listening to key down events outside the NG-CHM), but which can also impact other cases of embedded NG-CHMs.
