### PR TITLE
Actions fix for releases

### DIFF
--- a/.github/workflows/build-NGCHMSupportFiles.yml
+++ b/.github/workflows/build-NGCHMSupportFiles.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   Build-ShaidyMapGen-and-ngchmWdiget-min:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       NGCHMSupportFiles_REPOSITORY: 'MD-Anderson-Bioinformatics/NGCHMSupportFiles'
       NGCHMSupportFiles_BRANCH: 'main'

--- a/.github/workflows/build-NGCHMSupportFiles.yml
+++ b/.github/workflows/build-NGCHMSupportFiles.yml
@@ -15,20 +15,21 @@ jobs:
     env:
       NGCHMSupportFiles_REPOSITORY: 'MD-Anderson-Bioinformatics/NGCHMSupportFiles'
       NGCHMSupportFiles_BRANCH: 'main'
+      JAVA_VERSION: 8
     steps:
       - name: Check out release tag
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
       - name: Get version number for use in NGCHMSupportFiles R package
         ## This collects just the version number, e.g. '2.20.3', for use 
         ## in DESCRIPTION file of NGCHMSupportFiles R package
         id: get_version
-        run: echo ::set-output name=version::${GITHUB_REF#refs/*/}
-      - name: Set up JDK for java 8
-        uses: actions/setup-java@v2
+        run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: Set up JDK for java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: "${{ env.JAVA_VERSION }}"
           distribution: 'temurin'
       - name: Build ShaidyMapGen.jar
         run: |
@@ -39,7 +40,7 @@ jobs:
           cd NGCHM
           ant -f build_ngchmApp.xml
       - name: Check out NGCHMSupportFiles repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ env.NGCHMSupportFiles_REPOSITORY }}
           token: ${{ secrets.DQS_DEV_BCB_ACTIONS_TOKEN }}

--- a/.github/workflows/build-NGCHMSupportFiles.yml
+++ b/.github/workflows/build-NGCHMSupportFiles.yml
@@ -7,9 +7,11 @@ name: Build artifacts for NGCHMSupportFiles
 on:
   release:
     types: [published]
+  workflow_dispatch:
+
 jobs:
   Build-ShaidyMapGen-and-ngchmWdiget-min:
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     env:
       NGCHMSupportFiles_REPOSITORY: 'MD-Anderson-Bioinformatics/NGCHMSupportFiles'
       NGCHMSupportFiles_BRANCH: 'main'

--- a/.github/workflows/create-tag-and-build-NG-CHM-Artifacts.yml
+++ b/.github/workflows/create-tag-and-build-NG-CHM-Artifacts.yml
@@ -37,6 +37,7 @@ on:
   push:
     branches:
       main
+  workflow_dispatch:
 
 jobs:
   make_build_tag:

--- a/.github/workflows/create-tag-and-build-NG-CHM-Artifacts.yml
+++ b/.github/workflows/create-tag-and-build-NG-CHM-Artifacts.yml
@@ -40,7 +40,7 @@ on:
 
 jobs:
   make_build_tag:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Creating Build Number Tag
     strategy:
       max-parallel: 1


### PR DESCRIPTION
This is a fix for the [failed action](https://github.com/MD-Anderson-Bioinformatics/NG-CHM/actions/runs/5293516110) during the release of 2.24.0.

Analysis showed the failure was due to the code trying to run on what appears to be a minified version of custom.js, and getting to the part for the cbioportal logo:

```js
   logo: "https://www.cbioportal.org/images/cbioportal_logo.png",
```

This part includes the search string "images/", which is hard-coded into `CompilerUtilities.java`, therefore triggering an attempt to copy a file 'cbioportal_logo.png'. Of course that file does not exist in this repo, resulting in failure of the action.

For reasons **I do not understand**, changing the runner from macOS to ubuntu eliminates the problem (I tested in a personal fork of this repo).

In addition to this "fix", this pull request

- Adds `workflow_dispatch` to allow each workflow to be triggered manually
  - This allows us to create the artifacts w/o creating a new release or push if desired
- Specifies ubuntu 22.04 for the runner instead of just using the latest stable version
- Updates the GitHub actions "checkout" and "setup-java" from v2 -> v3
  - This eliminates the deprecation notice: 
       Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-java@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
- Replaces the deprecated `set-output` command
  - This eliminates the deprecation notice:
       The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/