### PR TITLE
Get version from action instead of tag

### DIFF
--- a/.github/workflows/build-NGCHMSupportFiles.yml
+++ b/.github/workflows/build-NGCHMSupportFiles.yml
@@ -21,11 +21,14 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.ref }}
-      - name: Get version number for use in NGCHMSupportFiles R package
-        ## This collects just the version number, e.g. '2.20.3', for use 
-        ## in DESCRIPTION file of NGCHMSupportFiles R package
-        id: get_version
-        run: echo "version=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      # https://github.com/marohrdanz/extract-version-from-file
+      # Output from this step is version from CompatibilityManager as 'version_number'.
+      - name: Get version number
+        id: get_version_number
+        uses: marohrdanz/extract-version-from-file@v1.0.0
+        with:
+          file_path: 'NGCHM/WebContent/javascript/CompatibilityManager.js'
+          start_string: 'CM.version = '
       - name: Set up JDK for java ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v3
         with:
@@ -52,7 +55,7 @@ jobs:
           cp ../NGCHM/ShaidyMapGen.jar inst/java
           cp ../NGCHM/ngchmWidget-min.js inst/js
           sed -i.bak '/Version:/d' DESCRIPTION
-          echo "Version: ${{ steps.get_version.outputs.version }}" >> DESCRIPTION
+          echo "Version: ${{ steps.get_version_number.outputs.version_number }}" >> DESCRIPTION
           cat DESCRIPTION
       - name: Verify NGCHMSupportFile R build
         run: |


### PR DESCRIPTION
The recent manually triggered run of build-NGCHMSupportFiles.yml [failed](https://github.com/MD-Anderson-Bioinformatics/NG-CHM/actions/runs/5327325468).

Reason for the failure: the action obtains the software version from the release tag. But there was no release tag because the action was triggered manually, so there was no version number. Therefore the building of the NGCHM-R package failed with error: `Malformed package version.`

To resolve the issue, this pull request updates the action use our [previously written custom github action](https://github.com/marohrdanz/extract-version-from-file) to extract the version number from CompatibilityManager.js. This is the same mechanism used by create-tag-and-build-NG-CHM-Artifacts.yml for obtaining the software version number (see Pull Request #442 ).