### PR TITLE
Special coordinates and black points option

### DIFF
--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -498,6 +498,7 @@ div.paneHeader button {
 
 .menuItem:hover {
      background-color: LightGray;
+     cursor: pointer; /* hint to user this is clickable */
 }
 
 .menuItem.disabled:hover {

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -511,6 +511,25 @@ div.paneHeader button {
 	height: 1em;
 }
 
+/* menuItem withSubItems are not clickable
+ * Example: "2D Scatter Plot" with special coordinate sub items.
+ * */
+.menuItem.withSubItems{
+	background-color: #ffffff;
+	cursor: default;
+}
+.menuItem.withSubItems:hover{
+	background-color: #ffffff;
+}
+
+/* The sub items are clickable
+ * Example, "PCA (row)" 2D scatter plot
+ * */
+.menuSubItem{
+	padding: 1px 10px 1px 30px;
+	cursor: pointer;
+}
+
 .gearPanel {
 	position: absolute;
 	border-radius: 10px;

--- a/NGCHM/WebContent/javascript/ColorMapManager.js
+++ b/NGCHM/WebContent/javascript/ColorMapManager.js
@@ -173,6 +173,9 @@
       if (value == "!CUT!") {
         return { r: 255, g: 255, b: 255, a: 255 };
       }
+      if (value === "All Black") {
+        return { r: 0, g: 0, b: 0, a: 255 };
+      }
       if (type == "discrete") {
         for (var i = 0; i < thresholds.length; i++) {
           if (value == thresholds[i]) {

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -1555,9 +1555,13 @@ var linkoutsVersion = "undefined";
 
       // If the plugin handles special coordinates, add them as separate plugins.
       if (pp.params.handlesSpecialCoordinates === true) {
-        pp.disabled = true; /* disable because functionality of plugin will be handled by the "generalPlugin" sub item below*/
-        panePlugins.push(pp); /* TODO: this is mildly inefficient: we are adding the plugin twice */
         let specialCoordinates = getSpecialCoordinatesList();
+        if (specialCoordinates.length === 0) { // no special coordinates in NG-CHM, so treat like regular plugin
+          panePlugins.push(pp);
+          return pp;
+        }
+        pp.disabled = true; /* disable because functionality of plugin will be handled by the "generalPlugin" sub item below*/
+        panePlugins.push(pp);
         /* Create a plugin for each of the special coordinates */
         specialCoordinates.forEach((sc) => {
           let specialPlugin = deepClone(pp);

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -952,6 +952,30 @@
       mi.innerText = text;
       menu.appendChild(mi);
     }
+    /**
+     * Creates a new menu sub-item and appends it to the menu.
+     *
+     * @param {string} text - The text to be displayed on the menu sub-item.
+     * @param {Function} callback - The function to be called when the menu sub-item is clicked.
+     */
+    function menuSubItem(text, callback) {
+      const msi = UTIL.newElement("DIV.menuSubItem.menuItem");
+      msi.onclick = () => { callback(); };
+      msi.innerText = text;
+      menu.appendChild(msi);
+    }
+
+    /**
+     * Creates a new menu item with sub-items and appends it to the menu.
+     *
+     * @param {string} text - The text to be displayed on the menu item.
+     */
+    function menuItemWSubItems(text) {
+      const mi = UTIL.newElement("DIV.menuItem.withSubItems");
+      mi.innerText = text;
+      menu.appendChild(mi);
+    }
+
 
     function menuSeparator() {
       const mb = UTIL.newElement("DIV.menuItemBorder");
@@ -973,10 +997,18 @@
           resizePane(loc.pane);
         });
       });
-      // Add plugin options.
+      // Add plugin options to pane menu. (i.e. the plugin menu and sub-menu items)
       paneExtraOptions.forEach((opt) => {
-        if (opt.enabled()) {
-          menuItem(opt.name, () => {
+        if (opt.enabled() && opt.data.disabled) {
+          menuItemWSubItems(opt.name); // <-- disabled, because sub-items are what user should click on
+        } else if (opt.enabled() && opt.data.subItem) {
+          menuSubItem(opt.data.nameInPaneMenu, () => { // <-- E.g. 'PCA (row)' or 'UMAP (column)' special coordinates
+            const loc = findPaneLocation(icon);
+            emptyPaneLocation(loc);
+            opt.switcher(loc, opt.data);
+          });
+        } else if (opt.enabled()) {
+          menuItem(opt.name, () => { // <-- plugin w/o any special coordinate options
             const loc = findPaneLocation(icon);
             emptyPaneLocation(loc);
             opt.switcher(loc, opt.data);

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -997,7 +997,7 @@
           resizePane(loc.pane);
         });
       });
-      // Add plugin options to pane menu. (i.e. the plugin menu and sub-menu items)
+      // Add plugin menu items and any sub-menu items to pane menu.
       paneExtraOptions.forEach((opt) => {
         if (opt.enabled() && opt.data.disabled) {
           menuItemWSubItems(opt.name); // <-- disabled, because sub-items are what user should click on

--- a/NGCHM/WebContent/javascript/custom/custom.js
+++ b/NGCHM/WebContent/javascript/custom/custom.js
@@ -7,7 +7,7 @@ linkouts.setVersion("2023-11-21");
 linkouts.addPanePlugin({
   name: "2D ScatterPlot",
   helpText: "Creates a two-dimensional scatter plot",
-  params: {},
+  params: {handlesSpecialCoordinates: true},
   src: "https://www.ngchm.net/Plugins/ScatterPlot/index.html",
 });
 
@@ -15,7 +15,7 @@ linkouts.addPanePlugin({
 linkouts.addPanePlugin({
   name: "3D ScatterPlot",
   helpText: "Creates a three-dimensional scatter plot",
-  params: {},
+  params: {handlesSpecialCoordinates: true},
   src: "https://www.ngchm.net/Plugins/ScatterPlot3D/index.html",
 });
 


### PR DESCRIPTION
This pull request addresses two feature requests: 

1. Special coordinates
   If the NG-CHM has covariate bars for coordinates (e.g. PCA, UMAP), Pane Menu entries to directly open those special coordinates in the plugin are shown. (Screenshot below)
2. "All Black" gear menu dropdown option
   A dropdown option to color points all black is added to the "Color By" dropdown. If no other covariates available, this is the default.

Example: Below is a screenshot of the pane menu for an NG-CHM with special coordinate covariate bars. In this example, clicking on "PCA (column)" under 2D Scatter Plot will directly open the 2D scatter plot for the PCA coordinates, clicking "UMAP (column)" under 2D Scatter plot will directly open the 2D scatter plot for UMAP coordinates, etc. etc.

![specalCoordsScreenshot](https://github.com/user-attachments/assets/18b2939f-ffe0-4b3a-99eb-6743b743b74d)
