### PR TITLE
Fix changing gap/cut color not updating in Summary Map

### DIFF
--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -494,6 +494,7 @@
       colors: colorMap.getColors(),
       thresholds: colorMap.getThresholds(),
       missingColor: colorMap.getMissingColor(),
+      cutsColor: colorMap.getCutsColor(),
     };
 
     const summaryProps = {


### PR DESCRIPTION
Gap/cut color was not updating in the summary map.  See issue #501.

The cause was that the gap/cut color was not included in the saved drawing properties that determines when a redraw is needed.

This fix adds the gap/cut color to the saved properties.