### PR TITLE
Allow the site manager to specify multiple custom.js files

### DIFF
--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -477,14 +477,14 @@
     function initNextScript(idx) {
       // Terminate when all scripts have been loaded.
       if (idx >= scriptList.length) {
-	console.log ("All customization scripts loaded");
-	linkouts.setVersion (scriptVersions.join("; "));
-	CUST.definePluginLinkouts();
-	return;
+        console.log ("All customization scripts loaded");
+        linkouts.setVersion (scriptVersions.join("; "));
+        CUST.definePluginLinkouts();
+        return;
       }
       if (idx > 0) {
-	script = document.createElement("script");
-	head.appendChild(script);
+        script = document.createElement("script");
+        head.appendChild(script);
       }
 
       linkouts.setVersion ("undefined");
@@ -492,24 +492,24 @@
       script.src = scriptList[idx];
       // Most browsers:
       script.onload = function() {
-	const version = linkouts.getVersion();
-	scriptVersions.push (version);
-	console.log (`Loaded custom script ${scriptList[idx]} version ${version}`);
-	initNextScript(idx+1);
+        const version = linkouts.getVersion();
+        scriptVersions.push (version);
+        console.log (`Loaded custom script ${scriptList[idx]} version ${version}`);
+        initNextScript(idx+1);
       };
       // Internet explorer:
       script.onreadystatechange = function () {
         if (this.readyState == "complete") {
-	  const version = linkouts.getVersion();
-	  scriptVersions.push (version);
-	  console.log (`Loaded custom script ${scriptList[idx]} version ${version}`);
-	  initNextScript(idx+1);
+          const version = linkouts.getVersion();
+          scriptVersions.push (version);
+          console.log (`Loaded custom script ${scriptList[idx]} version ${version}`);
+          initNextScript(idx+1);
         }
       };
       script.onerror = function () {
-	scriptVersions.push ("error");
-	console.warn(`Loading of custom script ${scriptList[idx]} failed.`);
-	initNextScript(idx+1);
+        scriptVersions.push ("error");
+        console.warn(`Loading of custom script ${scriptList[idx]} failed.`);
+        initNextScript(idx+1);
       };
     }
   };

--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -455,7 +455,7 @@
     const heatMap = MMGR.getHeatMap();
     CUST.beforeLoadCustom(heatMap);
     const head = document.getElementsByTagName("head")[0];
-    const script = document.createElement("script");
+    let script = document.createElement("script");
     if (CFG.custom_specified) {
       initScript();
     } else {
@@ -465,20 +465,43 @@
     }
     head.appendChild(script);
 
+    var scriptList;
+
     function initScript() {
+      const ScriptSeparator = ';';
+      scriptList = CFG.custom_script.split(ScriptSeparator).map(x => x.trim()).filter(x => x != '');
+      initNextScript (0);
+    }
+
+    function initNextScript(idx) {
+      // Terminate when all scripts have been loaded.
+      if (idx >= scriptList.length) {
+	console.log ("All customization scripts loaded");
+	CUST.definePluginLinkouts();
+	return;
+      }
+      if (idx > 0) {
+	script = document.createElement("script");
+	head.appendChild(script);
+      }
+
       script.type = "text/javascript";
-      script.src = CFG.custom_script;
+      script.src = scriptList[idx];
       // Most browsers:
-      script.onload = CUST.definePluginLinkouts;
+      script.onload = function() {
+	console.log ("Loaded custom script " + scriptList[idx]);
+	initNextScript(idx+1);
+      };
       // Internet explorer:
       script.onreadystatechange = function () {
         if (this.readyState == "complete") {
-          CUST.definePluginLinkouts();
+	  console.log ("Loaded custom script " + scriptList[idx]);
+	  initNextScript(idx+1);
         }
       };
       script.onerror = function () {
-        console.warn("Loading of " + CFG.custom_script + " failed.");
-        CUST.definePluginLinkouts();
+        console.warn("Loading of " + scriptList[idx] + " failed.");
+	initNextScript(idx+1);
       };
     }
   };

--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -466,6 +466,7 @@
     head.appendChild(script);
 
     var scriptList;
+    const scriptVersions = [];
 
     function initScript() {
       const ScriptSeparator = ';';
@@ -477,6 +478,7 @@
       // Terminate when all scripts have been loaded.
       if (idx >= scriptList.length) {
 	console.log ("All customization scripts loaded");
+	linkouts.setVersion (scriptVersions.join("; "));
 	CUST.definePluginLinkouts();
 	return;
       }
@@ -485,22 +487,28 @@
 	head.appendChild(script);
       }
 
+      linkouts.setVersion ("undefined");
       script.type = "text/javascript";
       script.src = scriptList[idx];
       // Most browsers:
       script.onload = function() {
-	console.log ("Loaded custom script " + scriptList[idx]);
+	const version = linkouts.getVersion();
+	scriptVersions.push (version);
+	console.log (`Loaded custom script ${scriptList[idx]} version ${version}`);
 	initNextScript(idx+1);
       };
       // Internet explorer:
       script.onreadystatechange = function () {
         if (this.readyState == "complete") {
-	  console.log ("Loaded custom script " + scriptList[idx]);
+	  const version = linkouts.getVersion();
+	  scriptVersions.push (version);
+	  console.log (`Loaded custom script ${scriptList[idx]} version ${version}`);
 	  initNextScript(idx+1);
         }
       };
       script.onerror = function () {
-        console.warn("Loading of " + scriptList[idx] + " failed.");
+	scriptVersions.push ("error");
+	console.warn(`Loading of custom script ${scriptList[idx]} failed.`);
 	initNextScript(idx+1);
       };
     }


### PR DESCRIPTION
Allows site manager to specify multiple customization scripts using the data-ngchm-custom-file attribute on the document.body element. Customization scripts are separated by semicolons (;) and trimmed.

Example
`<body ... data-ngchm-custom-file="javascript/custom/custom.js; site.js">`

Outstanding issues:
Currently there is no way for each script to specify its own version number.  Only the last version number set is kept.