### PR TITLE
Add asynchronous canSAR.ai linkout

### DIFF
--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -260,20 +260,31 @@
           selectMode,
       );
 
-    // Wrap linkout in a check function.
+    // Wrap linkout in a check function that displays error message if no labels or if first label is '-'.
+    // If the linkout callback is async, then check function is async. Otherwise, the check function is sync.
     if (selectMode === linkouts.SINGLE_SELECT) {
       linkoutFn = (function (lofn) {
-        return function (labels) {
-          if (labels.length === 0 || labels[0] === "-") {
-            //console.log("No information known for the selected label"); //alert
-            UHM.systemMessage(
-              "NG-CHM Plug-in",
-              "No information known for the selected label.",
-            );
-          } else {
-            lofn(labels);
+        if (lofn.constructor.name === "AsyncFunction") { // plugin callback is async so check function is async
+          return async function (labels) {
+            if (labels.length === 0 || labels[0] === "-") {
+              UHM.systemMessage("NG-CHM Plug-in", "No information known for the selected label.");
+            } else {
+              try {
+                await lofn(labels);
+              } catch (e) {
+                UHM.linkoutError(e);
+              }
+            }
           }
-        };
+        } else { // plugin callback is sync so check function is sync
+          return function (labels) {
+            if (labels.length === 0 || labels[0] === "-") {
+              UHM.systemMessage("NG-CHM Plug-in", "No information known for the selected label.");
+            } else {
+              lofn(labels);
+            }
+          }
+        }
       })(linkoutFn);
     } else if (selectMode === linkouts.MULTI_SELECT) {
       linkoutFn = (function (lofn) {

--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -288,19 +288,31 @@
       })(linkoutFn);
     } else if (selectMode === linkouts.MULTI_SELECT) {
       linkoutFn = (function (lofn) {
-        return function (labels) {
-          var idx = labels.indexOf("-");
-          if (idx >= 0) labels.splice(idx, 1);
-          if (labels.length === 0) {
-            //console.log("No information known for any selected label"); //alert
-            UHM.systemMessage(
-              "NG-CHM Plug-in",
-              "No information known for any selected label.",
-            );
-          } else {
-            lofn(labels);
+        if (lofn.constructor.name === "AsyncFunction") { // plugin callback is async so check function is async
+          return async function (labels) {
+            var idx = labels.indexOf("-");
+            if (idx >= 0) labels.splice(idx, 1);
+            if (labels.length === 0) {
+              UHM.systemMessage("NG-CHM Plug-in", "No information known for any selected label.");
+            } else {
+              try {
+                await lofn(labels);
+              } catch (e) {
+                UHM.linkoutError(e);
+              }
+            }
           }
-        };
+        } else { // plugin callback is sync so check function is sync
+          return function (labels) {
+            var idx = labels.indexOf("-");
+            if (idx >= 0) labels.splice(idx, 1);
+            if (labels.length === 0) {
+              UHM.systemMessage("NG-CHM Plug-in", "No information known for any selected label.");
+            } else {
+              lofn(labels);
+            }
+          };
+        }
       })(linkoutFn);
     } else {
       console.log("Unknown selectMode: " + selectMode); //alert

--- a/NGCHM/WebContent/javascript/custom/custom.js
+++ b/NGCHM/WebContent/javascript/custom/custom.js
@@ -297,7 +297,11 @@ function linkoutHelp () {
 (function (linkouts) {
   linkouts.addPlugin({
     name: "canSAR.ai",
-    description: "Opens canSAR.ai for protein corresponding to gene.<br>(Queries UniProt for primary accession number of protien corresponding to gene.)",
+    description: "Adds linkout to canSAR.ai for either of:" +
+         "<ul>" +
+           "<li>primary accession number (UniProt)<br>canSAR.ai is indexed by primary accession number</li>" +
+           "<li>gene name<br>queries UniProt for primary accession number of protein corresponding to gene</li>" +
+         "</ul>",
     version: "0.1.0",
     site: "https://cansar.ai",
     logo: "https://cansar.ai/img/logo.svg",
@@ -306,24 +310,35 @@ function linkoutHelp () {
         menuEntry: "View canSAR.ai",
         typeName: "bio.gene.hugo",
         selectMode: linkouts.SINGLE_SELECT,
-        linkoutFn: openCanSARdotAI,
+        linkoutFn: openCanSAR_gene,
+      },
+      {
+        menuEntry: "View canSAR.ai",
+        typeName: "bio.protein.uniprotid",
+        selectMode: linkouts.SINGLE_SELECT,
+        linkoutFn: openCanSAR_uniprotID,
       }
     ]
   })
 
-  /*
+  /**
    * Open canSAR.ai for a gene name.
-   *
-   * This function is asynchronous because it queries UniProt to get the primary accession number
-   * for the protein corresponding to the gene input argument.
    */
-  async function openCanSARdotAI(names) {
+  async function openCanSAR_gene(names) {
     const gname = names[0];
     const primaryAccession = await linkouts.getUniprotID(gname);
     const cansarURL = "https://cansar.ai/target/" + encodeURIComponent(primaryAccession) + "/synopsis"
     linkouts.openUrl(cansarURL, "CansarAI", { noframe: true });
   }
 
+  /**
+   * Open canSAR.ai for a UniProt ID (primary accession number).
+   */
+  function openCanSAR_uniprotID(ids) {
+    const primaryAccession = ids[0];
+    const cansarURL = "https://cansar.ai/target/" + encodeURIComponent(primaryAccession) + "/synopsis"
+    linkouts.openUrl(cansarURL, "CansarAI", { noframe: true });
+  }
 
 
 })(linkouts);


### PR DESCRIPTION
This PR adds a linkout to canSAR.ai: https://cansar.ai

This linkout is for UniProt primary accession numbers and gene names. The data in canSAR.ai data is referenced via protein primary accession numbers, so for gene names this linkout queries UniProt to retrieve the primary accession number of the protein corresponding to the gene.

Because of the UniProt query for gene names, the linkout is asynchronous. The viewer code has been updated to allow for handling asynchronous linkouts.