### PR TITLE
Change dendrogram scale multiplicatively on scroll.

### DIFF
--- a/NGCHM/WebContent/javascript/DetailDendrogram.js
+++ b/NGCHM/WebContent/javascript/DetailDendrogram.js
@@ -226,14 +226,14 @@
 			// Determine delta from scroll event
 			delta = e.deltaY;
 		}
-		let newLevel = this.zoomLevel - delta/800;
+		let newLevel = this.zoomLevel * (1 - delta/800);
 		if (newLevel < 1 && this.zoomLevel > 1 ||
 		    newLevel > 1 && this.zoomLevel < 1) {
 			// Pause at default zoom level.
 			this.zoomLevel = 1;
 			this.draw();
 		} else {
-			if (newLevel < 0.1) newLevel = 0.1;
+			if (newLevel < 0.0001) newLevel = 0.0001;
 			if (newLevel > 100) newLevel = 100;
 			if (newLevel !== this.zoomLevel) {
 				this.zoomLevel = newLevel;


### PR DESCRIPTION
See issue #504.

The issue was caused by the initial dendrogram scale being set to a value smaller than the minimum scale allowed after a dendrogram rescale. (I think because the minimum dendrogram leaf height is very large.)

So scrolling would try to reduce the scale, but then increase it to the minimum allowed value.

Reducing the minimum dendrogram scale would only delay the issue to maps with even longer minimum leaf heights.

I've also noticed issues on other maps where scaling only makes miniscule changes to the dendrogram height and it's extremely tedious to get the desired scale.

So, this patch changes the scroll behavior so that it multiplies the dendrogram scale for each level of zoom, rather than incrementing/ decrementing the scale by a constant each time.
