### PR TITLE
Convert cuts_color to hex if needed

### DIFF
--- a/NGCHM/src/mda/ngchm/datagenerator/ShaidyRMapGen.java
+++ b/NGCHM/src/mda/ngchm/datagenerator/ShaidyRMapGen.java
@@ -494,6 +494,9 @@ public class ShaidyRMapGen {
 					fileout.println("\t\t\"grid_color\" : \"" + gridColor + "\",");
 				}	
 				String cutsColor = (String)layer.get("cuts_color");
+				if (!cutsColor.startsWith("#")) {
+					cutsColor = ColorMapGenerator.hexForColor(cutsColor);
+				}
 				if (cutsColor != null) {
 					fileout.println("\t\t\"cuts_color\" : \"" + cutsColor + "\",");
 				}	


### PR DESCRIPTION
This is bug fix for this issue in the NGCHM R package repo: https://github.com/MD-Anderson-Bioinformatics/NGCHM-R/issues/35

Strictly speaking, this change in ShaidyRMapGen.java is all that is required to address the bug. However, for other color variables, the R code checks that the color name is valid. That check is included in a related PR in the NGCHM R package repo: https://github.com/MD-Anderson-Bioinformatics/NGCHM-R/pull/65