### PR TITLE
Use build args to send git info to Docker

### DIFF
--- a/.github/workflows/build-NGCHMSupportFiles.yml
+++ b/.github/workflows/build-NGCHMSupportFiles.yml
@@ -16,6 +16,8 @@ jobs:
       NGCHMSupportFiles_REPOSITORY: 'MD-Anderson-Bioinformatics/NGCHMSupportFiles'
       NGCHMSupportFiles_BRANCH: 'main'
       JAVA_VERSION: 11
+      GIT_COMMIT: ${{ github.sha }}
+      GIT_LATEST_TAG: ${{ github.ref }}
     steps:
       - name: Check out release tag
         uses: actions/checkout@v3

--- a/.github/workflows/create-tag-and-build-NG-CHM-Artifacts.yml
+++ b/.github/workflows/create-tag-and-build-NG-CHM-Artifacts.yml
@@ -73,6 +73,9 @@ jobs:
       tag_name: ${{ steps.make_tag.outputs.tag_name }}
   build_artifacts:
     runs-on: ubuntu-latest
+    env:
+      GIT_COMMIT: ${{ github.sha }}
+      GIT_LATEST_TAG: ${{ github.ref }}
     name: Build Artifacts
     needs: make_build_tag
     strategy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN mkdir -p ${VIEWER} &&\
 
 # Stage 1: Create Shaidy R MapGen
 FROM ant AS shaidy
+ARG GIT_COMMIT
+ARG GIT_LATEST_TAG
 COPY NGCHM /NGCHM/
 
 ENV SMAPGEN=/artifacts/shaidymapgen
@@ -30,6 +32,8 @@ RUN mkdir -p ${SMAPGEN} &&\
 
 # Stage 2: Create Galaxy MapGen
 FROM ant AS galaxy
+ARG GIT_COMMIT
+ARG GIT_LATEST_TAG
 COPY NGCHM /NGCHM/
 
 ENV GMAPGEN=/artifacts/galaxymapgen
@@ -39,8 +43,9 @@ RUN mkdir -p ${GMAPGEN} &&\
 
 # Stage 3: Create NG-CHM Standalone
 FROM ant AS standalone
+ARG GIT_COMMIT
+ARG GIT_LATEST_TAG
 COPY NGCHM /NGCHM/
-COPY .git /.git/
 
 ENV STANDALONE=/artifacts/standalone
 ENV SERVERAPP=/artifacts/server.app
@@ -56,6 +61,8 @@ RUN mkdir -p ${STANDALONE} &&\
 
 # Stage 4: Create GUIBuilderMapGen
 FROM ant AS builder
+ARG GIT_COMMIT
+ARG GIT_LATEST_TAG
 COPY NGCHM /NGCHM/
 
 ENV BMAPGEN=/artifacts/builder

--- a/NGCHM/build_galaxymapgen.xml
+++ b/NGCHM/build_galaxymapgen.xml
@@ -10,6 +10,7 @@
     <property name="dir.workspace" value="${dir.buildfile}"/>
     <property name="dir.jarfile" value="."/>
     <property name="mapgen.path" value="${dir.jarfile}/GalaxyMapGen.jar"/>
+    <property environment="env"/>
 
 	<!-- Clean the NGCHM Project -->
     <target name="clean">
@@ -24,22 +25,12 @@
 
 	<!-- Execute the JAVA class to build the GalaxyMapGen JAR-->
 	<target name="create_run_jar" depends="compile">
-		<exec executable="git" outputproperty="commithash">
-			<arg value="rev-parse"/>
-			<arg value="--short"/>
-			<arg value="HEAD"/>
-		</exec>
-		<exec executable="git" outputproperty="latest_tag">
-			<arg value="describe"/>
-			<arg value="--tags"/>
-			<arg value="--abbrev=0"/>
-		</exec>
         <jar destfile="${mapgen.path}" filesetmanifest="mergewithoutmain">
             <manifest>
                 <attribute name="Main-Class" value="mda.ngchm.datagenerator.GalaxyMapGen"/>
                 <attribute name="Class-Path" value="."/>
-                <attribute name="Git-Hash" value="${commithash}"/>
-                <attribute name="Git-Tag" value="${latest_tag}"/>
+                <attribute name="Git-Hash" value="${env.GIT_COMMIT}"/>
+                <attribute name="Git-Tag" value="${env.GIT_LATEST_TAG}"/>
             </manifest>
             <fileset dir="${dir.jarfile}/build/classes">
             	<exclude name="**/WEB-INF/**"/>

--- a/NGCHM/build_guibuildermapgen.xml
+++ b/NGCHM/build_guibuildermapgen.xml
@@ -10,6 +10,7 @@
     <property name="dir.workspace" value="${dir.buildfile}"/>
     <property name="dir.jarfile" value="."/>
     <property name="mapgen.path" value="${dir.jarfile}/GUIBuilderMapGen.jar"/>
+    <property environment="env"/>
 
 	<!-- Clean the NGCHM Project -->
     <target name="clean">
@@ -24,22 +25,12 @@
 
 	<!-- Execute the JAVA class to build the GUIBuilderMapGen JAR-->
 	<target name="create_run_jar" depends="compile">
-		<exec executable="git" outputproperty="commithash">
-			<arg value="rev-parse"/>
-			<arg value="--short"/>
-			<arg value="HEAD"/>
-		</exec>
-		<exec executable="git" outputproperty="latest_tag">
-			<arg value="describe"/>
-			<arg value="--tags"/>
-			<arg value="--abbrev=0"/>
-		</exec>
         <jar destfile="${mapgen.path}" filesetmanifest="mergewithoutmain">
             <manifest>
                 <attribute name="Main-Class" value="mda.ngchm.datagenerator.HeatmapDataGenerator"/>
                 <attribute name="Class-Path" value="."/>
-                <attribute name="Git-Hash" value="${commithash}"/>
-                <attribute name="Git-Tag" value="${latest_tag}"/>
+                <attribute name="Git-Hash" value="${env.GIT_COMMIT}"/>
+                <attribute name="Git-Tag" value="${env.GIT_LATEST_TAG}"/>
             </manifest>
             <fileset dir="${dir.jarfile}/build/classes">
             	<exclude name="**/WEB-INF/**"/>

--- a/NGCHM/build_ngchmApp.xml
+++ b/NGCHM/build_ngchmApp.xml
@@ -9,6 +9,7 @@
 	<property name="dir.jarfile" value="./WebContent/WEB-INF/lib"/>
 	<property name="java.dir" value="./src/mda/ngchm/util/"/>
 	<property name="closure.jar" value="${dir.jarfile}/closure-compiler-v20230802.jar"/>
+	<property environment="env"/>
 
 	<!-- Execute a Javascript miminizer to generate a minified custom-min.js file -->
 	<target name="minimize_custom_js">
@@ -68,14 +69,8 @@
 	    <mapper type="glob" from="*.js" to="ngchmEmbed-min.js"/>
 	    <targetfile/>
 	</apply>
-	<exec executable="git" outputproperty="commithash"><arg value="rev-parse"/><arg value="--short"/><arg value="HEAD"/></exec>
-	<echo file="ngchmEmbed-min.js" append="true">/* commit hash: ${commithash} */${line.separator} </echo>
-	<exec executable="git" outputproperty="latest_tag">
-	    <arg value="describe"/>
-	    <arg value="--tags"/>
-	    <arg value="--abbrev=0"/>
-	</exec>
-	<echo file="ngchmEmbed-min.js" append="true">/* build tag: ${latest_tag} */${line.separator}</echo>
+	<echo file="ngchmEmbed-min.js" append="true">/* commit hash: ${env.GIT_COMMIT} */${line.separator} </echo>
+	<echo file="ngchmEmbed-min.js" append="true">/* build tag: ${env.GIT_LATEST_TAG} */${line.separator}</echo>
 	</target>  
 
 	<!-- Execute the JAVA NGCHM_AppGenerator to create the stand-alone viewer ngChmApp.html file -->
@@ -111,14 +106,8 @@
 	        <pathelement path="build/classes"/>
 	    </classpath>
 	</java>
-	<exec executable="git" outputproperty="commithash"><arg value="rev-parse"/><arg value="--short"/><arg value="HEAD"/></exec>
-	<echo file="ngchmWidget-min.js" append="true">/* commit hash: ${commithash} */${line.separator}</echo>
-	<exec executable="git" outputproperty="latest_tag">
-	    <arg value="describe"/>
-	    <arg value="--tags"/>
-	    <arg value="--abbrev=0"/>
-	</exec>
-	<echo file="ngchmWidget-min.js" append="true">/* build tag: ${latest_tag} */${line.separator}</echo>
+	<echo file="ngchmWidget-min.js" append="true">/* commit hash: ${env.GIT_COMMIT} */${line.separator}</echo>
+	<echo file="ngchmWidget-min.js" append="true">/* build tag: ${env.GIT_LATEST_TAG} */${line.separator}</echo>
 	</target>
 
 	<!-- Target to call the steps to build just the ngChmApp.html stand-alone viewer file -->

--- a/NGCHM/build_shaidyRmapgen.xml
+++ b/NGCHM/build_shaidyRmapgen.xml
@@ -10,6 +10,7 @@
     <property name="dir.workspace" value="${dir.buildfile}"/>
     <property name="dir.jarfile" value="."/>
     <property name="mapgen.path" value="${dir.jarfile}/ShaidyMapGen.jar"/>
+    <property environment="env"/>
 
 	<!-- Clean the NGCHM Project -->
     <target name="clean">
@@ -24,22 +25,12 @@
 
 	<!-- Execute the JAVA class to build the ShaidyRMapGen JAR-->
 	<target name="create_run_jar" depends="compile">
-		<exec executable="git" outputproperty="commithash">
-			<arg value="rev-parse"/>
-			<arg value="--short"/>
-			<arg value="HEAD"/>
-		</exec>
-		<exec executable="git" outputproperty="latest_tag">
-			<arg value="describe"/>
-			<arg value="--tags"/>
-			<arg value="--abbrev=0"/>
-		</exec>
         <jar destfile="${mapgen.path}" filesetmanifest="mergewithoutmain">
             <manifest>
                 <attribute name="Main-Class" value="mda.ngchm.datagenerator.ShaidyRMapGen"/>
                 <attribute name="Class-Path" value="."/>
-                <attribute name="Git-Hash" value="${commithash}"/>
-                <attribute name="Git-Tag" value="${latest_tag}"/>
+                <attribute name="Git-Hash" value="${env.GIT_COMMIT}"/>
+                <attribute name="Git-Tag" value="${env.GIT_LATEST_TAG}"/>
             </manifest>
             <fileset dir="${dir.jarfile}/build/classes">
             	<exclude name="**/WEB-INF/**"/>

--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ This [demo video](https://youtu.be/DuObpGNpDhw) quickly demonstrates the viewer'
 
 The project [homepage](https://bioinformatics.mdanderson.org/main/NG-CHM-V2:Overview)
 includes additional documentation, introductory videos, and tutorials. 
+
+To build image:
+
+```bash
+docker build \
+       --build-arg="GIT_COMMIT=$(git rev-parse --short HEAD)" \
+       --build-arg="GIT_LATEST_TAG=$(git describe --tags --abbrev=0)" \
+       -t ngchm:latest .
+```


### PR DESCRIPTION
We have been using git information in the ant builds, but doing so in a clumsy way: using `exec git` in the ant build file, which necessitated passing in the whole .git directory in the Dockerfile.

This pull request changes this to instead pass the git information via build arguments. For example:

```bash
docker build \
       --build-arg="GIT_COMMIT=$(git rev-parse --short HEAD)" \
       --build-arg="GIT_LATEST_TAG=$(git describe --tags --abbrev=0)" \
       -t ngchm:latest .
```
