### PR TITLE
Address GitHub Actions issues

### DIFF
--- a/.github/workflows/NG-CHM-Artifacts_push_main.yml
+++ b/.github/workflows/NG-CHM-Artifacts_push_main.yml
@@ -133,10 +133,10 @@ jobs:
           cp ../NGCHM/WebContent/ngChmApp.html viewer.standalone/
           echo "Build tag: ${{ needs.make_build_tag.outputs.tag_name }}" > viewer.standalone/build_version.txt
           echo "Git hash: ${{ github.sha }}" >> viewer.standalone/build_version.txt
+          git rm viewer.build/server.app/javascript/*.js # rm old minified js files
           cp -r ../NGCHM/WebContent/server.app viewer.build/
           echo "Build tag: ${{ needs.make_build_tag.outputs.tag_name }}" > viewer.build/server.app/build_version.txt
           echo "Git hash: ${{ github.sha }}" >> viewer.build/server.app/build_version.txt
-          rm -rf ../NGCHM/WebContent/server.app
           cp -r ../NGCHM/WebContent/ viewer.source/
           echo "Build tag: ${{ needs.make_build_tag.outputs.tag_name }}" > viewer.source/WebContent/build_version.txt
           echo "Git hash: ${{ github.sha }}" >> viewer.source/WebContent/build_version.txt

--- a/.github/workflows/NG-CHM-Artifacts_release.yml
+++ b/.github/workflows/NG-CHM-Artifacts_release.yml
@@ -89,6 +89,7 @@ jobs:
           cp ../NGCHM/WebContent/ngChmApp.html viewer.standalone/
           echo "Build tag: ${{ github.ref_name }}" > viewer.standalone/build_version.txt
           echo "Git hash: ${{ github.sha }}" >> viewer.standalone/build_version.txt
+          git rm viewer.build/server.app/javascript/*.js # rm old minified js files
           cp -r ../NGCHM/WebContent/server.app viewer.build/
           echo "Build tag: ${{ github.ref_name }}" > viewer.build/server.app/build_version.txt
           echo "Git hash: ${{ github.sha }}" >> viewer.build/server.app/build_version.txt

--- a/.github/workflows/NGCHMSupportFiles_release.yml
+++ b/.github/workflows/NGCHMSupportFiles_release.yml
@@ -69,6 +69,13 @@ jobs:
           sed -i.bak '/Version:/d' DESCRIPTION
           echo "Version: ${{ steps.get_version_number.outputs.version_number }}" >> DESCRIPTION
           cat DESCRIPTION
+      - name: Set up R enviornment
+        uses: r-lib/actions/setup-r@v2
+      - name: Install knitr (for vignette)
+        uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: knitr
+          working-directory: NGCHMSupportFiles
       - name: Verify NGCHMSupportFile R build
         run: |
           cd NGCHMSupportFiles


### PR DESCRIPTION
This merge request addresses the following issues with GitHub Actions:

- NGCHMSupportFiles action failed because of newly added vignette
  - Issue: #534
  - Resolution: add knitr to GitHub Action workflow to allow vignette to build
- NG-CHM-Artifacts actions leave old minified js files in viewer.build/server.app/javascript
  - Issue: #528
  - Resolution: add a `git rm` to remove these old files