### PR TITLE
Fix chrome console errors about bad label elements

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -40,7 +40,7 @@
 				<div id="detail_buttons" class="divTable hide" data-show-on-load>
 				    <div class="divRow">
 					<div id="MapRow">
-					    <label for="mapName">Map name:</label>
+					    <span>Map name:</span>
 					    <div class="divLeft" id="mapName"
 						data-title='Map Name'
 						data-intro="The map's name. Hover over the name to see the map's caption (if provided)."
@@ -50,7 +50,7 @@
 				    </div>
 				    <div class="divRow">
 					<div id="SelectionsRow">
-						<label>Search:</label>
+						<span>Search:</span>
 						<select name="search_on" id="search_on" class='srchSelect'
 						    data-title='Search Target'
 						    data-intro='Select whether to search on map labels or a specific covariate.'
@@ -274,7 +274,7 @@
 											<option value="A3">Ledger/Tabloid (11 x 17 inches)</option>
 											<option value="A4">A4 International (210 x 297 mm)</option>
 										    </select>
-										    <label>Orientation:</label>
+										    <span>Orientation:</span>
 										    <div>
 											<input id="pdfInputPortrait" type="radio" name="orientation" value="portrait"> Portrait
 											<input id="pdfInputLandscape" type="radio" name="orientation" value="Landscape" checked> Landscape
@@ -367,7 +367,7 @@
 							        <!-- WIDGET INCLUDE -->
 								<div class="msgBoxTxt"></div>
 								<div class="msgBoxProgressDiv" style="display: none;">
-								    <label>Progress:</label>
+								    <span>Progress:</span>
 								    <progress class="msgBoxProgressBar"></progress>
 								</div>
 							    </div>


### PR DESCRIPTION
Chrome now complains about label elements with missing or incorrect "for" attributes. See issue #505.

I found four \<label> elements in chm.html that were semantically labels, but not labels in the strict HTML sense as referring to a specific form input element.

I changed them to plain \<span> elements.  Since we weren't formatted them any differently from plain elements, I didn't add a class field that we could use as a css selector in the future.  I could easily be convinced to add one.