### PR TITLE
Don't attempt to draw zero height column covariate bars. Fixes issue #499.

### DIFF
--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -2350,6 +2350,11 @@ DET.drawColorPlotColClassBar = function(mapItem, pixels, pos, rowClassBarWidth, 
  * bar and scatter plot class bars on a given detail heat map canvas.
  **********************************************************************************/
 DET.drawScatterBarPlotColClassBar = function(mapItem, pixels, pos, rowClassBarWidth, start, length, currentClassBar, classBarValues, colorMap) {
+	// Don't attempt to draw zero height (or less) covariate bar.
+	if (currentClassBar.height <= DET.paddingHeight) {
+	    return pos;
+	}
+
 	const colors = currentClassBar.getScatterBarPlotColors ();
 	const matrix = SUM.buildScatterBarPlotMatrix(currentClassBar.height - DET.paddingHeight, 1, classBarValues.slice (start-1, start-1+length), currentClassBar);
 


### PR DESCRIPTION
Nothing to draw if bar height <= zero.
Negative height bars try to allocate a matrix of negative length, hence the error.