### PR TITLE
Added capabilities to the User Preference Manager

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -493,6 +493,8 @@
 		<!-- NEW CHUNK -->
 		<script src="javascript/NGCHM_Util.js"></script>
 		<script src="javascript/CompatibilityManager.js"></script>
+		<script src="javascript/UI-Table.js"></script>
+		<script src="javascript/ColorPalettes.js"></script>
 		<script src="javascript/FlickManager.js"></script>
 		<script src="javascript/UserHelpManager.js"></script>
 		<script src="javascript/HeatMapRep.js"></script>

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -280,6 +280,10 @@ div.pane canvas {
     opacity: 25%;
 }
 
+.upm_label_type {
+  width: 15em;
+}
+
 .msgBox,
 #msgBox {
     display: grid;
@@ -1163,7 +1167,7 @@ th.breakpointContainer {
 }
 
 #prefs {
-	width: 420px;
+	min-width: 420px;
 	overflow: hidden;
 	position: absolute;
 	background-color: var(--dialog-body-background);

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -16,6 +16,7 @@
 	--dialog-header-background: #CBD1EA;
 	--dialog-body-background: #D2E3FF; /* #CBDBF6; */
 	--pressed-button-color: #b0ffb0;
+  --chm-table-color: #0843c1;
 	--selected-button-color: #00abcd;
 	--disabled-button-color: #7f7f7f;
 	--button-background-color: #efefef;
@@ -912,7 +913,7 @@ button#layers_open_close[data-state='closed'] div.closed {
     font-size: 0.80rem !important;
     font-family: Arial;
     font-weight: normal;
-    color: #0843c1;
+    color: var(--chm-table-color);
     vertical-align: middle;
     text-align: left;
 }
@@ -1815,6 +1816,14 @@ iframe.nopointer {
 	background-color: #CBDBF6;
 }
 
+.ngchm-ui-table {
+  width: 100%;
+}
+
+#all_searchPref {
+  width: 100%;
+}
+
 span.errorMessage {
     color: red;
 }
@@ -1875,6 +1884,77 @@ div#droptarget.visible {
 .keyTable TBODY TD:nth-child(2) {
     padding-left: 0.2em;
     padding-right: 0.2em;
+}
+
+.histogram {
+  display: grid;
+  margin-top: 2em;
+  width: fit-content;
+}
+.histogram-header {
+  font-weight: bold;
+  font-size: 0.8rem;
+  padding-left: 0.3125em;
+  padding-right: 1em;
+  color: var(--chm-table-color);
+  grid-row: 1;
+  grid-column: 1;
+}
+.histogram-update {
+  grid-row: 2;
+  grid-column: 1;
+  justify-self: right;
+  padding-top: 1em;
+  padding-right: 1em;
+}
+.histogram-preview {
+  grid-column: 2;
+  grid-row: 1 / 4;
+  height: 120px;
+  width: 110px;
+  position: relative;
+  display: flex;
+}
+/* The histogram preview is 120px high by 110 px wide.
+ * The main color section is a 100px wide by 100px high box at the top-left.
+ * To the immediate right of the main color section is a 10px wide missing color box.
+ * Overlaying both of these boxes is the 110px wide by 100px high histogram SVG.
+ * Below all of these are the left and legend boxes.
+ */
+.preview-main-color {
+  position: absolute;
+  left: 0px;
+  width: 100px;
+  top: 0px;
+  height: 100px;
+}
+.preview-missing-color {
+  position: absolute;
+  left: 100px;
+  width: 10px;
+  top: 0px;
+  height: 100px;
+}
+.preview-svg {
+  position: absolute;
+  left: 0px;
+  width: 110px;
+  top: 0px;
+  height: 100px;
+}
+.preview-legend-left {
+  position: absolute;
+  left: 5px;
+  top: 100px;
+  margin-top: 5px;
+  font-size: 10px;
+}
+.preview-legend-right {
+  position: absolute;
+  right: 5px;
+  top: 100px;
+  margin-top: 5px;
+  font-size: 10px;
 }
 
 /* Use opacity:0 instead of display:none for elements that will be faded in

--- a/NGCHM/WebContent/css/NGCHM.css
+++ b/NGCHM/WebContent/css/NGCHM.css
@@ -1886,6 +1886,11 @@ div#droptarget.visible {
     padding-right: 0.2em;
 }
 
+.chmTblRow textarea.ngchm-upm-top-items-text {
+  width: 100%;
+  margin-left: 0;
+}
+
 .histogram {
   display: grid;
   margin-top: 2em;

--- a/NGCHM/WebContent/javascript/ColorMapManager.js
+++ b/NGCHM/WebContent/javascript/ColorMapManager.js
@@ -352,13 +352,25 @@
       return colorMap;
     };
 
-    this.setColorMap = function (colorMapName, colorMap, type) {
+    this.getColorMapJSON = function (type, colorMapName) {
       const colorMapIdx = type === "data" ? 0 : type === "row" ? 1 : 2;
-      const existingColorMap =
-        colorMapCollection[colorMapIdx][colorMapName].color_map;
-      existingColorMap.colors = colorMap.getColors();
-      existingColorMap.thresholds = colorMap.getThresholds();
-      existingColorMap.missing = colorMap.getMissingColor();
+      return JSON.stringify(colorMapCollection[colorMapIdx][colorMapName].color_map);
+    };
+
+    this.setColorMap = function (type, colorMapName, colorMap) {
+      const colorMapIdx = type === "data" ? 0 : type === "row" ? 1 : 2;
+      let newMap;
+      if (colorMap instanceof CMM.ColorMap) {
+        newMap = {
+          type: colorMap.getType(),
+          colors: colorMap.getColors(),
+          thresholds: colorMap.getThresholds(),
+          missing: colorMap.getMissingColor(),
+        };
+      } else {
+        newMap = colorMap;
+      }
+      Object.assign (colorMapCollection[colorMapIdx][colorMapName].color_map, newMap);
     };
   };
 

--- a/NGCHM/WebContent/javascript/ColorPalettes.js
+++ b/NGCHM/WebContent/javascript/ColorPalettes.js
@@ -1,0 +1,203 @@
+/**********************************************************************************
+ * COLOR PALETTE MANAGER:  Manage color palettes.
+ **********************************************************************************/
+(function () {
+  "use strict";
+  NgChm.markFile();
+
+  // Define the NgChm Color Palettes namespace.
+  const PALETTES = NgChm.createNS("NgChm.PALETTES");
+  PALETTES.addPredefinedPalettes = addPredefinedPalettes;  // Export this function.
+
+  // Import other namespaces we need.
+  const UTIL = NgChm.importNS("NgChm.UTIL");
+
+  const presetPalettes = new Map();
+
+  presetPalettes.set ("Data Layer", [
+    {
+      name: "Blue Red",
+      colors: ["#0000FF", "#FFFFFF", "#FF0000"],
+      missing: "#000000",
+    },
+    {
+      name: "Rainbow",
+      colors: [
+        "#FF0000",
+        "#FF8000",
+        "#FFFF00",
+        "#00FF00",
+        "#0000FF",
+        "#FF00FF",
+      ],
+      missing: "#000000",
+    },
+    {
+      name: "Green Red",
+      colors: ["#00FF00", "#000000", "#FF0000"],
+      missing: "#FFFFFF",
+    },
+    {
+      name: "Greyscale",
+      colors: ["#000000", "#A0A0A0", "#FFFFFF"],
+      missing: "#EBEB00",
+    },
+  ]);
+  presetPalettes.set ("Discrete", [
+    {
+      name: "Palette 1",
+        colors: [
+          "#1f77b4",
+          "#ff7f0e",
+          "#2ca02c",
+          "#d62728",
+          "#9467bd",
+          "#8c564b",
+          "#e377c2",
+          "#7f7f7f",
+          "#bcbd22",
+          "#17becf",
+        ],
+        missing: "#ffffff",
+      },
+    {
+      name: "Palette 2",
+        colors: [
+          "#1f77b4",
+          "#aec7e8",
+          "#ff7f0e",
+          "#ffbb78",
+          "#2ca02c",
+          "#98df8a",
+          "#d62728",
+          "#ff9896",
+          "#9467bd",
+          "#c5b0d5",
+          "#8c564b",
+          "#c49c94",
+          "#e377c2",
+          "#f7b6d2",
+          "#7f7f7f",
+          "#c7c7c7",
+          "#bcbd22",
+          "#dbdb8d",
+          "#17becf",
+          "#9edae5",
+        ],
+        missing: "#ffffff",
+    },
+    {
+      name: "Palette3 3",
+        colors: [
+          "#393b79",
+          "#637939",
+          "#8c6d31",
+          "#843c39",
+          "#7b4173",
+          "#5254a3",
+          "#8ca252",
+          "#bd9e39",
+          "#ad494a",
+          "#a55194",
+          "#6b6ecf",
+          "#b5cf6b",
+          "#e7ba52",
+          "#d6616b",
+          "#ce6dbd",
+          "#9c9ede",
+          "#cedb9c",
+          "#e7cb94",
+          "#e7969c",
+          "#de9ed6",
+        ],
+        missing: "#ffffff",
+    },
+  ]);
+  presetPalettes.set ("Continuous", [
+    { name: "Greyscale",
+      colors: ["#FFFFFF", "#000000"],
+        missing: "#FF0000",
+    },
+    {
+      name: "Rainbow",
+        colors: ["#FF0000", "#FF8000", "#FFFF00", "#00FF00", "#0000FF", "#FF00FF"],
+        missing: "#000000",
+    },
+    { name: "Green Red",
+      colors: ["#00FF00", "#000000", "#FF0000"],
+        missing: "#ffffff",
+    },
+  ]);
+
+  // Add the predefined color schemes put here
+  // colorMapAxis: "row", "col", or undefined (for data layer),
+  // colorMapType: "Discrete", "Continuous", or undefined (for data layer)
+  function addPredefinedPalettes(prefTable, key, clickHandler, colorMapAxis, colorMapType) {
+    prefTable.addRow( ["Choose a pre-defined color palette:"], { underline: true });
+    prefTable.addBlankSpace();
+    prefTable.addIndent();
+
+    // Iterate over the palette definitions.
+    // Add rows of at most three palettes per row.
+    const presets = [];
+    const names = [];
+    for (const preset of presetPalettes.get(colorMapType? colorMapType : "Data Layer")) {
+      presets.push(genPreset(key, clickHandler, preset.colors, preset.missing, colorMapAxis, colorMapType));
+      names.push(`&nbsp;<b>${preset.name}</b>`);
+      if (names.length == 3) {
+        prefTable.addRow(presets.slice());
+        prefTable.addRow(names.slice(), { fontWeight: 'bold' });
+        presets.length = 0;
+        names.length = 0;
+      }
+    }
+    if (names.length > 0) {
+      prefTable.addRow(presets.slice());
+      prefTable.addRow(names.slice(), { fontWeight: 'bold' });
+    }
+    prefTable.popIndent();
+  }
+
+  /* Generate a color scheme preset element.
+   * It consists of a gradient bar for the colors in the color scheme
+   * followed by a box containing the color for missing values.
+   * When clicked, the layer (based on key, axis, and mapType) breaks
+   * are set to those of the preset.
+   *
+   * A unique id is assigned to each new preset to assist automated tests.
+   */
+  var presetId = 0;
+  function genPreset(key, clickHandler, colors, missingColor, axis, mapType) {
+    ++presetId;
+    const gradient = "linear-gradient(to right, " + colors.join(", ") + ")";
+    const onclick = genHandler (key, colors, missingColor, axis, mapType);
+    const colorsEl = UTIL.newElement(
+      "DIV.presetPalette",
+      { id: "preset" + presetId, style: { background: gradient } },
+      null,
+      function (el) {
+        el.onclick = onclick;
+        return el;
+      },
+    );
+    const missingEl = UTIL.newElement(
+      "DIV.presetPaletteMissingColor",
+      { style: { background: missingColor } },
+      null,
+      function (el) {
+        el.onclick = onclick;
+        return el;
+      },
+    );
+    return UTIL.newElement("DIV", { style: { display: "flex" } }, [
+      colorsEl,
+      missingEl,
+    ]);
+    function genHandler (key, colors, missingColor, axis, mapType) {
+      return function () {
+        clickHandler(key, colors, missingColor, axis, mapType);
+      }
+    }
+  }
+
+})();

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -6,8 +6,7 @@
   const CM = NgChm.createNS("NgChm.CM");
 
   const UTIL = NgChm.importNS("NgChm.UTIL");
-  const debugCM = UTIL.getURLParameter("debug").split(",").includes("compatibility");
-
+  const debugCM = UTIL.getDebugFlag("compatibility");
 
   // jsonConfigStr contains the entire configuration.json file.  This was previously located in a JSON file stored with the application code
   // but has been placed here at the top of the CompatibilityManager class so that the configuration can be utilized in File Mode.

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -9,17 +9,59 @@
   const debugCM = UTIL.getURLParameter("debug").split(",").includes("compatibility");
 
 
-  // This string contains the entire configuration.json file.  This was previously located in a JSON file stored with the application code
+  // jsonConfigStr contains the entire configuration.json file.  This was previously located in a JSON file stored with the application code
   // but has been placed here at the top of the CompatibilityManager class so that the configuration can be utilized in File Mode.
-  CM.jsonConfigStr =
-    '{"row_configuration": {"classifications": {"show": "Y","height": 15,"bar_type": "color_plot","fg_color": "#000000","bg_color": "#FFFFFF","low_bound": "0","high_bound": "100"},"classifications_order": 1,"organization": {"agglomeration_method": "unknown",' +
-    '"order_method": "unknown","distance_metric": "unknown"},"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items":"","top_items_cv": "--text-entry--"},' +
-    '"col_configuration": {"classifications": {"show": "Y","height": 15,"bar_type": "color_plot","fg_color": "#000000","bg_color": "#FFFFFF","low_bound": "0","high_bound": "100"},"classifications_order": 1,' +
-    '"organization": {"agglomeration_method": "unknown","order_method": "unknown","distance_metric": "unknown"},' +
-    '"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items":"","top_items_cv": "--text-entry--"},"data_configuration": {"map_information": {"data_layer": {' +
-    '"name": "Data Layer","grid_show": "Y","grid_color": "#FFFFFF","selection_color": "#00FF38","cuts_color": "#FFFFFF' +
-    '"},"name": "CHM Name","description": "' +
-    'Full length description of this heatmap","summary_width": "50","builder_version": "NA","summary_height": "100","detail_width": "50","detail_height": "100","read_only": "N","version_id": "1.0.0","map_cut_rows": "0","map_cut_cols": "0"}}}';
+  const axisConfigStr = `{
+    "classifications": {
+      "show": "Y",
+      "height": 15,
+      "bar_type": "color_plot",
+      "fg_color": "#000000",
+      "bg_color": "#FFFFFF",
+      "low_bound": "0",
+      "high_bound": "100"
+    },
+    "classifications_order": 1,
+    "organization": {
+      "agglomeration_method": "unknown",
+      "order_method": "unknown",
+      "distance_metric": "unknown"
+    },
+    "dendrogram": {
+      "show": "ALL",
+      "height": "100"
+    },
+    "label_display_length": "20",
+    "label_display_method": "END",
+    "top_items": [],
+    "top_items_cv": "--text-entry--"
+  }`;
+  const jsonConfigStr = `{
+    "row_configuration": ${axisConfigStr},
+    "col_configuration": ${axisConfigStr},
+    "data_configuration": {
+      "map_information": {
+        "data_layer": {
+          "name": "Data Layer",
+          "grid_show": "Y",
+          "grid_color": "#FFFFFF",
+          "selection_color": "#00FF38",
+          "cuts_color": "#FFFFFF"
+        },
+        "name": "CHM Name",
+        "description": "Full length description of this heatmap",
+        "summary_width": "50",
+        "builder_version": "NA",
+        "summary_height": "100",
+        "detail_width": "50",
+        "detail_height": "100",
+        "read_only": "N",
+        "version_id": "1.0.0",
+        "map_cut_rows": "0",
+        "map_cut_cols": "0"
+      }
+    }
+  }`;
 
   // CURRENT VERSION NUMBER
   // WARNING: The line starting with 'CM.version = ' is used by .github/workflows/create-build-tag.yml for creating build tags
@@ -58,7 +100,7 @@
     // standardMapConfig for each data layer and classification bar that
     // mapConfig contains.
     //
-    const standardMapConfig = JSON.parse(CM.jsonConfigStr);
+    const standardMapConfig = JSON.parse(jsonConfigStr);
     const standardMapEntries = buildConfigComparisonObject(standardMapConfig, mapConfig);
 
     // Construct a flattened entry map from the heatmap's configuration, for comparison.

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -300,16 +300,33 @@
       if (!Array.isArray(types)) types = [types];
       // Fix label types that were erroneously joined by ".bar.".
       types = types.map((x) => x.split(".bar.")).flat();
-      // Convert to object and add visibility.
+      // Convert type entries to objects and add visibility.
       types = types.map((type,idx) => ({ type: type, visible: idx == 0 }));
-
-      if (debugCM) {
-        console.log("CM.checkAxis", { axis, oldLabelTypes: classData.label.label_type, newLabelTypes: types });
+      // Ensure we have as many types as fields.
+      const numTypes = arrayMax(axisData.label.labels.map(numFields));
+      while (types.length < numTypes) {
+        types.push({ type: "none", visible: false });
       }
+      // Update axis type.
       axisData.label.labelTypes = types;
       delete axisData.label.label_type;
       updated = true;
     }
     return updated;
+
+    // Helper functions.
+    // Return the number of vertical bar (|) separated fields in a label.
+    function numFields(label) {
+      return label.split('|').length;
+    }
+
+    // Return the maximum value in an array.
+    function arrayMax(arr) {
+      let max = arr[0];
+      for (const val of arr.slice(1)) {
+        if (val > max) max = val;
+      }
+      return max;
+    }
   };
 })();

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -13,10 +13,10 @@
   // but has been placed here at the top of the CompatibilityManager class so that the configuration can be utilized in File Mode.
   CM.jsonConfigStr =
     '{"row_configuration": {"classifications": {"show": "Y","height": 15,"bar_type": "color_plot","fg_color": "#000000","bg_color": "#FFFFFF","low_bound": "0","high_bound": "100"},"classifications_order": 1,"organization": {"agglomeration_method": "unknown",' +
-    '"order_method": "unknown","distance_metric": "unknown"},"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items_cv": ""},' +
+    '"order_method": "unknown","distance_metric": "unknown"},"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items":"","top_items_cv": "--text-entry--"},' +
     '"col_configuration": {"classifications": {"show": "Y","height": 15,"bar_type": "color_plot","fg_color": "#000000","bg_color": "#FFFFFF","low_bound": "0","high_bound": "100"},"classifications_order": 1,' +
     '"organization": {"agglomeration_method": "unknown","order_method": "unknown","distance_metric": "unknown"},' +
-    '"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items_cv": ""},"data_configuration": {"map_information": {"data_layer": {' +
+    '"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items":"","top_items_cv": "--text-entry--"},"data_configuration": {"map_information": {"data_layer": {' +
     '"name": "Data Layer","grid_show": "Y","grid_color": "#FFFFFF","selection_color": "#00FF38","cuts_color": "#FFFFFF' +
     '"},"name": "CHM Name","description": "' +
     'Full length description of this heatmap","summary_width": "50","builder_version": "NA","summary_height": "100","detail_width": "50","detail_height": "100","read_only": "N","version_id": "1.0.0","map_cut_rows": "0","map_cut_cols": "0"}}}';
@@ -110,50 +110,6 @@
     }
 
     return foundUpdate;
-  };
-
-  // Checks the specified axis in mapConfig and mapData for compatibility issues and
-  // updates mapConfig and mapData appropriately.
-  //
-  // Checks performed:
-  // + If there is no top_items_cv entry but there is a top_items entry, create a continuous
-  //   covariate bar from the top_items, set top_items_cv to its name, and remove top_items.
-  //
-  CM.checkAxis = function checkAxis (mapConfig, mapData, axis) {
-    let changed = false;
-    const axisConfig = mapConfig[axis+"_configuration"];
-    const classData =  mapData[axis+"_data"];
-    if (axisConfig.top_items_cv == "" && axisConfig.top_items && axisConfig.top_items.length > 0) {
-      let suffix = "";
-      while (axisConfig.classifications.hasOwnProperty ("LabelPriority" + suffix)) {
-        suffix = +suffix + 1;
-      }
-      const topClass = "LabelPriority" + suffix;
-      axisConfig.classifications[topClass] = {
-        bar_type: "color_plot",
-        bg_color: "#ffffff",
-        fg_color: "#000000",
-        height: "15",
-        low_bound: "1.0",
-        high_bound: "2.0",
-        show: "N",
-        color_map: {
-          type: "continuous",
-          thresholds: [ 1, 2 ],
-          colors: [ "#ffffff", "#ff0000" ],
-          missing: "#b3b3b3",
-        }
-      };
-      axisConfig.classifications_order.push(topClass);
-      classData.classifications[topClass] = { values: classData.label.labels.map (label => axisConfig.top_items.includes(label) ? "1" : "NA") };
-      axisConfig.top_items_cv = topClass;
-      if (debugCM) {
-        console.log("CM.checkAxis", { axis, topClass, top_items: axisConfig.top_items });
-      }
-      delete axisConfig.top_items;
-      changed = true;
-    }
-    return changed;
   };
 
   function getObjectPart (obj, parts) {

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -11,10 +11,10 @@
   // but has been placed here at the top of the CompatibilityManager class so that the configuration can be utilized in File Mode.
   CM.jsonConfigStr =
     '{"row_configuration": {"classifications": {"show": "Y","height": 15,"bar_type": "color_plot","fg_color": "#000000","bg_color": "#FFFFFF","low_bound": "0","high_bound": "100"},"classifications_order": 1,"organization": {"agglomeration_method": "unknown",' +
-    '"order_method": "unknown","distance_metric": "unknown"},"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items": "[]"},' +
+    '"order_method": "unknown","distance_metric": "unknown"},"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items_cv": ""},' +
     '"col_configuration": {"classifications": {"show": "Y","height": 15,"bar_type": "color_plot","fg_color": "#000000","bg_color": "#FFFFFF","low_bound": "0","high_bound": "100"},"classifications_order": 1,' +
     '"organization": {"agglomeration_method": "unknown","order_method": "unknown","distance_metric": "unknown"},' +
-    '"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items": "[]"},"data_configuration": {"map_information": {"data_layer": {' +
+    '"dendrogram": {"show": "ALL","height": "100"},"label_display_length": "20","label_display_method": "END","top_items_cv": ""},"data_configuration": {"map_information": {"data_layer": {' +
     '"name": "Data Layer","grid_show": "Y","grid_color": "#FFFFFF","selection_color": "#00FF38","cuts_color": "#FFFFFF' +
     '"},"name": "CHM Name","description": "' +
     'Full length description of this heatmap","summary_width": "50","builder_version": "NA","summary_height": "100","detail_width": "50","detail_height": "100","read_only": "N","version_id": "1.0.0","map_cut_rows": "0","map_cut_cols": "0"}}}';
@@ -108,6 +108,46 @@
     }
 
     return foundUpdate;
+  };
+
+  // Checks the specified axis in mapConfig and mapData for compatibility issues and
+  // updates mapConfig and mapData appropriately.
+  //
+  // Checks performed:
+  // + If there is no top_items_cv entry but there is a top_items entry, create a continuous
+  //   covariate bar from the top_items, set top_items_cv to its name, and remove top_items.
+  //
+  CM.checkAxis = function checkAxis (mapConfig, mapData, axis) {
+    const axisConfig = mapConfig[axis+"_configuration"];
+    const classData =  mapData[axis+"_data"];
+    if (axisConfig.top_items_cv == "" && axisConfig.top_items && axisConfig.top_items.length > 0) {
+      let suffix = "";
+      while (axisConfig.classifications.hasOwnProperty ("LabelPriority" + suffix)) {
+        suffix = +suffix + 1;
+      }
+      const topClass = "LabelPriority" + suffix;
+      axisConfig.classifications[topClass] = {
+        bar_type: "color_plot",
+        bg_color: "#ffffff",
+        fg_color: "#000000",
+        height: "15",
+        low_bound: "1.0",
+        high_bound: "2.0",
+        show: "N",
+        color_map: {
+          type: "continuous",
+          thresholds: [ 1, 2 ],
+          colors: [ "#ffffff", "#ff0000" ],
+          missing: "#b3b3b3",
+        }
+      };
+      axisConfig.classifications_order.push(topClass);
+      classData.classifications[topClass] = { values: classData.label.labels.map (label => axisConfig.top_items.includes(label) ? "1" : "NA") };
+      axisConfig.top_items_cv = topClass;
+      delete axisConfig.top_items;
+      return true;
+    }
+    return false;
   };
 
   function getObjectPart (obj, parts) {

--- a/NGCHM/WebContent/javascript/Customization.js
+++ b/NGCHM/WebContent/javascript/Customization.js
@@ -148,6 +148,7 @@
   }
 
   function initLabelTypes(typeList) {
+    typeList = typeList.map((type) => type.type); // Ignore visibility.
     CUST.superTypes = {};
     CUST.subTypes = {};
 
@@ -371,22 +372,22 @@
 
   // Executed before custom.js is loaded.
   CUST.beforeLoadCustom = function (heatMap) {
-    var colTypes = heatMap.getColLabels().label_type;
-    var rowTypes = heatMap.getRowLabels().label_type;
+    var colTypes = heatMap.getLabelTypes("col");
+    var rowTypes = heatMap.getLabelTypes("row");
     if (CUST.verbose) {
       console.log("Column types:");
       colTypes.forEach(function (ty) {
-        console.log(ty);
+        console.log(ty.type);
       });
       console.log("Row types:");
       rowTypes.forEach(function (ty) {
-        console.log(ty);
+        console.log(ty.type);
       });
     }
 
     CUST.customPlugins = [];
     CUST.linkoutTypes = [];
-    initLabelTypes([].concat(colTypes, rowTypes));
+    initLabelTypes([].concat(colTypes, rowTypes).flat());
   };
 
   var pluginsLoaded = false;

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -1663,7 +1663,7 @@
         bars.forEach((bar) => {
           addTmpLabelForSizeCalc(
             mapItem,
-            legendText + MMGR.getLabelText(bar.label, otherAxis),
+            legendText + mapItem.heatMap.getLabelText(bar.label, otherAxis),
             barLabelFont,
           );
         });
@@ -1775,7 +1775,7 @@
       const firstLabel = MMGR.isRow(axis)
         ? mapItem.currentRow
         : mapItem.currentCol;
-      const shownLabels = MMGR.getShownLabels(axis);
+      const shownLabels = mapItem.heatMap.shownLabels(axis);
       for (let i = firstLabel; i < firstLabel + numLabels; i++) {
         addTmpLabelForSizeCalc(mapItem, shownLabels[i - 1], fontSize);
       }
@@ -2025,8 +2025,8 @@
       }
 
       // Calculate label independent constants.
-      const actualLabels = MMGR.getActualLabels(axis);
-      const shownLabels = MMGR.getShownLabels(axis);
+      const actualLabels = mapItem.heatMap.actualLabels(axis);
+      const shownLabels = mapItem.heatMap.shownLabels(axis);
       const firstLabelIdx = isRow ? mapItem.currentRow : mapItem.currentCol;
       const rotate = isRow ? "F" : "T";
       const labelDivAxis = isRow ? "Row" : "Column"; // Must match SearchState.js/searchResults
@@ -2095,7 +2095,7 @@
             DET.maxLabelSize,
           );
           if (availableSpace >= mapItem.rowClassLabelFont) {
-            const labelText = MMGR.getLabelText(currentClassBar.label, "COL");
+            const labelText = mapItem.heatMap.getLabelText(currentClassBar.label, "COL");
             DET.addLabelDiv(
               mapItem,
               mapItem.labelElement,
@@ -2193,7 +2193,7 @@
               (barHeightScaled - mapItem.colClassLabelFont) / 2 - 3,
               0,
             );
-            const labelText = MMGR.getLabelText(currentClassBar.label, "ROW");
+            const labelText = mapItem.heatMap.getLabelText(currentClassBar.label, "ROW");
             DET.addLabelDiv(
               mapItem,
               mapItem.labelElement,

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -320,7 +320,7 @@
             coveredHeight +=
               (mapItem.canvas.clientHeight * currentBar.height) /
               mapItem.canvas.height;
-            if (coveredHeight >= mapItem.offsetY) {
+            if (Math.ceil(coveredHeight) >= mapItem.offsetY) {
               hoveredBar = key;
               hoveredBarValues = heatMap.getColClassificationData()[key].values;
               break;
@@ -348,7 +348,7 @@
             coveredWidth +=
               (mapItem.canvas.clientWidth * currentBar.height) /
               mapItem.canvas.width;
-            if (coveredWidth >= mapItem.offsetX) {
+            if (Math.ceil(coveredWidth) >= mapItem.offsetX) {
               hoveredBar = key;
               hoveredBarValues = heatMap.getRowClassificationData()[key].values;
               break;

--- a/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapEvent.js
@@ -699,9 +699,9 @@
    * click on a given detail panel.
    *********************************************************************************************/
   DEV.matrixRightClick = function (e) {
+    const mapItem = DVW.getMapItemFromCanvas(e.currentTarget);
     e.preventDefault();
-    LNK.labelHelpClose("Matrix", e);
-    LNK.labelHelpOpen("Matrix", e);
+    LNK.openLinkoutMenu(mapItem.heatMap, "Matrix", e);
     let selection = window.getSelection();
     selection.removeAllRanges();
     return false;
@@ -970,7 +970,7 @@
    **********************************************************************************/
   DEV.detailDataZoomIn = function (mapItem) {
     UHM.hlpC();
-    LNK.labelHelpCloseAll();
+    LNK.closeAllLinkoutMenus();
     if (!mapItem.modeHistory) mapItem.modeHistory = [];
     if (mapItem.mode == "FULL_MAP") {
       let mode = mapItem.mode,
@@ -1134,7 +1134,7 @@
     const chm = mapItem.chm;
     const heatMap = mapItem.heatMap;
     UHM.hlpC();
-    LNK.labelHelpCloseAll();
+    LNK.closeAllLinkoutMenus();
     if (!mapItem.modeHistory) mapItem.modeHistory = [];
     mapItem.modeHistory.push({
       mode: mapItem.mode,
@@ -1366,10 +1366,11 @@
    *********************************************************************************************/
   DEV.labelRightClick = labelRightClick;
   function labelRightClick(e) {
+    const loc = PANE.findPaneLocation (e.currentTarget);
+    const mapItem = DVW.getMapItemFromPane(loc.pane.id);
     e.preventDefault();
     const axis = e.target.dataset.axis;
-    LNK.labelHelpClose(axis, e);
-    LNK.labelHelpOpen(axis, e);
+    LNK.openLinkoutMenu(mapItem.heatMap, axis, e);
     let selection = window.getSelection();
     selection.removeAllRanges();
     return false;

--- a/NGCHM/WebContent/javascript/DetailHeatMapManager.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapManager.js
@@ -456,15 +456,15 @@
     }
   };
 
-  LNK.addLinkout(
+  LNK.addMatrixLinkout(
     "Set selection as detail view",
-    "Matrix",
+    [], [],
     linkouts.MULTI_SELECT,
     setSelectionAsDetailView,
     null,
     0,
   );
-  function setSelectionAsDetailView(searchLabels, axis) {
+  function setSelectionAsDetailView(searchLabels) {
     const menuOpenCanvas = LNK.getMenuOpenCanvas();
     if (menuOpenCanvas) {
       const mapItem = DVW.getMapItemFromCanvas(menuOpenCanvas);

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -31,7 +31,7 @@ var linkoutsVersion = "undefined";
   linkouts.POSITION = "position";
   linkouts.SINGLE_SELECT = "singleSelection";
   linkouts.MULTI_SELECT = "multiSelection";
-  LNK.EMPTY_SELECT = "emptySelection"; // NOT exported
+  const EMPTY_SELECT = "emptySelection"; // NOT exported
 
   linkouts.getAttribute = function (attribute) {
     return MMGR.getHeatMap().getMapInformation().attributes[attribute];
@@ -63,6 +63,8 @@ var linkoutsVersion = "undefined";
     return UTIL.mapId;
   };
 
+  const debugLinkoutCallbacks = UTIL.getURLParameter("debug").split(",").includes("linkouts");
+
   //adds axis linkout objects to the linkouts global variable
   linkouts.addLinkout = function (
     name,
@@ -72,7 +74,12 @@ var linkoutsVersion = "undefined";
     reqAttributes,
     index,
   ) {
-    LNK.addLinkout(name, labelType, selectType, callback, reqAttributes, index);
+    // Cannot pass heatMap object to external callback function.
+    const cb = function (heatMap, labels, axis) {
+      if (debugLinkoutCallbacks) console.log ("AxisLinkout callback", { name, labels, axis });
+      callback (labels, axis);
+    };
+    LNK.addLinkout(name, labelType, selectType, cb, reqAttributes, index);
   };
 
   //adds matrix linkout objects to the linkouts global variable
@@ -85,12 +92,17 @@ var linkoutsVersion = "undefined";
     reqAttributes,
     index,
   ) {
+    // Cannot pass heatMap object to external callback function.
+    const cb = function (heatMap, labels, axis) {
+      if (debugLinkoutCallbacks) console.log ("MatrixLinkout callback", { name, labels, axis });
+      callback (labels, axis);
+    };
     LNK.addMatrixLinkout(
       name,
       rowType,
       colType,
       selectType,
-      callback,
+      cb,
       reqAttributes,
       index,
     );
@@ -156,8 +168,6 @@ var linkoutsVersion = "undefined";
   const SRCH = NgChm.importNS("NgChm.SRCH");
   const PANE = NgChm.importNS("NgChm.Pane");
   const UHM = NgChm.importNS("NgChm.UHM");
-  const DVW = NgChm.importNS("NgChm.DVW");
-  const DET = NgChm.importNS("NgChm.DET");
   const PIM = NgChm.importNS("NgChm.PIM");
   const CMM = NgChm.importNS("NgChm.CMM");
 
@@ -237,8 +247,9 @@ var linkoutsVersion = "undefined";
     LNK.hamburgerLinkCtr++;
   };
 
-  //the linkout object
-  LNK.linkout = function (
+  // The axis linkout class.
+  // Create an instance using new.
+  function AxisLinkout (
     title,
     labelType,
     selectType,
@@ -252,7 +263,9 @@ var linkoutsVersion = "undefined";
     this.callback = callback;
   };
 
-  LNK.matrixLinkout = function (
+  // The matrix linkout class.
+  // Create an instance using new.
+  function MatrixLinkout (
     title,
     rowType,
     colType,
@@ -268,7 +281,12 @@ var linkoutsVersion = "undefined";
     this.callback = callback;
   };
 
-  //this function is used to add standard linkouts to the row/col, covariate, and matrix menu
+  const matrixLinkouts = [];      // An array for all matrix linkouts.
+  const linkoutsDB = new Map();   // A map from linkout types to an array of linkouts for all axis linkouts.
+
+  const NullTypeKey = "---null---";
+
+  // This function is used to add standard linkouts to the row/col, covariate menus.
   // labelType will decide which menu to place the linkout in.
   // selectType decides when the linkout is executable. (passing in null or undefined, or false will allow the function to be executable for all selection types)
   LNK.addLinkout = function (
@@ -279,35 +297,70 @@ var linkoutsVersion = "undefined";
     reqAttributes,
     index,
   ) {
-    var linkout = new LNK.linkout(
+    if (!Array.isArray(labelType)) labelType = labelType.split("|");
+    const linkout = new AxisLinkout(
       name,
       labelType,
       selectType,
       reqAttributes,
       callback,
     );
-    if (!linkouts[labelType]) {
-      linkouts[labelType] = [linkout];
+    // If labelType includes multiple types (all of which are required), save it under one type,
+    // independent of the order of the types given.
+    const key = labelType.length == "0" ? NullTypeKey : labelType.sort()[0];
+    if (!linkoutsDB.has(key)) {
+      // Create the first linkout for that type.
+      linkoutsDB.set(key, [linkout]);
     } else {
+      // Get the array of linkouts for that type.
+      const linkoutsForType = linkoutsDB.get(key);
       if (index !== undefined) {
-        linkouts[labelType].splice(index, 0, linkout);
+        // Replace the existing linkout at index.
+        //linkoutsForType.splice(index, 0, linkout);
+        console.error ("addLinkout: obsolete attempt to replace a specific linkout", { linkout, index });
+        return;
       } else {
-        LNK.dupeLinkout(linkouts[labelType], linkout);
-        linkouts[labelType].push(linkout);
+        // Append to the array of linkouts for that type.
+        // But first remove any existing linkout with the same title.
+        removeExistingLinkout(linkoutsForType, linkout);
+        linkoutsForType.push(linkout);
       }
     }
   };
 
-  //Check to see if the linkout being added already exists.  This would be in a case where a secondary custom.js is being used (embedded NG-CHM)
-  //If so, delete the existing linkout and allow the new linkout to be added in its place.
-  LNK.dupeLinkout = function (linkouts, linkout) {
-    for (var i = 0; i < linkouts.length; i++) {
-      var curLink = linkouts[i];
-      if (curLink.title === linkout.title) {
+  // Check to see if there is already a linkout with the same title and the same type
+  // requirements as the one being added.
+  // This would be in a case where a secondary custom.js is being used (embedded NG-CHM).
+  // If so, delete the existing linkout to allow the new linkout to be added.
+  function removeExistingLinkout (linkouts, linkout) {
+    const labelType = canonical(linkout.labelType);
+    for (let i = 0; i < linkouts.length; i++) {
+      if (linkouts[i].title === linkout.title && canonical(linkouts[i].labelType) == labelType) {
         linkouts.splice(i, 1);
+        return;
       }
     }
-  };
+  }
+
+  // Similar to removeExistingLinkout, but in this case there can be multiple
+  // entries with the same titles but with different row and column type requirements.
+  function removeExistingMatrixLinkout (linkouts, linkout) {
+    const rowType = canonical(linkout.rowType);
+    const colType = canonical(linkout.colType);
+    for (let i = 0; i < linkouts.length; i++) {
+      if (linkouts[i].title === linkout.title && canonical(linkouts[i].rowType) == rowType && canonical(linkouts[i].colType) == colType) {
+        linkouts.splice(i, 1);
+        return;
+      }
+    }
+  }
+
+  // Sort label type into a canonical order, so we treat "typea|typeb" the same as
+  // "typeb|typea".
+  function canonical (labelType) {
+    if (!Array.isArray(labelType)) labelType = labelType.split("|");
+    return labelType.sort().join("|");
+  }
 
   LNK.addMatrixLinkout = function (
     name,
@@ -318,153 +371,96 @@ var linkoutsVersion = "undefined";
     reqAttributes,
     index,
   ) {
-    // this function is used to add linkouts to the matrix menu when the linkout needs a specific criteria for the row and column (ie: same attribute)
-    var linkout = new LNK.matrixLinkout(
+    const linkout = new MatrixLinkout(
       name,
-      rowType,
-      colType,
+      Array.isArray(rowType) ? rowType : rowType.split("|"),
+      Array.isArray(colType) ? colType : colType.split("|"),
       selectType,
       reqAttributes,
       callback,
     );
-    if (!linkouts["Matrix"]) {
-      linkouts["Matrix"] = [linkout];
+    if (index !== undefined) {
+      matrixLinkouts.splice(index, 0, linkout);
     } else {
-      if (index !== undefined) {
-        linkouts["Matrix"].splice(index, 0, linkout);
-      } else {
-        linkouts["Matrix"].push(linkout);
-      }
+      removeExistingMatrixLinkout(matrixLinkouts, linkout);
+      matrixLinkouts.push(linkout);
     }
   };
 
-  //this function goes through searchItems and returns the proper label type for linkout functions to use
-  LNK.getLabelsByType = function (axis, linkout) {
-    var searchLabels;
-    const heatMap = MMGR.getHeatMap();
-    var labels =
-      axis == "Row"
-        ? heatMap.getRowLabels()["labels"]
-        : axis == "Column"
-          ? heatMap.getColLabels()["labels"]
-          : axis == "ColumnCovar"
-            ? heatMap.getColClassificationConfigOrder()
-            : axis == "RowCovar"
-              ? heatMap.getRowClassificationConfigOrder()
-              : [
-                  heatMap.getRowLabels()["labels"],
-                  heatMap.getColLabels()["labels"],
-                ];
-
-    var types;
+  // Return the labels from heatMap required by the specified linkout (and axis if applicable).
+  //
+  function getLabelsByType (heatMap, linkout, axis) {
 
     if (linkout.labelType) {
-      // if this is a standard linkout (ie: added using addLinkout and not addMatrixLinkout)
-      types = linkout.labelType.split("|"); // split 'types' into an array if a combined label type is requested
-      if (!Array.isArray(types)) {
-        // make sure it's an array!
-        types = [types];
-      }
-
-      // matrix and class bar linkouts can only access the visible labeltype right now. TODO: find a way to let matrix and class bar linkouts access specific labeltypes.
-      var formatIndex = [];
-      for (var i = 0; i < types.length; i++) {
-        var type = types[i];
-        formatIndex[i] =
-          !type || axis == "Matrix"
-            ? 0
-            : axis == "Row"
-              ? heatMap.getRowLabels()["label_type"].indexOf(type)
-              : axis == "Column"
-                ? heatMap.getColLabels()["label_type"].indexOf(type)
-                : 0;
-      }
-      if (axis !== "Matrix") {
-        searchLabels = [];
-        //IF the linkout is single select, load ONLY the item that was clicked on to searchLabels.
-        if (linkout.selectType === linkouts.SINGLE_SELECT) {
-          searchLabels.push(generateSearchLabel(LNK.selection, formatIndex));
-        } else {
-          //ELSE the linkout is multi select, load all selected items to searchLabels (not necessarily the item that was clicked on)
-          SRCHSTATE.getAxisSearchResults(axis).forEach((i) => {
-            if (axis.includes("Covar")) {
-              // Covariate linkouts have not been tested very extensively. May need revision in future.
-              searchLabels.push(generateSearchLabel(labels[i], formatIndex));
-            } else {
-              searchLabels.push(
-                generateSearchLabel(labels[i - 1], formatIndex),
-              );
-            }
-          });
-        }
-      } else {
-        searchLabels = { Row: [], Column: [] };
-        SRCHSTATE.getAxisSearchResults("Row").forEach((i) => {
-          searchLabels["Row"].push(
-            generateSearchLabel(labels[0][i - 1], [formatIndex[0]]),
-          );
-        });
-        SRCHSTATE.getAxisSearchResults("Column").forEach((i) => {
-          searchLabels["Column"].push(
-            generateSearchLabel(labels[1][i - 1], [formatIndex[0]]),
-          );
-        });
-        if (linkout.title !== "Copy selected labels to clipboard") {
-          const heatMap = MMGR.getHeatMap();
-          if (searchLabels["Row"].length === 0) {
-            searchLabels["Row"] = heatMap.getAxisLabels("Row")["labels"];
-          }
-          if (searchLabels["Column"].length === 0) {
-            searchLabels["Column"] = heatMap.getAxisLabels("Column")["labels"];
-          }
-        }
-      }
+      // Single-axis linkout.
+      return getAxisLinkoutLabels(axis, linkout.labelType, linkout.selectType);
     } else {
-      // if this linkout was added using addMatrixLinkout
-      searchLabels = { Row: [], Column: [] };
-      types = { row: linkout.rowType, col: linkout.colType };
-      var formatIndex = { row: [], col: [] };
-      if (!Array.isArray(types.row)) types.row = [types.row];
-      if (!Array.isArray(types.col)) types.col = [types.col];
-      // Build the formatIndex array to help build the labels
-      for (var i = 0; i < types.row.length; i++) {
-        var type = types.row[i];
-        formatIndex.row[i] = heatMap.getRowLabels()["label_type"].indexOf(type);
-      }
-      for (var i = 0; i < types.col.length; i++) {
-        var type = types.col[i];
-        formatIndex.col[i] = heatMap.getColLabels()["label_type"].indexOf(type);
-      }
-      // Build the searchLabels and put them into the return object
-      SRCHSTATE.getAxisSearchResults("Row").forEach((i) => {
-        searchLabels["Row"].push(
-          generateSearchLabel(labels[0][i - 1], formatIndex.row),
-        );
-      });
-      SRCHSTATE.getAxisSearchResults("Column").forEach((i) => {
-        searchLabels["Column"].push(
-          generateSearchLabel(labels[1][i - 1], formatIndex.col),
-        );
-      });
+      // Matrix linkout.
+      return {
+        Row: getAxisLinkoutLabels("Row", linkout.rowType, linkout.selectType),
+        Column: getAxisLinkoutLabels("Column", linkout.colType, linkout.selectType),
+      };
     }
-    return searchLabels;
 
-    // This is a helper function that will create the proper label types
-    // 'label' is the full row/column label, and 'indexes' is an array that tells you how  to put the searchLabel together
-    function generateSearchLabel(label, indexes) {
-      var searchLabel = "";
-      if (label !== undefined) {
-        for (var i = 0; i < indexes.length; i++) {
-          searchLabel += label.split("|")[indexes[i]] + "|";
+    function getAxisLinkoutLabels (axis, labelType, selectType) {
+      // Build an array of the individual types required.
+      const types = getRequiredTypes (labelType); // split 'types' into an array if a combined label type is requested
+      const axisLabelTypes = axis.includes("Covar") ? [axis] : heatMap.getAxisLabels(axis).label_type;
+      const formatIndex = types.map (type => axisLabelTypes.indexOf(type));
+
+      // formatIndex should not contain any missing (negative) indices.
+      formatIndex.forEach ((value, idx) => {
+        if (value < 0) {
+          console.error ("getAxisLinkoutLabels: missing type", { axis, labelType, missingType: types[idx], axisLabelTypes });
         }
-        searchLabel = searchLabel.slice(0, -1); // remove the last character (the extra "|")
+      });
+
+      if (selectType === linkouts.SINGLE_SELECT) {
+        return [generateLinkoutLabel(LNK.selection, formatIndex)];
+      } else {
+        const srchResults = SRCHSTATE.getAxisSearchResults(axis);
+        if (axis.includes("Covar")) {
+          const labels = heatMap.getAxisCovariateOrder(axis.replace("Covar",""));
+          return srchResults.map(idx => generateLinkoutLabel(labels[idx], formatIndex));
+        } else {
+          const labels = heatMap.getAxisLabels(axis).labels;
+          return srchResults.map(idx => generateLinkoutLabel(labels[idx-1], formatIndex));
+        }
       }
+
+      // Return an array of the individual label types specified by labelType.
+      // Normally involves splitting a string at the vertical bar character.
+      // Special cases:
+      // - labelType is a non-empty array. Just return it.
+      // - labelType is an empty array. Return an array of all types in the data.
+      function getRequiredTypes (labelType) {
+        if (Array.isArray(labelType)) {
+          if (labelType.length == 0) {
+            return heatMap.getAxisLabels(axis.replace("Covar","")).label_type;
+          } else {
+            return labelType;
+          }
+        } else {
+          return labelType.split("|");
+        }
+      }
+    }
+
+    // This is a helper function to create labels consisting of the specified
+    // parts of the given full label, separated by vertical bars.
+    // 'indexes' is an array, each element of which is the index (zero-based)
+    // of the desired part of the full label.
+    // For example, if fullLabel = "part0|part1|part2|part3" and indexes=[3,1],
+    // then the function will return "part3|part1".
+    function generateLinkoutLabel(fullLabel, indexes) {
+      if (fullLabel === undefined) return "";
+      const parts = fullLabel.split("|");
+      const searchLabel = indexes.map(idx => parts[idx]).join("|");
       return searchLabel;
     }
-  };
+  }
 
-  function downloadAllMatrixData(selectedLabels, axis) {
-    const heatMap = MMGR.getHeatMap();
+  function downloadAllMatrixData(heatMap) {
     const selection = {
       rowLabels: heatMap.actualLabels("row"),
       colLabels: heatMap.actualLabels("column"),
@@ -476,8 +472,7 @@ var linkoutsVersion = "undefined";
     createMatrixData(heatMap, selection);
   }
 
-  function downloadSelectedMatrixData(selectedLabels, axis) {
-    const heatMap = MMGR.getHeatMap();
+  function downloadSelectedMatrixData(heatMap, selectedLabels) {
     const selection = {
       rowLabels: selectedLabels.Row,
       colLabels: selectedLabels.Column,
@@ -637,32 +632,34 @@ var linkoutsVersion = "undefined";
 
   LNK.createLabelMenus = function () {
     if (!document.getElementById("RowLabelMenu")) {
-      LNK.createLabelMenu("Column"); // create the menu divs if they don't exist yet
-      LNK.createLabelMenu("ColumnCovar");
-      LNK.createLabelMenu("Row");
-      LNK.createLabelMenu("RowCovar");
-      LNK.createLabelMenu("Matrix");
-      LNK.getDefaultLinkouts();
+      createLabelMenu("Column"); // create the menu divs if they don't exist yet
+      createLabelMenu("ColumnCovar");
+      createLabelMenu("Row");
+      createLabelMenu("RowCovar");
+      createLabelMenu("Matrix");
+      defineDefaultLinkouts();
     }
   };
 
-  LNK.labelHelpCloseAll = function (ev) {
+  LNK.closeAllLinkoutMenus = function (ev) {
     ev = ev || {};
-    LNK.labelHelpClose("Matrix", ev);
-    LNK.labelHelpClose("Column", ev);
-    LNK.labelHelpClose("Row", ev);
+    closeLinkoutMenu("Matrix", ev);
+    closeLinkoutMenu("Column", ev);
+    closeLinkoutMenu("ColumnCovar", ev);
+    closeLinkoutMenu("Row", ev);
+    closeLinkoutMenu("RowCovar", ev);
   };
 
-  LNK.labelHelpClose = function (axis, ev) {
+  function closeLinkoutMenu (axis, ev) {
     if (ev.ctrlKey || ev.metaKey) {
       // Prevent extra ctrl-click event sent by Safari from closing newly opened label menus.
       // See issue #539.
       return;
     }
-    var labelMenu =
-      axis !== "Matrix"
-        ? document.getElementById(axis + "LabelMenu")
-        : document.getElementById("MatrixMenu");
+    const labelMenu =
+      axis === "Matrix"
+        ? document.getElementById("MatrixMenu")
+        : document.getElementById(axis + "LabelMenu");
     var tableBody = labelMenu.getElementsByTagName("TBODY")[0];
     var tempClass = tableBody.className;
     var newTableBody = document.createElement("TBODY");
@@ -673,10 +670,9 @@ var linkoutsVersion = "undefined";
     }
   };
 
-  LNK.labelHelpOpen = function (axis, e) {
+  LNK.openLinkoutMenu = function (heatMap, axis, e) {
     menuOpenCanvas = e.currentTarget;
-    const heatMap = MMGR.getHeatMap();
-    LNK.labelHelpCloseAll(e);
+    LNK.closeAllLinkoutMenus(e);
     //Get the label item that the user clicked on (by axis) and save that value for use in LNK.selection
     var index = e.target.dataset.index;
     LNK.selection = "";
@@ -690,10 +686,10 @@ var linkoutsVersion = "undefined";
       LNK.selection = heatMap.getColClassificationConfigOrder()[index];
     }
 
-    var labelMenu =
-      axis !== "Matrix"
-        ? document.getElementById(axis + "LabelMenu")
-        : document.getElementById("MatrixMenu");
+    const labelMenu =
+      axis === "Matrix"
+        ? document.getElementById("MatrixMenu")
+        : document.getElementById(axis + "LabelMenu");
     var labelMenuTable =
       axis !== "Matrix"
         ? document.getElementById(axis + "LabelMenuTable")
@@ -714,7 +710,7 @@ var linkoutsVersion = "undefined";
         "s : " +
         axisLabelsLength;
       labelMenuTable.getElementsByTagName("TBODY")[0].style.display = "inherit";
-      LNK.populateLabelMenu(axis, axisLabelsLength);
+      populateLabelMenu(heatMap, axis, axisLabelsLength);
     } else if (axis == "Matrix") {
       if (axisLabelsLength["Row"] > 0 || axisLabelsLength["Column"] > 0) {
         if (axisLabelsLength["Row"] === 0) {
@@ -730,7 +726,7 @@ var linkoutsVersion = "undefined";
         axisLabelsLength["Row"] +
         "<br>Selected Columns: " +
         axisLabelsLength["Column"];
-      LNK.populateLabelMenu(axis, axisLabelsLength);
+      populateLabelMenu(heatMap, axis, axisLabelsLength);
     } else {
       row.innerHTML = "Please select a " + axis.replace("Covar", " Covariate");
       labelMenuTable.getElementsByTagName("TBODY")[0].style.display = "none";
@@ -754,7 +750,7 @@ var linkoutsVersion = "undefined";
   };
 
   //creates the divs for the label menu
-  LNK.createLabelMenu = function (axis) {
+  function createLabelMenu (axis) {
     var labelMenu =
       axis !== "Matrix"
         ? UHM.getDivElement(axis + "LabelMenu")
@@ -782,7 +778,7 @@ var linkoutsVersion = "undefined";
     closeMenu.addEventListener(
       "click",
       function (ev) {
-        LNK.labelHelpClose(axis, ev);
+        closeLinkoutMenu(axis, ev);
       },
       false,
     );
@@ -797,7 +793,7 @@ var linkoutsVersion = "undefined";
     var tableBody = table.createTBody();
     tableBody.classList.add("labelMenuBody");
     var labelHelpCloseAxis = function (ev) {
-      LNK.labelHelpClose(axis, ev);
+      closeLinkoutMenu(axis, ev);
     };
     document.addEventListener("click", labelHelpCloseAxis);
     labelMenu.addEventListener(
@@ -843,97 +839,95 @@ var linkoutsVersion = "undefined";
   };
 
   //adds the row linkouts and the column linkouts to the menus
-  LNK.populateLabelMenu = function (axis, axisLabelsLength) {
-    const heatMap = MMGR.getHeatMap();
-    var table =
-      axis !== "Matrix"
-        ? document.getElementById(axis + "LabelMenuTable")
-        : document.getElementById("MatrixMenuTable");
-    var labelType =
-      axis == "Row"
-        ? heatMap.getRowLabels()["label_type"]
-        : axis == "Column"
-          ? heatMap.getColLabels()["label_type"]
-          : axis == "ColumnCovar"
-            ? ["ColumnCovar"]
-            : axis == "RowCovar"
-              ? ["RowCovar"]
-              : ["Matrix"];
-    var linkoutsKeys = Object.keys(linkouts);
-    //Arrays here are used to store linkouts by type (e.g. individual OR group)
-    var indLinkouts = [];
-    var grpLinkouts = [];
-    var itemInSelection = axis !== "Matrix" && LNK.itemInSelection(axis);
-    for (var i = 0; i < labelType.length; i++) {
-      // for every labeltype that the map has...
-      var type = labelType[i];
-      if (linkouts[type]) {
-        // and for every linkout that the label type has, we add the linkout to the menu
-        for (var j = 0; j < linkouts[type].length; j++) {
-          var linkout = linkouts[type][j];
-          if (
-            linkout.selectType == LNK.EMPTY_SELECT ||
-            type !== "Matrix" ||
-            (axisLabelsLength["Row"] > 0 && axisLabelsLength["Column"] > 0)
-          ) {
-            if (linkout.rowType && linkout.colType && type == "Matrix") {
-              // if this is a MatrixLinkout...
-              handleMatrixLinkout(axis, table, linkout, grpLinkouts);
-            } else if (linkout.selectType == linkouts.SINGLE_SELECT) {
-              indLinkouts.push({ linkout: linkout });
-            } else {
-              grpLinkouts.push({ linkout: linkout });
-            }
-          }
-        }
-      }
-      // add combined labels to the linkout menu
-      var combinedLinkouts = []; // list of all  combined linkouts starting with this given type
-      for (var j = 0; j < linkoutsKeys.length; j++) {
-        if (linkoutsKeys[j].includes(type + "|")) {
-          // if the linkout contains a
-          combinedLinkouts.push(linkoutsKeys[j]);
-        }
-      }
+  function populateLabelMenu (heatMap, axis, axisLabelsLength) {
 
-      for (var j = 0; j < combinedLinkouts.length; j++) {
-        var type = combinedLinkouts[j];
-        var typelist = type.split("|");
-        var add = true;
-        for (var ii = 0; ii < typelist.length; ii++) {
-          if (!labelType.includes(typelist[ii])) {
-            add = false;
-            continue;
-          }
-        }
-        if (linkouts[type] && add) {
-          // and for every linkout that the label type has, we add the linkout to the menu
-          for (var j = 0; j < linkouts[type].length; j++) {
-            var linkout = linkouts[type][j];
-            if (linkout.selectType == linkouts.SINGLE_SELECT) {
-              indLinkouts.push({ linkout: linkout });
-            } else {
-              grpLinkouts.push({ linkout: linkout });
+    // Arrays here are used to store linkouts by type (e.g. individual OR group)
+    const indLinkouts = [];
+    const grpLinkouts = [];
+
+    const rowLabelTypes = heatMap.getRowLabels().label_type;
+    const colLabelTypes = heatMap.getColLabels().label_type;
+
+    if (axis.includes("Row") || axis.includes("Column")) {
+      // This handles Row, RowCovar, Column, and ColumnCovar "axes".
+      // The labelTypes for RowCovar and ColumnCovar are ["RowCovar"] and ["ColumnCovar"] respectively.
+      // For Row and Column, we get them from the labels on the corresponding axis of the heatMap.
+      const labelTypes = axis.includes("Covar") ? [axis] : axis == "Row" ? rowLabelTypes : colLabelTypes;
+      // For every labeltype that the map has...
+      [NullTypeKey].concat(labelTypes).forEach((key) => {
+        if (linkoutsDB.has(key)) {
+          // Add linkout saved under that key but only if the map has all the required types.
+          linkoutsDB.get(key).forEach((linkout) => {
+            if (includesAll (labelTypes, linkout.labelType)) {
+              addLinkoutToSection (linkout);
             }
-          }
+          });
         }
-      }
+      });
+    } else if (axis === "Matrix") {
+      matrixLinkouts.filter(validRegion).filter(hasAllAxisLabelTypes).forEach((linkout) => {
+        grpLinkouts.push({ linkout: linkout });
+      });
+    } else {
+      throw new Error ("populateLabelMenu: Unknown 'axis'", { axis });
     }
+
+    // Helper function.
+    // - linkout is of type "Matrix".
+    // Returns true iff the heatMap includes all of the linkout's required row and column types.
+    function hasAllAxisLabelTypes(linkout) {
+      return includesAll (rowLabelTypes, asArray(linkout.rowType)) &&
+             includesAll (colLabelTypes, asArray(linkout.colType));
+    }
+
+    // Helper function.
+    // - linkout is of type "Matrix".
+    // Returns true iff the heatMap has a valid selection for the linkout.
+    function validRegion (linkout) {
+      return linkout.selectType == EMPTY_SELECT ||
+             (axisLabelsLength["Row"] > 0 && axisLabelsLength["Column"] > 0);
+    }
+
+    // Helper function.
+    // - values and required are arrays.
+    // Returns true iff values includes all the elements of required.
+    function includesAll (values, required) {
+      // Remove all required values that are present in values.
+      // If none are left, all are included.
+      return required.filter((rq) => !values.includes(rq)).length == 0;
+    }
+
+    // Helper function: add linkout to either the individual or group linkout sections.
+    function addLinkoutToSection (linkout) {
+      const section = linkout.selectType == linkouts.SINGLE_SELECT ? indLinkouts : grpLinkouts;
+      section.push({ linkout: linkout });
+    }
+
+    // *****************************************************************************
+
+    // Populate either the MatrixMenuTable or the axisLabelMenuTable.
+
+    const table =
+      axis === "Matrix"
+        ? document.getElementById("MatrixMenuTable")
+        : document.getElementById(axis + "LabelMenuTable");
+
     if (axis === "Matrix") {
-      for (var l = 0; l < grpLinkouts.length; l++) {
-        LNK.addMenuItemToTable(axis, table, grpLinkouts[l].linkout, true);
-      }
+      grpLinkouts.forEach((linkout) => {
+        addMenuItemToTable(heatMap, "Matrix", table, linkout.linkout, true);
+      });
     } else {
       const covar = axis.indexOf("Covar") != -1;
       if (!covar) {
         // Always add clipboard link at top of list
-        LNK.addMenuItemToTable(axis, table, grpLinkouts[0].linkout, true);
+        addMenuItemToTable(heatMap, axis, table, grpLinkouts[0].linkout, true);
       }
       const firstGroupLinkout = covar ? 0 : 1;
       if (indLinkouts.length > 0 && LNK.selection !== undefined) {
         let addedHeader = false;
         for (let k = 0; k < indLinkouts.length; k++) {
-          addedHeader = LNK.addMenuItemToTable(
+          addedHeader = addMenuItemToTable(
+            heatMap,
             axis,
             table,
             indLinkouts[k].linkout,
@@ -954,7 +948,8 @@ var linkoutsVersion = "undefined";
             // if there are no selected labels on that axis.
             continue;
           }
-          addedHeader = LNK.addMenuItemToTable(
+          addedHeader = addMenuItemToTable(
+            heatMap,
             axis,
             table,
             grpLinkouts[l].linkout,
@@ -966,41 +961,16 @@ var linkoutsVersion = "undefined";
     //Add blank row so links don't overlay close button
     var body = table.getElementsByClassName("labelMenuBody")[0];
     body.insertRow();
-
-    // Helper functions for populateLabelMenu
-    function handleMatrixLinkout(axis, table, linkout, grpLinkouts) {
-      var rowLabelTypes = heatMap.getRowLabels().label_type;
-      var colLabelTypes = heatMap.getColLabels().label_type;
-      if (Array.isArray(linkout.rowType)) {
-        // if there are mutliple rowTypes required
-        for (var i = 0; i < linkout.rowType.length; i++) {
-          if (rowLabelTypes.indexOf(linkout.rowType[i]) == -1) {
-            return;
-          }
-        }
-      } else {
-        if (rowLabelTypes.indexOf(linkout.rowType) == -1) {
-          return;
-        }
-      }
-      if (Array.isArray(linkout.colType)) {
-        // if there are mutliple colTypes required
-        for (var i = 0; i < linkout.colType.length; i++) {
-          if (colLabelTypes.indexOf(linkout.colType[i]) == -1) {
-            return;
-          }
-        }
-      } else {
-        if (colLabelTypes.indexOf(linkout.colType) == -1) {
-          return;
-        }
-      }
-      grpLinkouts.push({ linkout: linkout });
-    }
   };
 
+  // Helper function. If thing is an array, return thing. Otherwise, return
+  // an array containing thing.
+  function asArray (thing) {
+    return Array.isArray(thing) ? thing : [thing];
+  }
+
   // Helper functions to add header comment lines to help box
-  LNK.addTextRowToTable = function (table, type, axis) {
+  function addTextRowToTable (table, type, axis) {
     var body = table.getElementsByClassName("labelMenuBody")[0];
     var row = body.insertRow();
     var cell = row.insertCell();
@@ -1016,15 +986,16 @@ var linkoutsVersion = "undefined";
     }
   };
 
-  LNK.addMenuItemToTable = function (axis, table, linkout, addedHeader) {
-    const heatMap = MMGR.getHeatMap();
-    var body = table.getElementsByClassName("labelMenuBody")[0];
+  function addMenuItemToTable (heatMap, axis, table, linkout, addedHeader) {
 
-    var functionWithParams = function () {
+    const functionWithParams = function () {
       // this is the function that gets called when the linkout is clicked
-      var input = LNK.getLabelsByType(axis, linkout);
-      if (linkout.callback !== null) linkout.callback(input, axis); // linkout functions will have inputs that correspond to the labelType used in the addlinkout function used to make them.
+      const labels = getLabelsByType(heatMap, linkout, axis);
+      if (linkout.callback !== null) linkout.callback(heatMap, labels, axis); // linkout functions will have inputs that correspond to the labelType used in the addlinkout function used to make them.
     };
+
+    const body = table.getElementsByClassName("labelMenuBody")[0];
+
     //Add indentation to linkout title if the link does not contain the word "clipboard" and it is not a Matrix linkout
     var linkTitle =
       linkout.title.indexOf("clipboard") > 0 && axis !== "Matrix"
@@ -1040,10 +1011,10 @@ var linkoutsVersion = "undefined";
         if (linkout.selectType === "multiSelection") {
           //Don't add a subsection header for multi links IF only one link has been selected
           if (LNK.hasSelection(axis)) {
-            LNK.addTextRowToTable(table, "multi", axis);
+            addTextRowToTable(table, "multi", axis);
           }
         } else {
-          LNK.addTextRowToTable(table, "ind", axis);
+          addTextRowToTable(table, "ind", axis);
         }
         addedHeader = true;
       }
@@ -1111,10 +1082,10 @@ var linkoutsVersion = "undefined";
         if (addedHeader === false) {
           if (linkout.selectType === "multiSelection") {
             if (LNK.hasSelection(axis)) {
-              LNK.addTextRowToTable(table, "multi", axis);
+              addTextRowToTable(table, "multi", axis);
             }
           } else {
-            LNK.addTextRowToTable(table, "ind", axis);
+            addTextRowToTable(table, "ind", axis);
           }
           addedHeader = true;
         }
@@ -1134,38 +1105,15 @@ var linkoutsVersion = "undefined";
     return addedHeader;
   };
 
-  LNK.selectionError = function (e) {
-    var message =
-      "<br>Please select only one label in this axis to use the following linkout:<br><br><b>" +
-      e.currentTarget.innerHTML +
-      "</b>";
-    UHM.linkoutError(message);
-  };
+  function defineDefaultLinkouts () {
 
-  LNK.getDefaultLinkouts = function () {
-    const heatMap = MMGR.getHeatMap();
-    var colLabelType = heatMap.getColLabels().label_type;
-    var rowLabelType = heatMap.getRowLabels().label_type;
-    //	LNK.addLinkout("Copy " + (colLabelType[0].length < 20 ? colLabelType[0] : "Column Labels") +" to Clipboard", colLabelType[0], linkouts.MULTI_SELECT, LNK.copyToClipBoard,null,0);
     LNK.addLinkout(
       "Copy selected labels to clipboard",
-      colLabelType[0],
+      [],
       linkouts.MULTI_SELECT,
-      LNK.copyToClipBoard,
+      copyToClipBoard,
       null,
-      0,
-    ); // text changed from the full label type to just "Column/Row Label" to prevent misreading of this linkout
-    if (rowLabelType[0] !== colLabelType[0]) {
-      //		LNK.addLinkout("Copy " + (rowLabelType[0].length < 20 ? rowLabelType[0] : "Row Labels") + " to Clipboard", rowLabelType[0], linkouts.MULTI_SELECT, LNK.copyToClipBoard,null,0);
-      LNK.addLinkout(
-        "Copy selected labels to clipboard",
-        rowLabelType[0],
-        linkouts.MULTI_SELECT,
-        LNK.copyToClipBoard,
-        null,
-        0,
-      );
-    }
+    );
 
     LNK.addLinkout(
       "Download covariate data for all columns",
@@ -1173,7 +1121,6 @@ var linkoutsVersion = "undefined";
       linkouts.MULTI_SELECT,
       downloadEntireClassBar,
       null,
-      0,
     );
     LNK.addLinkout(
       "Download covariate data for selected columns",
@@ -1181,7 +1128,6 @@ var linkoutsVersion = "undefined";
       linkouts.MULTI_SELECT,
       downloadPartialClassBar,
       null,
-      1,
     );
     LNK.addLinkout(
       "Download covariate data for all rows",
@@ -1189,7 +1135,6 @@ var linkoutsVersion = "undefined";
       linkouts.MULTI_SELECT,
       downloadEntireClassBar,
       null,
-      0,
     );
     LNK.addLinkout(
       "Download covariate data for selected rows",
@@ -1197,48 +1142,42 @@ var linkoutsVersion = "undefined";
       linkouts.MULTI_SELECT,
       downloadPartialClassBar,
       null,
-      1,
     );
-    LNK.addLinkout(
+    LNK.addMatrixLinkout(
       "Copy selected labels to clipboard",
-      "Matrix",
+      [], [],
       linkouts.MULTI_SELECT,
-      LNK.copySelectionToClipboard,
+      copySelectionToClipboard,
       null,
-      0,
     );
-    LNK.addLinkout(
+    LNK.addMatrixLinkout(
       "Download all matrix data to file",
-      "Matrix",
-      LNK.EMPTY_SELECT,
+      [], [],
+      EMPTY_SELECT,
       downloadAllMatrixData,
       null,
-      0,
     );
-    LNK.addLinkout(
+    LNK.addMatrixLinkout(
       "Download selected matrix data to file",
-      "Matrix",
+      [], [],
       linkouts.MULTI_SELECT,
       downloadSelectedMatrixData,
       null,
-      0,
     );
     if (LNK.enableBuilderUploads) {
-      LNK.addLinkout(
+      LNK.addMatrixLinkout(
         "Upload all NG-CHM data to builder",
-        "Matrix",
-        LNK.EMPTY_SELECT,
+        [], [],
+        EMPTY_SELECT,
         uploadAllToBuilder,
         null,
-        0,
       );
-      LNK.addLinkout(
+      LNK.addMatrixLinkout(
         "Upload selected NG-CHM data to builder",
-        "Matrix",
+        [], [],
         linkouts.MULTI_SELECT,
         uploadSelectedToBuilder,
         null,
-        0,
       );
     }
   };
@@ -1260,14 +1199,13 @@ var linkoutsVersion = "undefined";
   // DEFAULT FUNCTIONS //
   //===================//
 
-  LNK.copyToClipBoard = function (labels, axis) {
+  function copyToClipBoard (heatMap, labels, axis) {
     window
       .open("", "", "width=335,height=330,resizable=1")
       .document.write(labels.join("<br>"));
-  };
+  }
 
-  function downloadEntireClassBar(labels, covarAxis) {
-    const heatMap = MMGR.getHeatMap();
+  function downloadEntireClassBar(heatMap, labels, covarAxis) {
     const axis = covarAxis == "ColumnCovar" ? "Column" : "Row";
     const axisLabels = heatMap.getAxisLabels(axis)["labels"];
     const classBars = heatMap.getAxisCovariateData(axis);
@@ -1282,8 +1220,7 @@ var linkoutsVersion = "undefined";
     downloadSelectedData(heatMap, rows, covarAxis, false);
   }
 
-  function downloadPartialClassBar(labels, covarAxis) {
-    const heatMap = MMGR.getHeatMap();
+  function downloadPartialClassBar(heatMap, labels, covarAxis) {
     const axis = covarAxis == "ColumnCovar" ? "Column" : "Row";
     const axisLabels = SRCHSTATE.getSearchLabelsByAxis(axis);
     const labelIndex = SRCHSTATE.getAxisSearchResults(axis);
@@ -1301,7 +1238,7 @@ var linkoutsVersion = "undefined";
     downloadSelectedData(heatMap, rows, covarAxis, false);
   }
 
-  LNK.copySelectionToClipboard = function (labels, axis) {
+  function copySelectionToClipboard (heatMap, labels, axis) {
     window
       .open("", "", "width=335,height=330,resizable=1")
       .document.write(
@@ -1312,22 +1249,21 @@ var linkoutsVersion = "undefined";
       );
   };
 
-  function uploadAllToBuilder(data, axis) {
-    uploadToBuilder("all", data, [], []);
+  function uploadAllToBuilder(heatMap, data, axis) {
+    uploadToBuilder(heatMap, "all", data, [], []);
   }
 
-  function uploadSelectedToBuilder(data, axis) {
+  function uploadSelectedToBuilder(heatMap, data, axis) {
     const rowRanges = NgChm.UTIL.getContigRanges(
       NgChm.SRCHSTATE.getAxisSearchResults("Row"),
     );
     const colRanges = NgChm.UTIL.getContigRanges(
       NgChm.SRCHSTATE.getAxisSearchResults("Column"),
     );
-    uploadToBuilder("selected", data, rowRanges, colRanges);
+    uploadToBuilder(heatMap, "selected", data, rowRanges, colRanges);
   }
 
-  function uploadToBuilder(selectType, data, rowSelection, colSelection) {
-    const heatMap = MMGR.getHeatMap();
+  function uploadToBuilder(heatMap, selectType, data, rowSelection, colSelection) {
     const msgBox = UHM.newMessageBox("upload");
     UHM.setNewMessageBoxHeader(
       msgBox,

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -466,8 +466,8 @@ var linkoutsVersion = "undefined";
   function downloadAllMatrixData(selectedLabels, axis) {
     const heatMap = MMGR.getHeatMap();
     const selection = {
-      rowLabels: MMGR.getActualLabels("row"),
-      colLabels: MMGR.getActualLabels("column"),
+      rowLabels: heatMap.actualLabels("row"),
+      colLabels: heatMap.actualLabels("column"),
       rowItems: null,
       colItems: null,
     };
@@ -1011,7 +1011,7 @@ var linkoutsVersion = "undefined";
         LNK.selection.indexOf("|") > 0
           ? LNK.selection.substring(0, LNK.selection.indexOf("|"))
           : LNK.selection;
-      labelVal = MMGR.getLabelText(labelVal, axis);
+      labelVal = MMGR.getHeatMap().getLabelText(labelVal, axis);
       cell.innerHTML = "<b>Linkouts for: " + labelVal + "</b>";
     }
   };
@@ -2018,7 +2018,7 @@ var linkoutsVersion = "undefined";
       });
       data.axes.push({
         fullLabels: filterGaps(fullLabels, gapIndices),
-        actualLabels: filterGaps(MMGR.getActualLabels(axisName), gapIndices),
+        actualLabels: filterGaps(heatMap.actualLabels(axisName), gapIndices),
         selectedLabels: selectedLabels,
       });
       for (let idx = 0; idx < axis.cocos.length; idx++) {
@@ -2072,9 +2072,10 @@ var linkoutsVersion = "undefined";
       );
       return false;
     }
+    const heatMap = MMGR.getHeatMap();
     var otherAxisName = MMGR.isRow(msg.axisName) ? "column" : "row";
-    var otherAxisLabels = MMGR.getActualLabels(otherAxisName);
-    var heatMapAxisLabels = MMGR.getActualLabels(msg.axisName); //<-- axis labels from heatmap (e.g. gene names in heatmap)
+    var otherAxisLabels = heatMap.actualLabels(otherAxisName);
+    var heatMapAxisLabels = heatMap.actualLabels(msg.axisName); //<-- axis labels from heatmap (e.g. gene names in heatmap)
     heatMapAxisLabels = heatMapAxisLabels.map((l) => l.toUpperCase());
     var axisIdx = [];
     const pluginLabels = [];
@@ -4077,7 +4078,7 @@ var linkoutsVersion = "undefined";
         PIM.sendMessageToPlugin({
           nonce: msg.nonce,
           op: "labels",
-          labels: MMGR.getActualLabels(msg.axisName),
+          labels: MMGR.getHeatMap().actualLabels(msg.axisName),
         });
       } else {
         console.log({

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -63,7 +63,7 @@ var linkoutsVersion = "undefined";
     return UTIL.mapId;
   };
 
-  const debugLinkoutCallbacks = UTIL.getURLParameter("debug").split(",").includes("linkouts");
+  const debugLinkoutCallbacks = UTIL.getDebugFlag("linkouts");
 
   //adds axis linkout objects to the linkouts global variable
   linkouts.addLinkout = function (

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -1304,6 +1304,10 @@
       return this.mapConfig.col_configuration.dendrogram;
     };
 
+    HeatMap.prototype.getAxisDendroConfig = function (axis) {
+      return this.getAxisConfig(axis).dendrogram;
+    };
+
     HeatMap.prototype.setRowDendrogramShow = function (value) {
       this.mapConfig.row_configuration.dendrogram.show = value;
     };

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -1518,6 +1518,20 @@
       return this.mapData.col_data.label;
     };
 
+    HeatMap.prototype.getLabelTypes = function (axis) {
+      const labels = this.getAxisLabels (axis);
+      return copyLabelTypes (labels.labelTypes);
+    };
+
+    HeatMap.prototype.setLabelTypes = function (axis, labelTypes) {
+      const labels = this.getAxisLabels (axis);
+      return labels.labelTypes = copyLabelTypes (labelTypes);
+    };
+
+    function copyLabelTypes (types) {
+      return types.map((obj) => ({ type: obj.type, visible: obj.visible }));
+    }
+
     HeatMap.prototype.getDendrogramData = function (axis) {
       const data = isRow(axis)
         ? this.mapData.row_data.dendrogram
@@ -2269,16 +2283,25 @@
 
     // Returns an array of the "actual" labels for the specified axis
     // of the NG-CHM.  The "actual" labels currently consist of the
-    // text before the first vertical bar in the "full" labels.
+    // visible text fields of the "full" labels.
     HeatMap.prototype.actualLabels = function actualLabels (axis) {
       axis = MMGR.isRow(axis) ? "ROW" : "COLUMN";
       if (!this.actualAxisLabels.hasOwnProperty(axis)) {
         const labels = this.getAxisLabels(axis)["labels"];
-        this.actualAxisLabels[axis] = labels.map((text) => {
-          return text === undefined ? undefined : text.split("|")[0];
-        });
+        const types = this.getLabelTypes(axis);
+        this.actualAxisLabels[axis] = labels.map(visibleParts);
+
+        function visibleParts (label) {
+          return label.split('|').filter((part,idx) => types[idx] && types[idx].visible).join("|");
+        }
       }
       return this.actualAxisLabels[axis];
+    };
+
+    // Return the visible label for the specified full label and axis.
+    HeatMap.prototype.getVisibleLabel = function getVisibleLabel (fullLabel, axis) {
+      const types = this.getLabelTypes(axis);
+      return fullLabel.split('|').filter((part,idx) => types[idx] && types[idx].visible).join("|");
     };
 
     // Returns an array of the "shown" labels for the specified axis of

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -1361,6 +1361,8 @@
       const cv = cfg.top_items_cv;
       // If top_items_cv is not selected, return an empty array.
       if (cv == "") return [];
+      // If top_items_cv is to use the text entry field.
+      if (cv == "--text-entry--") return (cfg.top_items || []).sort();
       // Cache the descending order of each covariate in a map added to the
       // heatmap object.  Each cache entry will be an array of index entries
       // into the axis's label list, such that the covariates values are
@@ -2953,13 +2955,6 @@
     // Perform compatibility checks required once *both* mapConfig and mapData are available.
     function checkAxes (heatMap) {
         if (heatMap.mapData != null && heatMap.mapConfig != null) {
-          const status = getMapStatus(heatMap);
-          if (COMPAT.checkAxis (heatMap.mapConfig, heatMap.mapData, "row")) {
-            status.mapUpdatedOnLoad = true;
-          }
-          if (COMPAT.checkAxis (heatMap.mapConfig, heatMap.mapData, "col")) {
-            status.mapUpdatedOnLoad = true;
-          }
           addDataLayers(heatMap);
           configureFlick(heatMap);
           heatMap.initAxisLabels();

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -1312,6 +1312,10 @@
       return showDendro;
     };
 
+    HeatMap.prototype.getTopItems = function getTopItems (axis, opts = {}) {
+        return (this.getAxisConfig(axis).top_items || []).sort();
+    };
+
     HeatMap.prototype.setReadOnly = function () {
       this.mapConfig.data_configuration.map_information.read_only = "Y";
     };

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -949,6 +949,18 @@
       );
     };
 
+    // Returns a generator over all covariates on both axes.  The returned
+    // values are objects with two entries: axis (row or col) and key.
+    //
+    HeatMap.prototype.genAllCovars = function* genAllCovars () {
+      for (const axis of [ "row", "col" ]) {
+        const covariates = this.getAxisCovariateOrder(axis);
+        for (const key of covariates) {
+          yield ({ axis, key });
+        }
+      };
+    };
+
     // Return an array of the display parameters of all visible covariate bars on an axis.
     // Hidden bars have no parameters.  The order of entries is fixed but not
     // specified.

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -266,6 +266,21 @@
     return button;
   };
 
+  // Create a new select element.
+  UTIL.newSelect = function newSelect(values, contents) {
+    if (values.length != contents.length) {
+      console.error ("UTIL.newSelect: values and contents do not have the same length", { values, contents });
+    }
+    const select = UTIL.newElement("SELECT");
+    for (let ii = 0; ii < values.length; ii++) {
+      const option = UTIL.newElement("OPTION");
+      option.value = values[ii];
+      option.innerText = contents[ii];
+      select.appendChild (option);
+    }
+    return select;
+  };
+
   /**********************************************************************************
    * FUNCTION - showTab: This function shows the tab identified by buttonId and hides
    * all the other tabs in the group.

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -24,6 +24,10 @@
   UTIL.mapId = UTIL.getURLParameter("map");
   UTIL.mapNameRef = UTIL.getURLParameter("name");
 
+  UTIL.getDebugFlag = function getDebugFlag (what) {
+    return UTIL.getURLParameter("debug").split(",").includes(what);
+  };
+
   UTIL.capitalize = function capitalize(str) {
     return str.substr(0, 1).toUpperCase() + str.substr(1);
   };

--- a/NGCHM/WebContent/javascript/PdfGenerator.js
+++ b/NGCHM/WebContent/javascript/PdfGenerator.js
@@ -17,6 +17,8 @@
   const SRCHSTATE = NgChm.importNS("NgChm.SRCHSTATE");
   const PANE = NgChm.importNS("NgChm.Pane");
 
+  const contMissingValues = [ "null", "NA" ];
+
   PDF.rowDendoWidth = null;
   PDF.rowDendroHeight = null;
   PDF.colDendroWidth = null;
@@ -1474,7 +1476,7 @@
       for (let i = 0; i < classBarData.values.length; i++) {
         if (classBarData.values[i] === "!CUT!") {
           cutValues++;
-        } else if (classBarData.values[i] !== "null") {
+        } else if (!contMissingValues.includes(classBarData.values[i])) {
           const num = parseFloat(classBarData.values[i]);
           if (isNaN(num)) {
             console.warn(

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -1132,7 +1132,7 @@
       var key = classBarConfigOrder[j];
       var currentClassBar = classBarsConfig[key];
       if (currentClassBar.show === "Y") {
-        var covLabel = MMGR.getLabelText(key, "COL", true);
+        var covLabel = heatMap.getLabelText(key, "COL", true);
         var covPct = parseInt(currentClassBar.height) / totalHeight;
         //scaled width of current bar
         var barWidth = SUM.rowClassBarWidth * covPct;
@@ -1183,7 +1183,7 @@
     //find the first, middle, and last vertical positions for the bar legend being drawn
     var topPos = beginClasses + prevHeight;
     var midPos = topPos + (currentClassBar.height - 15) / 2 - 1;
-    var midVal = MMGR.getLabelText(key, "ROW", true);
+    var midVal = MMGR.getHeatMap().getLabelText(key, "ROW", true);
     //Create div and place mid legend value
     SUM.setLabelDivElement(key + "ColLabel", midVal, midPos, leftPos, false);
   };
@@ -2042,7 +2042,7 @@
 
         // Helper function. Determine maximum width of top items on the specified axis.
         function calcTopItemsMaxWidth(axis) {
-          const shownLabels = MMGR.getShownLabels(axis);
+          const shownLabels = MMGR.getHeatMap().shownLabels(axis);
           const topItems = getTopItemLabelIndices(axis);
           let maxWidth = 0;
           topItems.forEach((ti) => {
@@ -2302,7 +2302,7 @@
       // function above).
       function placeTopItemLabels(canvas, topItemPosns, axis, otherAxisPosn) {
         const isRow = MMGR.isRow(axis);
-        const shownLabels = MMGR.getShownLabels(axis);
+        const shownLabels = MMGR.getHeatMap().shownLabels(axis);
         topItemPosns.forEach((tip) => {
           const item = document.createElement("Div");
           item.classList.add("topItems");
@@ -2335,7 +2335,7 @@
     // Return an array of the label indices of the top items on the specified axis.
     function getTopItemLabelIndices(axis) {
       const topItems = MMGR.isRow(axis) ? SUM.rowTopItems : SUM.colTopItems;
-      const mapLabels = MMGR.getActualLabels(axis);
+      const mapLabels = MMGR.getHeatMap().actualLabels(axis);
       // Trim top items, filter out empty items, uniqify.
       const uniqTopItems = topItems
         .map((l) => l.trim())

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -194,12 +194,8 @@
       if (!SUM.rowDendro) {
         SUM.rowDendro = new SUMDDR.SummaryRowDendrogram(heatMap, ddrCallbacks);
       }
-      if (heatMap.getColConfig().top_items) {
-        SUM.colTopItems = heatMap.getColConfig().top_items.sort();
-      }
-      if (heatMap.getRowConfig().top_items) {
-        SUM.rowTopItems = heatMap.getRowConfig().top_items.sort();
-      }
+      SUM.colTopItems = heatMap.getTopItems("column");
+      SUM.rowTopItems = heatMap.getTopItems("row");
 
       SUM.matrixWidth = heatMap.getNumColumns(MAPREP.SUMMARY_LEVEL);
       SUM.matrixHeight = heatMap.getNumRows(MAPREP.SUMMARY_LEVEL);

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -194,8 +194,8 @@
       if (!SUM.rowDendro) {
         SUM.rowDendro = new SUMDDR.SummaryRowDendrogram(heatMap, ddrCallbacks);
       }
-      SUM.colTopItems = heatMap.getTopItems("column");
-      SUM.rowTopItems = heatMap.getTopItems("row");
+      SUM.colTopItems = heatMap.getTopItems("column", { count: 10 });
+      SUM.rowTopItems = heatMap.getTopItems("row", { count: 10 });
 
       SUM.matrixWidth = heatMap.getNumColumns(MAPREP.SUMMARY_LEVEL);
       SUM.matrixHeight = heatMap.getNumRows(MAPREP.SUMMARY_LEVEL);

--- a/NGCHM/WebContent/javascript/TCGACompendium/custom.js
+++ b/NGCHM/WebContent/javascript/TCGACompendium/custom.js
@@ -34,7 +34,7 @@ linkouts.addLinkout("View miRBase Page", "MIRNA_SYM", linkouts.SINGLE_SELECT,vie
 NgChm.LNK.addMatrixLinkout("View scatter plot", ["GENE_SYM","GENE_ID"], ["GENE_SYM","GENE_ID"], linkouts.MULTI_SELECT,scatterplot,["dataset"]);
 NgChm.LNK.addMatrixLinkout("View cordist plot", ["GENE_SYM","GENE_ID"], ["GENE_SYM","GENE_ID"], linkouts.MULTI_SELECT,cordistplot,["dataset"]);
 // this is here to prevent duplicate linkouts for maps with GeneSym and GeneID labelTypes
-if (NgChm.heatMap.getColLabels().label_type.indexOf("GENE_ID") == -1 && NgChm.heatMap.getRowLabels().label_type.indexOf("GENE_ID") == -1){
+if (!hasLabelType("col","GENE_ID") && !hasLabelType("row", "GENE_ID")){
 	NgChm.LNK.addMatrixLinkout("View scatter plot", "GENE_SYM", "GENE_SYM", linkouts.MULTI_SELECT,scatterplot,["dataset"]);
 	NgChm.LNK.addMatrixLinkout("View cordist plot", "GENE_SYM", "GENE_SYM", linkouts.MULTI_SELECT,cordistplot,["dataset"]);
 }
@@ -53,6 +53,10 @@ NgChm.LNK.addMatrixLinkout("View cordist plot", "GENE_SYM_ID", "GENE_SYM_ID", li
 //========================//
 // functions defined here //
 //========================//
+
+function hasLabelType (axis, type) {
+  return NgChm.heatMap.getLabelTypes(axis).filter((tt) => tt.type == type).length > 0;
+}
 
 function pointsplot(labels){
 	var dataset = linkouts.getAttribute('dataset');

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -1106,15 +1106,15 @@
       const heatMap = MMGR.getHeatMap();
       var validPluginCtr = 0;
       var pluginTbl = document.createElement("TABLE");
-      var rowLabels = heatMap.getRowLabels().label_type;
-      var colLabels = heatMap.getColLabels().label_type;
+      const rowTypes = heatMap.getLabelTypes("row");
+      const colTypes = heatMap.getLabelTypes("col");
       pluginTbl.insertRow().innerHTML = UHM.formatBlankRow();
       var tr = pluginTbl.insertRow();
       var tr = pluginTbl.insertRow();
       for (var i = 0; i < CUST.customPlugins.length; i++) {
         var plugin = CUST.customPlugins[i];
-        var rowPluginFound = isPluginFound(plugin, rowLabels);
-        var colPluginFound = isPluginFound(plugin, colLabels);
+        var rowPluginFound = isPluginFound(plugin, rowTypes);
+        var colPluginFound = isPluginFound(plugin, colTypes);
         var matrixPluginFound = isPluginMatrix(plugin);
         var axesFound =
           matrixPluginFound && rowPluginFound && colPluginFound
@@ -1253,6 +1253,7 @@
      * Row or column label types are passed into this function.
      **********************************************************************************/
     function isPluginFound(plugin, labels) {
+      labels = labels.map ((type) => type.type);
       var pluginFound = false;
       if (plugin.name === "TCGA") {
         for (var l = 0; l < labels.length; l++) {
@@ -1296,19 +1297,14 @@
      * a given plugin is also a Matrix plugin.
      **********************************************************************************/
     function isPluginMatrix(plugin) {
-      var pluginMatrix = false;
       if (typeof plugin.linkouts !== "undefined") {
-        for (var k = 0; k < plugin.linkouts.length; k++) {
-          var pluginName = plugin.linkouts[k].menuEntry;
-          for (var l = 0; l < linkouts.Matrix.length; l++) {
-            var matrixName = linkouts.Matrix[l].title;
-            if (pluginName === matrixName) {
-              pluginMatrix = true;
-            }
+        for (const linkout of plugin.linkouts) {
+          if (LNK.isMatrixLinkout (linkout.menuEntry)) {
+            return true;
           }
         }
       }
-      return pluginMatrix;
+      return false;
     }
 
     /**********************************************************************************

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -653,7 +653,6 @@
     SUM.rowTopItemsHeight = 0;
     DMM.nextMapNumber = 1;
     DEV.setMouseDown(false);
-    MMGR.initAxisLabels();
     UTIL.removeElementsByClass("DynamicLabel");
     SRCH.clearAllCurrentSearchItems();
   }
@@ -1946,13 +1945,14 @@
     function vanodiSelectLabels(instance, msg) {
       const axis = MMGR.isRow(msg.selection.axis) ? "Row" : "Column";
       const pluginLabels = msg.selection.pointIds.map((l) => l.toUpperCase()); // labels from plugin
+      const heatMap = MMGR.getHeatMap();
       var heatMapAxisLabels;
       if (pluginLabels.length > 0 && pluginLabels[0].indexOf("|") !== -1) {
         // Plugin sent full labels
-        heatMapAxisLabels = MMGR.getHeatMap().getAxisLabels(axis).labels;
+        heatMapAxisLabels = heatMap.axisLabels(axis).labels;
       } else {
         // Plugin sent actual labels (or actual and full are identical).
-        heatMapAxisLabels = MMGR.getActualLabels(axis);
+        heatMapAxisLabels = heatMap.actualLabels(axis);
       }
       heatMapAxisLabels = heatMapAxisLabels.map((l) => l.toUpperCase());
       var setSelected = new Set(pluginLabels); // make a set for faster access below, and avoiding use of indexOf
@@ -1984,7 +1984,7 @@
     "mouseover",
     function vanodiMouseover(instance, msg) {
       const axis = MMGR.isRow(msg.selection.axis) ? "Row" : "Column";
-      const allLabels = MMGR.getActualLabels(axis);
+      const allLabels = MMGR.getHeatMap().actualLabels(axis);
       const pointId = msg.selection.pointId;
       const ptIdx = allLabels.indexOf(pointId) + 1;
       SRCH.setAxisSearchResults(axis, ptIdx, ptIdx);

--- a/NGCHM/WebContent/javascript/UI-Table.js
+++ b/NGCHM/WebContent/javascript/UI-Table.js
@@ -1,0 +1,297 @@
+/**********************************************************************************
+ * UI Table:  Define a class for creating and manipulating tables in the user
+ * interface.
+ **********************************************************************************/
+(function () {
+  "use strict";
+  NgChm.markFile();
+
+  // Define Namespace for NgChm UI Tables.
+  const TABLE = NgChm.createNS("NgChm.UI.TABLE");
+
+  // Import other required name spaces.
+  const UTIL = NgChm.importNS("NgChm.UTIL");
+
+  // Only export is a function for creating a new UI table.
+  TABLE.createTable = function(opts = {}) {
+    return new Table(opts);
+  };
+
+  const defaultProperties = {
+    columns: 2,
+  };
+
+  // CLASS Table - Create a new Table using TABLE.createTable.
+  //
+  function Table (opts) {
+    this.props = Object.assign({}, defaultProperties, opts);
+    this.content = UTIL.newElement("TABLE.ngchm-ui-table");
+    this.indents = [];
+    this.insertPosn = -1;
+  }
+
+  const blankSpaceUnit = 0.3125;// One unit of blank space (in em) for separator rows.
+  const indentUnit = 0.28;      // One unit of indent (in em).
+
+  // METHOD Table.addBlankSpace: Append some vertical blank space to the table.
+  //
+  // - count is the relative amount of space to add, in blankSpaceUnits.
+  //
+  Table.prototype.addBlankSpace = function(count) {
+    if (typeof count === "undefined") count = 1;
+    const newRow = this.content.insertRow(this.insertPosn);
+    if (this.insertPosn != -1) this.insertPosn++;
+    const blankSpace = newRow.insertCell(0);
+    blankSpace.style.lineHeight = (count * blankSpaceUnit).toFixed(3) + 'em';  // toFixed because of limited precision generating ridiculously many digits.
+    blankSpace.setAttribute ('colspan', this.props.columns);
+    blankSpace.innerHTML = "&nbsp;";
+  };
+
+  Table.prototype.addIndent = function(count) {
+    if (typeof count === "undefined") count = 1;
+    this.indents.push(count);
+  };
+
+  Table.prototype.popIndent = function() {
+    this.indents.pop();
+  };
+
+  // METHOD - Table.addRow: Append a row to the table.
+  //
+  // - contents is an array containing the contents of the cells in the new row.
+  // - options is an object that may contain the following fields:
+  //   - colSpan: an array of the colspans for each cell
+  //   - fontWeight: fontWeight for each cell
+  //   - underline: underline text in each cell
+  //   - align: an array of alignments for each cell
+  //
+  Table.prototype.addRow = function (contents, options = {}) {
+    if (typeof contents == "undefined") {
+      throw new Error ("Table.addRow: no contents provided.");
+    }
+    if (contents.length > this.props.columns) {
+      console.warn ("Table.addRow: adding row with more columns than the table", { contents, tableColumns: this.props.columns });
+    }
+
+    if (options.hasOwnProperty('indent')) {
+      console.error ("Table.addRow: obsolete indent in options", { options });
+    }
+
+    // Set default options.
+    options = Object.assign({}, { fontWeight: ["bold","normal"], paddingRight: "0.5em" }, options);
+
+    // Determine span of each column.
+    const colSpan = calcColumnSpans (this.props.columns, contents.length, options);
+    const tr = this.content.insertRow(this.insertPosn);
+    if (this.insertPosn != -1) this.insertPosn++;
+    tr.className = "chmTblRow";
+
+    // Replicate other options, if needed.
+    const align = replicateOption ("align", contents.length, options);
+    const fontWeight = replicateOption ("fontWeight", contents.length, options);
+    const paddingRight = replicateOption ("paddingRight", contents.length, options);
+    const underline = replicateOption ("underline", contents.length, options);
+
+    // Create cells.
+    for (let i = 0; i < contents.length; i++) {
+      const td = tr.insertCell(i);
+      td.colSpan = colSpan[i];
+      if (fontWeight[i]) td.style.fontWeight = fontWeight[i];
+      if (align[i]) td.align = align[i];
+      if (paddingRight[i]) td.style.paddingRight = paddingRight[i];
+      if (underline[i]) td.style.textDecoration = 'underline';
+      for (const item of contents.slice(i,i+1).flat()) {
+        if (["string", "number"].includes(typeof item)) {
+          const span = document.createElement("SPAN");
+          span.innerHTML = item;
+          td.appendChild (span);
+        } else {
+          td.appendChild (item);
+        }
+      }
+    }
+    // Add indent to first cell if requested.
+    if (this.indents.length > 0 && tr.firstChild) {
+      const indent = this.indents.reduce((acc,amt) => acc+amt);
+      tr.firstChild.style.paddingLeft = (indent * indentUnit).toFixed(3) + "em";
+    }
+
+    // Return the row.
+    return tr;
+  };
+
+  // METHOD setInsertPosn - set the row insert position
+  //
+  // If posn == -1, new rows will be appended to the table.
+  // Otherwise, rows will be inserted before the specified row.
+  Table.prototype.setInsertPosn = function (posn) {
+    this.insertPosn = posn;
+  };
+
+  // METHOD addRowX: eXperimental/eXtended version of addRow.
+  // or configuration html TABLE item for a given help pop-up panel. It receives text for
+  // the header column, detail column, and the number of columns to span as inputs.
+  Table.prototype.addRowX = function (rowContent, options = {}) {
+
+    // Set default options.
+    options = Object.assign({}, { cellClasses: ["label","value"],  cellProperties: {} }, options);
+
+    // Determine span of each column.
+    const colSpan = calcColumnSpans (this.props.columns, rowContent.length, options);
+
+    // Append a new row and set class chmTblRow.
+    const tr = this.content.insertRow();
+    tr.classList.add("chmTblRow");
+
+    // Add one or more additional classes to the row.
+    if (options.hasOwnProperty("rowClasses")) {
+      if (Array.isArray(options.rowClasses)) {
+        options.rowClasses.forEach(opt => tr.classList.add(opt));
+      } else {
+        tr.classList.add(options.rowClasses);
+      }
+    }
+
+    // ???? Why do this?
+    if (tr.classList.length == 1) {
+      tr.classList.add("entry");
+    }
+
+    const cellProperties = replicateOption ("cellProperties", rowContent.length, options);
+    const cellClasses = replicateOption ("cellClasses", rowContent.length, options);
+
+    for (let i = 0; i < rowContent.length; i++) {
+      // Create cell.
+      const td = tr.insertCell(i);
+
+      // Add any specified cell classes.
+      if (callClasses[i]) {
+        if (Array.isArray(cellClasses[i])) {
+          cellClasses[i].forEach(cls => td.classList.add(cls));
+        } else {
+          td.classList.add(cellClasses[i]);
+        }
+      }
+      // Add any specified cell properties.
+      if (cellProperties[i]) {
+        for (let [key, value] of Object.entries(cellProperties[i])) {
+          if (typeof value != "object") {
+            td[key] = value;
+          } else if (key == "style") {
+            for (let [k2, v2] of Object.entries(value)) {
+              td.style[k2] = v2;
+            }
+          } else if (key == "classList") {
+            value.forEach((className) => td.classList.add(className));
+          } else if (key == "dataset") {
+            for (let [k2, v2] of Object.entries(value)) {
+              td.dataset[k2] = v2;
+            }
+          } else {
+            console.error("Table.addRowX: Unknown object in cellProperties: ", { i, key, value });
+          }
+        }
+      }
+      // Add cell content.
+      if (
+        ["string", "number"].includes(typeof rowContent[i]) ||
+        Array.isArray(rowContent[i])
+      ) {
+        td.innerHTML = rowContent[i];
+      } else if (rowContent[i]) {
+        td.appendChild(rowContent[i]);
+      }
+    }
+  };
+
+  // FUNCTION replicateOption - replicate an option length times.
+  //
+  // Parameters:
+  // - optionName: the name of the option to replicate.
+  // - length: the number of replicates.
+  // - options: an object that may contain an entry for optionName.
+  //
+  // If options does not include optionName, returns an empty array.
+  // Otherwise returns an array of at least length values.
+  //
+  // If options[optionName] is not an array the contents of the returned array
+  // will be options[optionName].
+  //
+  // If options[optionName] is an array, its contents will be copied to the
+  // returned array. If it contains fewer than length elements, the last
+  // element will be replicated until the returned array contains length elements.
+  //
+  function replicateOption (optionName, length, options) {
+    const replicates = [];
+    if (options.hasOwnProperty(optionName)) {
+      const value = options[optionName];
+      if (Array.isArray(value)) {
+        for (let ii = 0; ii < value.length; ii++) {
+          replicates.push (value[ii]);
+        }
+      } else {
+        replicates.push(value);
+      }
+      if (replicates.length > 0) {
+        const lastValue = replicates[replicates.length-1];
+        while (replicates.length < length) {
+          replicates.push (lastValue);
+        }
+      }
+    }
+    return replicates;
+  }
+
+  // FUNCTION calcColumnSpans - Calculate the number of table columns spanned by each column in a row.
+  //
+  // Parameters:
+  // - tableColumns: the number of columns in the table
+  // - numColumnsInRow: the number of columns in the row
+  // - options: an object, which may contain the following option:
+  //   - colSpan: the number of columns spanned by each row column.
+  //
+  // If:
+  // colSpan is not specified: each row column will span one table column.
+  // colSpan is specified and is not an array: every column will span that many table columns.
+  // colSpan is specified and is an array:
+  // - it will determine the number of table columns spanned by each row column.
+  // - if it is shorter than the number of row columns, each additional column will span one table column.
+  //
+  // If the total number of assigned columns is less than the number of table columns,
+  // the excess columns will be silently added to the last column.
+  //
+  // If the total number of assigned columns exceeds the number of table columns,
+  // a warning will be issued.
+  //
+  // Returns:
+  // - an array of length numColumnsInRow containing the number of table columns spanned
+  //   by each row column.
+  function calcColumnSpans (tableColumns, numColumnsInRow, options) {
+    const colSpans = [];
+    let span = options.hasOwnProperty('colSpan') ? options.colSpan : 1;
+    if (Array.isArray(span)) {
+      if (span.length > numColumnsInRow) {
+        console.error ("Table.calcColumnSpans: colSpan has more columns than the row:", { colSpan: span, numColumnsInRow });
+      }
+      for (let ii = 0; ii < Math.min(span.length,numColumnsInRow); ii++) {
+        colSpans.push (span[ii]);
+      }
+      while (colSpans.length < numColumnsInRow) {
+        colSpans.push (1);
+      }
+    } else {
+      for (let ii = 0; ii < numColumnsInRow; ii++) {
+        colSpans.push (span);
+      }
+    }
+    const totalColumns = colSpans.reduce((acc,val) => acc+val, 0);
+    if (totalColumns > tableColumns) {
+      console.warn ("Table.calcColumnSpans: assigned columns exceeds number of columns in table", { totalColumns, tableColumns, colSpans });
+    } else if (totalColumns < tableColumns) {
+      const excess = tableColumns - totalColumns;
+      colSpans[numColumnsInRow-1] += excess;
+    }
+    return colSpans;
+  }
+
+})();

--- a/NGCHM/WebContent/javascript/UserHelpManager.js
+++ b/NGCHM/WebContent/javascript/UserHelpManager.js
@@ -295,7 +295,7 @@
    * the header column, detail column, and the number of columns to span as inputs.
    **********************************************************************************/
   UHM.setTableRow = function (tableObj, tdArray, colSpan, align) {
-    var tr = tableObj.insertRow();
+    const tr = tableObj.insertRow();
     tr.className = "chmTblRow";
     for (var i = 0; i < tdArray.length; i++) {
       var td = tr.insertCell(i);
@@ -317,6 +317,7 @@
         td.align = align;
       }
     }
+    return tr;
   };
 
   /**********************************************************************************

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -2582,8 +2582,13 @@
         if (["row_DendroShowPref", "col_DendroShowPref"].includes(target.id)) {
           startChange();
           dendroShowChange(target.dataset.axis);
-        }
-        if (target.classList.contains('ngchm-upm-input')) {
+        } else if (target.id == KAID("row","TopItems")) {
+          startChange();
+          KAE("row","TopItemsTextRow").style.display = KAE("row","TopItems").value == "--text-entry--" ? "" : "none";
+        } else if (target.id == KAID("col","TopItems")) {
+          startChange();
+          KAE("col","TopItemsTextRow").style.display = KAE("col","TopItems").value == "--text-entry--" ? "" : "none";
+        } else if (target.classList.contains('ngchm-upm-input')) {
           startChange();
           break;
         }
@@ -2595,21 +2600,35 @@
     // Helper functions.
 
     function addTopItemsSelector(prefContents, axis, pluralAxisName) {
+      const axisConfig = UPM.heatMap.getAxisConfig(axis);
       const covars = UPM.heatMap.getAxisCovariateConfig(axis, {
         type: "continuous",
       });
       const covarNames = Object.keys(covars);
       const selector = UTIL.newSelect(
-        [""].concat(covarNames),
-        ["Not Selected"].concat(covarNames),
+        ["","--text-entry--"].concat(covarNames), // Values
+        ["Not Selected", "Manual Entry"].concat(covarNames), // Option texts
       );
       selector.id = KAID(axis,"TopItems");
       selector.classList.add('ngchm-upm-input');
-      selector.value = UPM.heatMap.getAxisConfig(axis).top_items_cv;
+      selector.value = axisConfig.top_items_cv;
       UHM.setTableRow(prefContents, [
         `&nbsp;&nbsp;Top ${pluralAxisName}:`,
         selector,
       ]);
+      const id = KAID(axis,"TopItemsText");
+      const topItemsText = UTIL.newElement("TEXTAREA.ngchm-upm-input.ngchm-upm-top-items-text", {
+        id: id,
+        name: id,
+        rows: 3,
+      });
+      topItemsText.value = axisConfig.top_items;
+      const tr = UHM.setTableRow(prefContents, [
+        `&nbsp;&nbsp;Top ${pluralAxisName} Input:`,
+        topItemsText,
+      ]);
+      tr.id = KAID(axis,"TopItemsTextRow");
+      tr.style.display = selector.value == "--text-entry--" ? "" : "none";
     }
 
     function dendroShowOptions() {
@@ -2727,6 +2746,8 @@
       KAE(axis,"LabelSizePref").value = axisResetVal.label_display_length;
       KAE(axis,"LabelAbbrevPref").value = axisResetVal.label_display_method;
       KAE(axis,"TopItems").value = axisResetVal.top_items_cv;
+      KAE(axis,"TopItemsText").value = axisResetVal.top_items;
+      KAE(axis,"TopItemsTextRow").style.display = axisResetVal.top_items_cv == "--text-entry--" ? "" : "none";
     }
   };
 
@@ -2746,6 +2767,12 @@
       axisConfig.label_display_method = KAE(axis,"LabelAbbrevPref").value;
       // Top items preferences.
       axisConfig.top_items_cv = KAE(axis,"TopItems").value;
+      axisConfig.top_items = [];
+      for (const item of KAE(axis,"TopItemsText").value.split(/[;, \r\n]+/)) {
+        if (item !== "") {
+          axisConfig.top_items.push(item);
+        }
+      }
     }
 
     // ------------------------------------------------------------------------

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -1,6 +1,6 @@
 /**********************************************************************************
- * USER PREFERENCE FUNCTIONS:  The following functions handle the processing
- * for user preference editing.
+ * USER PREFERENCE MANAGER:  The following functions handle the processing
+ * for user preferences popup.
  **********************************************************************************/
 (function () {
   "use strict";
@@ -9,202 +9,424 @@
   //Define Namespace for NgChm UserPreferenceManager
   const UPM = NgChm.createNS("NgChm.UPM");
 
+  const TABLE = NgChm.importNS("NgChm.UI.TABLE");
+  const PALETTES = NgChm.importNS("NgChm.PALETTES");
   const UHM = NgChm.importNS("NgChm.UHM");
   const MAPREP = NgChm.importNS("NgChm.MAPREP");
   const MMGR = NgChm.importNS("NgChm.MMGR");
   const UTIL = NgChm.importNS("NgChm.UTIL");
-  const DVW = NgChm.importNS("NgChm.DVW");
   const SUM = NgChm.importNS("NgChm.SUM");
   const DET = NgChm.importNS("NgChm.DET");
-  const DEV = NgChm.importNS("NgChm.DEV");
   const DMM = NgChm.importNS("NgChm.DMM");
   const CMM = NgChm.importNS("NgChm.CMM");
   const COMPAT = NgChm.importNS("NgChm.CM");
 
-  // Define action handlers for static UPM UI elements.
-  (function () {
-    let uiElement;
+  // The DIV that contains the entire Preferences Manager.
+  const prefspanel = document.getElementById("prefs");
 
-    uiElement = document.getElementById("colorMenu_btn");
-    uiElement.onclick = (ev) => {
-      UPM.editPreferences(ev.target, null);
-    };
+  // The Preferences Manager interface consists of an overall interface and
+  // four tabs.
+  //
+  // The overall Preference Manager interface consists of those items outside of
+  // the four tabs.  In particular: the panel header and its buttons (left/right
+  // arrow, red X), the panel footer and its buttons (Apply, Reset, Close),
+  // the gear button in the NG-CHM header, and the Modify Map Preferences
+  // option in the NG-CHM hamburger menu.
+  //
+  // Each of the four tabs is implemented as an instance of a derived class of
+  // PreferencesTab.
+  // Here, we define the prototype chains for the derived PreferencesTab classes.
+  Object.setPrototypeOf(MapInfoTab.prototype, PreferencesTab.prototype);
+  Object.setPrototypeOf(MapLayersTab.prototype, PreferencesTab.prototype);
+  Object.setPrototypeOf(RowsColsTab.prototype, PreferencesTab.prototype);
+  Object.setPrototypeOf(CovariatesPrefsTab.prototype, PreferencesTab.prototype);
 
-    uiElement = document.getElementById("prefsMove_btn");
-    uiElement.onclick = () => {
-      UPM.prefsMoveButton();
-    };
+  // Create an instance of each tab.  These calls create the tab instances but do not
+  // populate the body of the tabs.  For that, see method setupTab below.
+  //
+  const mapInfoTab = new MapInfoTab();
+  const mapLayersTab = new MapLayersTab();
+  const rowsColsTab = new RowsColsTab();
+  const covariatesTab = new CovariatesPrefsTab();
+  const allTabs = [mapInfoTab, mapLayersTab, rowsColsTab, covariatesTab];
 
-    uiElement = document.getElementById("redX_btn");
-    uiElement.onclick = () => {
-      UPM.prefsCancelButton();
-    };
+  // VIRTUAL CLASS PreferencesTab - Core functionality of a tab in Preferences Manager.
+  //
+  // All PreferencesTabs have a button and tab div.
+  // Clicking on the tab's button will show the tab's div.
+  //
+  function PreferencesTab(buttonId, tabId) {
+    this.buttonId = buttonId;
+    this.button = document.getElementById(buttonId);
+    this.tabId = tabId;
+    this.tabDiv = document.getElementById(tabId);
+    this.button.onclick = (ev) => this.show(ev);
+  }
 
-    uiElement = document.getElementById("prefMapInfo_btn");
-    uiElement.onclick = () => {
-      UPM.showInfoPrefs();
-    };
+  // VIRTUAL METHOD PreferencesTab.setupTab : populate the tab.
+  //
+  // Derived classes must override this function to setup the tab's UI.
+  // It is called when a new Preferences Manager window is created.
+  // i.e. when openPreferencesManager() is called.
+  // The contents of the tab will be removed when closePreferencesManager()
+  // is called.
+  //
+  PreferencesTab.prototype.setupTab = function setupTab() {
+    console.error("PreferencesTab.setupTab not overridden", { tab: this });
+  };
 
-    uiElement = document.getElementById("prefLayer_btn");
-    uiElement.onclick = () => {
-      UPM.showLayerPrefs();
-    };
+  // VIRTUAL METHOD PreferencesTab.validateTab : validate the entries in the tab.
+  //
+  // Derived classes must override this function to validate the tab's inputs.
+  // It returns null iff all checks pass otherwise an ErrorMsg array.
+  //
+  PreferencesTab.prototype.validateTab = function validateTab() {
+    console.error("PreferencesTab.validateTab not overridden", { tab: this });
+    return null;
+  };
 
-    uiElement = document.getElementById("prefRowsCols_btn");
-    uiElement.onclick = () => {
-      UPM.showRowsColsPrefs();
-    };
+  // Functions that validate preferences return:
+  // - on success: null,
+  // - on error: a string array (called errorMsg) with at least three elements.
+  //
+  // The elements of an ErrorMsg array are:
+  // - errorMsg[0] : selector (only used by the layersTab and the covariatesTab),
+  // - errorMsg[1] : tabId
+  // - errorMsg[2] : error message text
+  // - errorMsg[3] : axis name (only used by the covariates tab)
+  //
+  // errorMsg[1] is used to show the tab containing the error.
+  // errorMsg[0] (and possibly errorMsg[3]) is used to show the relevant view within the tab.
+  // errorMsg[2] is the error text displayed at the bottom of the preferences popup.
 
-    uiElement = document.getElementById("prefClass_btn");
-    uiElement.onclick = () => {
-      UPM.showClassPrefs();
-    };
+  // VIRTUAL METHOD PreferencesTab.resetTabPrefs : reset the preference inputs
+  // in the tab from resetVal.
+  //
+  // Derived classes must override this function to reset the tab's preferences.
+  //
+  PreferencesTab.prototype.resetTabPrefs = function resetTabPrefs(resetVal) {
+    console.error("PreferencesTab.resetTabPrefs not overridden", { tab: this });
+  };
 
-    uiElement = document.getElementById("menuGear");
-    uiElement.onclick = (ev) => {
-      UPM.editPreferences(ev.target, null);
-    };
-  })();
+  // VIRTUAL METHOD PreferencesTab.applyTabPrefs : update the heatMap from the
+  // preference inputs in the tab.
+  //
+  // Derived classes must override this function to apply the tab's preferences.
+  // It is only called if validateTab has been called and returned null (success).
+  //
+  PreferencesTab.prototype.applyTabPrefs = function applyTabPrefs() {
+    console.error("PreferencesTab.applyTabPrefs not overridden", { tab: this });
+  };
 
-  //Global variables for preference processing
-  UPM.bkpColorMaps = null;
-  UPM.filterVal = null;
-  UPM.searchPerformed = false;
-  UPM.resetVal = {};
-  UPM.applyDone = true;
-  UHM.previewDiv = null;
-  UPM.hasClasses = false;
+  // METHODS prepareView and prepareErrorView.
+  //
+  // Some tabs present multiple views. For instance, the Map Layers tab presents a
+  // different view for each data layer.  Normally, we want to show a tab's default
+  // view, but after an error we want to show the view containing the error.
+  //
+  // editPreferences will call either prepareView or prepareErrorView every
+  // time it is called, either initially or after an error.
+  // - prepareView is called if there is no error message, or it does not apply
+  //   to this tab.  The function should prepare the default view for display.
+  // - prepareErrorView is called when there is an error message and it applies
+  //   to this tab.  The function should prepare the view specified in the errorMsg
+  //   array for display.
+  // The total number of times these functions are called and the order
+  // in which they are called is determined by how many errors are identified.
+  //
+  // Tabs that do not provide multiple views do not need to override these methods.
+  // The default for both is that no specific actions are required to prepare
+  // the tab.
 
-  /*===================================================================================
- *  COMMON PREFERENCE PROCESSING FUNCTIONS
- *  
- *  The following functions are utilized to present the entire heat map preferences
- *  dialog and, therefore, sit above those functions designed specifically for processing
- *  individual data layer and covariate classification bar preferences:
- *  	- editPreferences
- *  	- setPrefsDivSizing
- *  	- showLayerPrefs
- *      - showClassPrefs
- *      - showRowsColsPrefs
- *      - prefsCancel
- *      - prefsApply
- *      - prefsValidate
- *      - prefsValidateBreakPoints
- *      - prefsValidateBreakColors
- *      - prefsApplyBreaks
- *      - getNewBreakColors
- *      - getNewBreakThresholds  
- *      - prefsSave
- =================================================================================*/
+  // METHOD PreferencesTab.prepareView : show the default tab view.
+  //
+  // By default, no specific actions are required to show the default view.
+  PreferencesTab.prototype.prepareView = function prepareView() {};
 
-  /**********************************************************************************
-   * FUNCTION - editPreferences: This is the MAIN driver function for edit
-   * preferences processing.  It is called under two conditions (1) The Edit
-   * preferences "gear" button is pressed on the main application screen
-   * (2) User preferences have been applied BUT errors have occurred.
-   *
-   * Processing for this function is documented in detail in the body of the function.
-   **********************************************************************************/
-  UPM.editPreferences = function (e, errorMsg) {
-    UHM.closeMenu();
-    UHM.hlpC();
+  // METHOD PreferencesTab.prepareErrorView : show the tab view that includes errorMsg.
+  //
+  // By default, no specific actions are required to show the view containing the error.
+  PreferencesTab.prototype.prepareErrorView = function prepareErrorView(
+    errorMsg,
+  ) {};
 
-    const prefspanel = document.getElementById("prefs");
-    const prefsPanelAlreadyOpen = prefspanel.style.display !== "none";
-    const heatMap = MMGR.getHeatMap();
+  // METHOD PreferencesTab.show : show this tab and hide its siblings.
+  //
+  // This method should not be overridden.
+  //
+  PreferencesTab.prototype.show = function () {
+    UTIL.showTab(this.buttonId);
+  };
 
-    var rowClassBarsOrder = heatMap.getRowClassificationOrder();
-    var colClassBarsOrder = heatMap.getColClassificationOrder();
-    if (colClassBarsOrder.length > 0 || rowClassBarsOrder.length > 0) {
-      UPM.hasClasses = true;
-    }
-
-    //If first time thru, save the dataLayer colorMap
-    //This is done because the colorMap must be edited to add/delete breakpoints while retaining their state
-    if (UPM.bkpColorMaps === null) {
-      UPM.bkpColorMaps = new Array();
-      var dataLayers = heatMap.getDataLayers();
-      for (var key in dataLayers) {
-        UPM.bkpColorMaps.push(
-          heatMap.getColorMapManager().getColorMap("data", key),
-        );
-      }
-    }
-
-    UPM.resetVal = UPM.getResetVals();
-
-    var prefprefs = document.getElementById("prefPrefs");
-
-    if (errorMsg !== null) {
-      UPM.setMessage(errorMsg[2]);
-    } else {
-      //Create and populate map info preferences DIV and add to parent DIV
-      const mapinfoprefs = UPM.setupMapInfoPrefs(e, prefprefs);
-
-      //Create and populate row & col preferences DIV and add to parent DIV
-      const rowcolprefs = UPM.setupRowColPrefs(e, prefprefs);
-
-      //Create and populate classifications preferences DIV and add to parent DIV
-      const classprefs = UPM.setupClassPrefs(e, prefprefs);
-
-      //Create and populate breakpoint preferences DIV and add to parent DIV
-      const layerprefs = UPM.setupLayerPrefs(e, prefprefs);
-
-      // Set DIV containing both class and break DIVs to visible and append to prefspanel table
-      prefprefs.style.display = "block";
-
-      UPM.setMessage("");
-    }
-
-    //If errors exist and they are NOT on the currently visible DIV (dataLayer1),
-    //hide the dataLayers DIV, set the tab to "Covariates", and open the appropriate
-    //covariate bar DIV.
-    if (errorMsg === null) {
-      UPM.addClassPrefOptions();
-    }
-    UPM.showDendroSelections();
-    UPM.showLabelSelections();
-    UPM.setShowAll();
-    if (errorMsg != null && errorMsg[1] === "classPrefs") {
-      UPM.showClassBreak(errorMsg[0], errorMsg[3]);
-      UPM.showClassPrefs();
-    } else if (errorMsg != null && errorMsg[1] === "layerPrefs") {
-      UPM.showLayerBreak(errorMsg[0]);
-      UPM.showLayerPrefs();
-    } else if (errorMsg != null && errorMsg[1] === "infoPrefs") {
-      UPM.showInfoPrefs();
-    } else if (errorMsg != null && errorMsg[1] === "rowsColsPrefs") {
-      UPM.showRowsColsPrefs();
-    } else if (UPM.searchPerformed) {
-      UPM.searchPerformed = false;
-      UPM.showClassPrefs();
-    } else {
-      UPM.showLayerBreak(heatMap.getCurrentDL());
-      UPM.showLayerPrefs();
-    }
-    errorMsg = null;
-    if (!prefsPanelAlreadyOpen) {
-      prefspanel.style.display = "";
-      UPM.locatePrefsPanel();
+  // METHOD PreferencesTab.removeTab : remove the contents of the tab.
+  //
+  // The tabDiv and the tabButton will remain as hidden elements.
+  //
+  // This method should not be overridden.
+  //
+  PreferencesTab.prototype.removeTab = function () {
+    while (this.tabDiv.firstChild) {
+      this.tabDiv.removeChild(this.tabDiv.firstChild);
     }
   };
 
+  // Generate a list of potential target elements for an event, starting at
+  // the event.target and proceeding up through its parents, up to
+  // and including the tab's highest div.  The caller should stop processing
+  // the generator's results when an applicable element is found.
+  PreferencesTab.prototype.targetGen = function* targetGen (event) {
+    for (let target = event.target; target; target = target.parentElement) {
+      yield (target);
+      if (target === this.tabDiv) {
+        break;
+      }
+    }
+    return null;
+  };
+
+  // --------------------------------------------------------------------------
+  //
+  // User Preferences Manager interface.
+  //
+  const applyButton = KAE("prefApply_btn");
+  const resetButton = KAE("prefReset_btn");
+
+  // Define a click handler for each of the Preferences Manager UI elements.
+  (function () {
+    // Two ways to open the Preferences Manager.
+    KAE ("colorMenu_btn").onclick = () => openPreferencesManager();
+    KAE ("menuGear").onclick = () => openPreferencesManager();
+
+    // Two ways to close the Preferences Manager.
+    KAE ("redX_btn").onclick = () => closePreferencesManager();
+    KAE ("prefClose_btn").onclick = () => closePreferencesManager();
+
+    // Move the Preferences Manager position.
+    KAE ("prefsMove_btn").onclick = () => movePreferencesManager();
+
+    // Define handlers for the Apply and Reset buttons.
+    applyButton.onclick = () => applyAllPreferences(false);
+    resetButton.onclick = () => resetAllPreferences();
+  })();
+
+  // Global variables for Preferences Manager.
+  //
+  // There can be at most one Preferences Manager window displayed at any time.
+  //
+  // These variables are set when the Preferences Manager is opened and cleared
+  // when it is closed.
+  clearGlobalVariables();
+
+  function clearGlobalVariables() {
+    UPM.heatMap = null;          // The heatMap in the open Preferences Manager (UPM).
+    UPM.bkpColorMaps = null;     // A backup copy of the heatMap's color maps, used by reset.
+    UPM.resetValJSON = null;     // A backup copy of the UPM's options, used by reset.
+  }
+
+  /*===================================================================================
+   *  COMMON PREFERENCE PROCESSING FUNCTIONS
+   *
+   *  The following functions are utilized to present the entire heat map preferences
+   *  dialog and, therefore, sit above those functions that are specific to a tab.
+   *  - openPreferencesManager
+   *  - closePreferencesManager
+   *  - editPreferences
+   *  - prefsValidateBreakPoints
+   *  - prefsValidateBreakColors
+   *  - prefsApplyBreaks
+   *  - getNewBreakColors
+   *  - getNewBreakThresholds
+   =================================================================================*/
+
+  /* FUNCTION openPreferencesManager - Open the User Preferences Manager for the current
+   * heatmap.
+   *
+   * This function is called if
+   * - the Edit Preferences "gear" button is pressed on the main application screen, or
+   * - the Modify Map Preferences menu option is selected from the hamburger menu.
+   */
+  function openPreferencesManager() {
+    UHM.closeMenu();
+    UHM.hlpC();
+
+    if (prefspanel.style.display !== "none") {
+      // The user clicked to open the preferences panel, but we believe it is already open.
+      // Nothing to do, but we reshow the preferences panel just in case it's not visible.
+      prefspanel.style.display = "";
+      locatePrefsPanel();
+      return;
+    }
+
+    // Set the heatMap we are editing.
+    UPM.heatMap = MMGR.getHeatMap();
+
+    // Disable the apply and reset buttons until a change is made.
+    applyButton.disabled = true;
+    resetButton.disabled = true;
+
+    // Execute common code to display the contents of the Preferences Manager.
+    editPreferences(null);
+  }
+
   /**********************************************************************************
-   * FUNCTION - locatePrefsPanel: The purpose of this function is to place the prefs
-   * panel on the screen.
+   * FUNCTION closePreferencesManager: Close the Preferences Manager Window.
+   *
+   * necessary to exit the user preferences dialog WITHOUT applying or saving any
+   * changes made by the user when the Cancel button is pressed on the ColorMap
+   * preferences dialog.  Since the dataLayer colormap must be edited to add/delete
+   * breakpoints, the backup colormap (saved when preferences are first opened) is re-
+   * applied to the colorMapManager.  Then the preferences DIV is retrieved and removed.
    **********************************************************************************/
-  UPM.locatePrefsPanel = function () {
-    const prefspanel = document.getElementById("prefs");
+  function closePreferencesManager() {
+    // Clear any error message.
+    showErrorMessage("");
+
+    // Remove the contents of all tabs.
+    // This will automatically cancel any unapplied changes in the
+    // non-colormap UI elements in those tabs.
+    for (const tab of allTabs) tab.removeTab();
+
+    // Restore the heatMap's color maps.
+    // This will remove any unapplied changes made to the color maps.
+    restoreColorMaps();
+
+    // Hide the user preferences panel.
+    document.getElementById("prefs").style.display = "none";
+
+    // Clear all global variables.
+    clearGlobalVariables();
+  }
+
+  // Call before making any change to the preferences.
+  // This will preserve, if necessary, the data required to reset any changes
+  // and enable the Apply and Reset buttons.
+  //
+  function startChange() {
+    if (resetButton.disabled) {
+      preserveColorMaps();
+      saveResetVals();
+    }
+    applyButton.disabled = false;
+    resetButton.disabled = false;
+  }
+
+  // FUNCTION preserveColorMaps: Preserve the contents of the NG-CHM color
+  // maps.
+  //
+  // This is done so that the state can still be reset after any color map
+  // changes have been applied.
+  //
+  // We make deep copies of the color map states by saving them as JSON.
+  //
+  function preserveColorMaps () {
+    if (UPM.bkpColorMaps === null) {
+      UPM.bkpColorMaps = { layers: new Map(), row: new Map(), col: new Map() };
+      const colorMapMgr = UPM.heatMap.getColorMapManager();
+      const dataLayers = UPM.heatMap.getDataLayers();
+      for (let key in dataLayers) {
+        UPM.bkpColorMaps.layers.set(key, colorMapMgr.getColorMapJSON("data", key));
+      }
+      for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+        UPM.bkpColorMaps[axis].set(key, colorMapMgr.getColorMapJSON(axis, key));
+      }
+    }
+  }
+
+  // FUNCTION restoreColorMaps: Undo any color map changes by restoring the
+  // NG-CHM's colormaps from bkpColorMaps.
+  function restoreColorMaps () {
+    if (UPM.bkpColorMaps !== null) {
+      const colorMapMgr = UPM.heatMap.getColorMapManager();
+      const dataLayers = UPM.heatMap.getDataLayers();
+      for (let key in dataLayers) {
+        colorMapMgr.setColorMap("data", key, JSON.parse(UPM.bkpColorMaps.layers.get(key)));
+      }
+      for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+        colorMapMgr.setColorMap(axis, key, JSON.parse(UPM.bkpColorMaps[axis].get(key)));
+      }
+    }
+  }
+
+  /**********************************************************************************
+   * FUNCTION editPreferences: This is the MAIN driver function for edit
+   * preferences processing.  It is called under two conditions:
+   *
+   * (1) The Edit Preferences "gear" button is pressed on the main application screen,
+   *     or the Modify Map Preferences menu option is selected from the hamburger menu.
+   *
+   * (2) The user attempted to apply preferences BUT at least error was detected
+   *     during validation.
+   *
+   **********************************************************************************/
+  function editPreferences(errorMsg) {
+    if (errorMsg === null) {
+      // Initialize all tabs.
+      for (const tab of allTabs) {
+        tab.setupTab();
+      }
+      // Show the Preferences Manager.
+      const tabContainer = document.getElementById("prefPrefs");
+      tabContainer.style.display = "block";
+      // Ensure no error message is displayed.
+      showErrorMessage("");
+    } else {
+      // Display the error message.
+      showErrorMessage(errorMsg[2]);
+    }
+
+    // Prepare each tab's view: either the default view or after an error was detected.
+    // errorMsg[1] is the id of the tab where the error was detcetd.
+    for (const tab of allTabs) {
+      if (errorMsg && errorMsg[1] == tab.tabId) {
+        tab.prepareErrorView(errorMsg);
+      } else {
+        tab.prepareView();
+      }
+    }
+
+    if (errorMsg != null) {
+      // If there's an error, show that tab.
+      showTabWithError(errorMsg);
+      errorMsg = null;
+    } else {
+      // Default to opening the map layers tab.
+      mapLayersTab.show();
+    }
+
+    // Display the Preferences Manager (if it isn't already) and set its location.
+    prefspanel.style.display = "";
+    locatePrefsPanel();
+
+    // ------------------------------------------------------------------------
+    // Helper functions.
+
+    // Switch to the tab containing the error.
+    function showTabWithError(errorMsg) {
+      for (let ii = 0; ii < allTabs.length; ii++) {
+        if (allTabs[ii].tabId == errorMsg[1]) {
+          allTabs[ii].show(errorMsg);
+          return;
+        }
+      }
+      console.error("UPM.editPreferences: unable to show error: bad tab id", {
+        errorMsg,
+      });
+    }
+  }
+
+  // FUNCTION locatePrefsPanel: Position the prefernces panel on the screen.
+  //
+  function locatePrefsPanel() {
     const icon = document.querySelector("*[data-prefs-panel-locator]");
-    const contBB = UTIL.containerElement.getBoundingClientRect();
     const iconBB = icon.getBoundingClientRect();
     const container = UTIL.containerElement.parentElement;
+    // Position the preferences panel over the container element.
     prefspanel.style.top = container.offsetTop + "px";
     prefspanel.style.height = container.offsetHeight + "px";
-    //done for builder panel sizing ONLY
+    // Done for builder panel sizing ONLY
     const screenNotes = document.getElementById("screenNotesDisplay");
     if (screenNotes !== null) {
-      notesBB = screenNotes.getBoundingClientRect();
+      const notesBB = screenNotes.getBoundingClientRect();
       prefspanel.style.top = iconBB.top - notesBB.height + "px";
     }
 
@@ -213,13 +435,13 @@
       UTIL.containerElement.getBoundingClientRect().right -
       prefspanel.offsetWidth +
       "px";
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - setMessage: The purpose of this function is to set the message at
-   * the bottom of the preferences panel when it is drawn or re-drawn.
+   * FUNCTION showErrorMessage: Set the error message at the bottom of the preferences
+   * panel.
    **********************************************************************************/
-  UPM.setMessage = function (errorMsgTxt) {
+  function showErrorMessage(errorMsgTxt) {
     const prefActions = document.getElementById("prefActions");
     const errMsg = prefActions.querySelector(".errorMessage");
     if (errMsg) {
@@ -233,79 +455,15 @@
         prefActions.firstChild,
       );
     }
-    document.getElementById("prefApply_btn").onclick = function () {
-      UPM.prefsApplyButton();
-    };
-    document.getElementById("prefReset_btn").onclick = function () {
-      UPM.prefsResetButton();
-    };
-    document.getElementById("prefClose_btn").onclick = function () {
-      UPM.prefsCancelButton();
-    };
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - showRowsColsPrefs: The purpose of this function is to perform the
-   * processing for the preferences tab when the user selects the "Rows & Cols" tab.
+   * FUNCTION movePreferencesManager: Toggle the preferences manager panel
+   * from the left side of the screen to the right (or vice-versa).
    **********************************************************************************/
-  UPM.showRowsColsPrefs = function () {
-    UTIL.showTab("prefRowsCols_btn");
-  };
-
-  UPM.showInfoPrefs = function () {
-    UTIL.showTab("prefMapInfo_btn");
-  };
-
-  /**********************************************************************************
-   * FUNCTION - showLayerPrefs: The purpose of this function is to perform the
-   * processing for the preferences tab when the user selects the "Data Layers" tab.
-   **********************************************************************************/
-  UPM.showLayerPrefs = function () {
-    UTIL.showTab("prefLayer_btn");
-    UPM.showLayerBreak(); // ??
-  };
-
-  /**********************************************************************************
-   * FUNCTION - showClassPrefs: The purpose of this function is to perform the
-   * processing for the preferences tab when the user selects the "Covariates" tab.
-   **********************************************************************************/
-  UPM.showClassPrefs = function () {
-    UTIL.showTab("prefClass_btn");
-  };
-
-  /**********************************************************************************
-   * FUNCTION - prefsCancelButton: The purpose of this function is to perform all processing
-   * necessary to exit the user preferences dialog WITHOUT applying or saving any
-   * changes made by the user when the Cancel button is pressed on the ColorMap
-   * preferences dialog.  Since the dataLayer colormap must be edited to add/delete
-   * breakpoints, the backup colormap (saved when preferences are first opened) is re-
-   * applied to the colorMapManager.  Then the preferences DIV is retrieved and removed.
-   **********************************************************************************/
-  UPM.prefsCancelButton = function () {
-    if (UPM.bkpColorMaps !== null) {
-      const heatMap = MMGR.getHeatMap();
-      var colorMapMgr = heatMap.getColorMapManager();
-      var dataLayers = heatMap.getDataLayers();
-      var i = 0;
-      for (var key in dataLayers) {
-        colorMapMgr.setColorMap(key, UPM.bkpColorMaps[i], "data");
-        i++;
-      }
-    }
-    UPM.removeSettingsPanels();
-    //Hide the preferences panel
-    document.getElementById("prefs").style.display = "none";
-    UPM.searchPerformed = false;
-  };
-
-  /**********************************************************************************
-   * FUNCTION - prefsMoveButton: The purpose of this function is to toggle the preferences
-   * editing panel from the left side of the screen to the right (or vice-versa).
-   **********************************************************************************/
-  UPM.prefsMoveButton = function () {
+  function movePreferencesManager() {
     UHM.hlpC();
-    var prefspanel = document.getElementById("prefs");
-    var moveBtn = document.getElementById("prefsMove_btn");
+    const moveBtn = document.getElementById("prefsMove_btn");
     if (moveBtn.dataset.state === "moveLeft") {
       moveBtn.dataset.state = "moveRight";
       prefspanel.style.right = "";
@@ -318,422 +476,114 @@
         prefspanel.offsetWidth +
         "px";
     }
-  };
+  }
+
+  // FUNCTION saveResetVals: save a copy of all the data needed to reset the heatMap state.
+  //
+  function saveResetVals() {
+    const resetVals = {
+      matrix: UPM.heatMap.getMapInformation(),
+    };
+    for (const axis of [ "row", "col" ]) {
+      resetVals[axis+"Config"] = UPM.heatMap.getAxisConfig(axis);
+      resetVals[axis+"LabelTypes"] = UPM.heatMap.getLabelTypes(axis);  // Comes from mapData.
+    }
+    // Turn resetVals into a string so the values don't change as the user changes
+    // stuff in the preferences manager.
+    UPM.resetValJSON = JSON.stringify(resetVals);
+  }
+
+  // FUNCTION resetAllPreferences: Reset the heatMap state and the UI to the saved values.
+  //
+  function resetAllPreferences() {
+    const resetVal = JSON.parse(UPM.resetValJSON);
+    // Reset all of the UI preferences.
+    for (const tab of allTabs) {
+      tab.resetTabPrefs(resetVal);
+    }
+    // Then set the heatMap to those restored values.
+    applyAllPreferences(true);
+  }
 
   /**********************************************************************************
-   * FUNCTION - removeSettingsPanels: The purpose of this function is to remove all
-   * panels that are content specific before closing the preferences dialog.
-   **********************************************************************************/
-  UPM.removeSettingsPanels = function () {
-    //Remove all panels that are content specific before closing
-    UPM.setMessage("");
-
-    const prefTabs = [...document.getElementById("prefPrefs").children];
-
-    prefTabs.forEach((tab) => {
-      while (tab.firstChild) {
-        tab.removeChild(tab.firstChild);
-      }
-    });
-  };
-
-  /**********************************************************************************
-   * FUNCTION - prefsApplyButton: The purpose of this function is to perform all processing
+   * FUNCTION applyAllPreferences: The purpose of this function is to perform all processing
    * necessary to reconfigure the "current" presentation of the heat map in the
    * viewer when the Apply button is pressed on the ColorMap Preferences Dialog.
    * First validations are performed.  If errors are found, preference
    * changes are NOT applied and the user is re-presented with the preferences dialog
    * and the error found.  If no errors are found, all changes are applied to the heatmap
-   * and the summary panel, detail panel, and covariate bars are redrawn.  However,
-   * these changes are not yet permanently  saved to the JSON files that are used to
-   * configure heat map presentation.
+   * and the summary panel, detail panel, and covariate bars are redrawn.
    **********************************************************************************/
-  UPM.prefsApplyButton = function (isReset) {
-    disableApplyButton();
-    setTimeout(function () {
-      // wait until the disable button has been updated, otherwise the disable button never shows up
-      UPM.doApply(isReset);
-    }, 10);
-  };
-
-  UPM.doApply = function (isReset) {
-    //Normal processing when not reset
-    const heatMap = MMGR.getHeatMap();
-    if (typeof isReset === "undefined") {
-      //Perform validations of all user-entered data layer and covariate bar
-      //preference changes.
-      var errorMsg = UPM.prefsValidate();
-      if (errorMsg !== null) {
-        UPM.prefsError(errorMsg);
-        UPM.applyDone = true;
-        enableApplyButton();
-      } else {
-        UPM.prefsApply();
-        heatMap.initAxisLabels();
-        heatMap.setUnAppliedChanges(true);
-        UPM.prefsSuccess();
-        enableApplyButton();
-      }
-    } else {
-      //When resetting no validations need be performed and, if they were,
-      //additional modifications to validation logic would be required.
-      UPM.prefsApply();
-      heatMap.setUnAppliedChanges(true);
-      UPM.prefsSuccess();
-      enableApplyButton();
-    }
-  };
-
-  /**********************************************************************************
-   * FUNCTION - disableApplyButton: This function toggles the Apply button to the
-   * greyed out version when the Apply or Reset button is pressed
-   **********************************************************************************/
-
-  function disableApplyButton() {
-    const applyButton = document.getElementById("prefApply_btn");
+  function applyAllPreferences(isReset) {
+    // Disable the apply and reset buttons.
     applyButton.disabled = true;
-    UPM.applyDone = false;
-  }
+    resetButton.disabled = true;
 
-  /**********************************************************************************
-   * FUNCTION - enableApplyButton: This function toggles the Apply button back to the
-   * standard/blue one after the apply/reset has finished
-   **********************************************************************************/
+    // Give the apply and reset buttons time to become disabled, otherwise
+    // that state might never show up.
+    setTimeout(() => doApply(isReset), 0);
 
-  function enableApplyButton() {
-    if (UPM.applyDone) {
-      // make sure the apply is done
-      const applyButton = document.getElementById("prefApply_btn");
-      applyButton.disabled = false;
-    } else {
-      // otherwise try again in a bit
-      setTimeout(enableApplyButton, 500);
-    }
-  }
+    // ------------------------------------------------------------------------
+    // Helper functions.
 
-  /**********************************************************************************
-   * FUNCTION - prefsSuccess: The purpose of this function perform the functions
-   * necessary when preferences are determined to be valid. It is shared by the
-   * Apply and Save buttons.
-   **********************************************************************************/
-  UPM.prefsSuccess = function () {
-    UPM.filterVal = null;
-    //Remove the backup color map (used to reinstate colors if user cancels)
-    //and formally apply all changes to the heat map, re-draw, and exit preferences.
-    UPM.bkpColorMaps = null;
-    SUM.redrawSummaryPanel();
-    DMM.resizeDetailMapCanvases();
-    DET.updateSelections(false); // Do not skip resize: covariate bar changes may require resize
-    UPM.applyDone = true;
-    UPM.setMessage("");
-  };
-
-  /**********************************************************************************
-   * FUNCTION - prefsError: The purpose of this function perform the functions
-   * necessary when preferences are determined to be invalid. It is shared by the
-   * Apply and Save buttons.
-   **********************************************************************************/
-  UPM.prefsError = function (errorMsg) {
-    //If a validation error exists, re-present the user preferences
-    //dialog with the error message displayed in red.
-    UPM.filterVal = null;
-    UPM.editPreferences(document.getElementById("gear_btn"), errorMsg);
-  };
-
-  /**********************************************************************************
-   * FUNCTION - prefsApply: The purpose of this function is to apply all user
-   * ColorMap preferences settings.  It is shared by the Apply and Save buttons.
-   **********************************************************************************/
-  UPM.prefsApply = function () {
-    // Apply Row & Column Preferences
-    const heatMap = MMGR.getHeatMap();
-    var rowDendroConfig = heatMap.getRowDendroConfig();
-    var rowOrganization = heatMap.getRowOrganization();
-    var rowOrder = rowOrganization["order_method"];
-    if (rowOrder === "Hierarchical") {
-      var rowDendroShowVal = document.getElementById("rowDendroShowPref").value;
-      rowDendroConfig.show = rowDendroShowVal;
-      rowDendroConfig.height = document.getElementById(
-        "rowDendroHeightPref",
-      ).value;
-    }
-
-    var colDendroConfig = heatMap.getColDendroConfig();
-    var colOrganization = heatMap.getColOrganization();
-    var colOrder = colOrganization["order_method"];
-    if (colOrder === "Hierarchical") {
-      var colDendroShowVal = document.getElementById("colDendroShowPref").value;
-      colDendroConfig.show = colDendroShowVal;
-      colDendroConfig.height = document.getElementById(
-        "colDendroHeightPref",
-      ).value;
-    }
-
-    for (let axis of [ "row", "col" ]) {
-      heatMap.getAxisConfig(axis).top_items_cv = document.getElementById(axis+"TopItems").value;
-      return applyLabelTypeInputs(heatMap, axis);
-    }
-
-    // Apply Covariate Bar Preferences
-    var rowClassBars = heatMap.getRowClassificationConfig();
-    for (var key in rowClassBars) {
-      var currentClassBar = rowClassBars[key];
-      var colorMap = heatMap.getColorMapManager().getColorMap("row", key);
-      var keyrow = key + "_row";
-      var showElement = document.getElementById(keyrow + "_showPref");
-      var heightElement = document.getElementById(keyrow + "_heightPref");
-      if (heightElement.value === "0") {
-        showElement.checked = false;
+    // Continue applying the preferences once the applyButton has had a chance to update.
+    function doApply(isReset) {
+      // When resetting, no validations need to be performed and, if they were,
+      // additional modifications to the validation logic would be required.
+      const errorMsg = isReset ? null : validateAllPreferences();
+      if (errorMsg) {
+        // If a validation error exists, re-present the user preferences
+        // dialog with the error message displayed.
+        resetButton.disabled = false;
+        editPreferences(errorMsg);
+      } else {
+        // Apply all preferences.
+        for (const tab of allTabs) {
+          tab.applyTabPrefs();
+        }
+        showErrorMessage("");
+        redrawHeatMap();
+        // Remove the backup color maps (used to reinstate colors if
+        // the user resets or cancels).
+        UPM.bkpColorMaps = null;
       }
-      heatMap.setClassificationPrefs(
-        key,
-        "row",
-        showElement.checked,
-        heightElement.value,
-      );
-      var barTypeElement = document.getElementById(keyrow + "_barTypePref");
-      var bgColorElement = document.getElementById(keyrow + "_bgColorPref");
-      var fgColorElement = document.getElementById(keyrow + "_fgColorPref");
-      var lowBoundElement = document.getElementById(keyrow + "_lowBoundPref");
-      var highBoundElement = document.getElementById(keyrow + "_highBoundPref");
-      if (colorMap.getType() === "continuous") {
-        heatMap.setClassBarScatterPrefs(
-          key,
-          "row",
-          barTypeElement.value,
-          lowBoundElement.value,
-          highBoundElement.value,
-          fgColorElement.value,
-          bgColorElement.value,
-        );
-      }
-      UPM.prefsApplyBreaks(key, "row");
-    }
-    var colClassBars = heatMap.getColClassificationConfig();
-    for (var key in colClassBars) {
-      var currentClassBar = colClassBars[key];
-      var colorMap = heatMap.getColorMapManager().getColorMap("col", key);
-      var keycol = key + "_col";
-      var showElement = document.getElementById(keycol + "_showPref");
-      var heightElement = document.getElementById(keycol + "_heightPref");
-      if (heightElement.value === "0") {
-        showElement.checked = false;
-      }
-      heatMap.setClassificationPrefs(
-        key,
-        "col",
-        showElement.checked,
-        heightElement.value,
-      );
-      var barTypeElement = document.getElementById(keycol + "_barTypePref");
-      var bgColorElement = document.getElementById(keycol + "_bgColorPref");
-      var fgColorElement = document.getElementById(keycol + "_fgColorPref");
-      var lowBoundElement = document.getElementById(keycol + "_lowBoundPref");
-      var highBoundElement = document.getElementById(keycol + "_highBoundPref");
-      if (colorMap.getType() === "continuous") {
-        heatMap.setClassBarScatterPrefs(
-          key,
-          "col",
-          barTypeElement.value,
-          lowBoundElement.value,
-          highBoundElement.value,
-          fgColorElement.value,
-          bgColorElement.value,
-        );
-      }
-      UPM.prefsApplyBreaks(key, "col");
     }
 
-    // Apply Label Sizing Preferences
-    heatMap.getColConfig().label_display_length =
-      document.getElementById("colLabelSizePref").value;
-    heatMap.getColConfig().label_display_method =
-      document.getElementById("colLabelAbbrevPref").value;
-    heatMap.getRowConfig().label_display_length =
-      document.getElementById("rowLabelSizePref").value;
-    heatMap.getRowConfig().label_display_method =
-      document.getElementById("rowLabelAbbrevPref").value;
-
-    // Apply Data Layer Preferences
-    var dataLayers = heatMap.getDataLayers();
-    for (var key in dataLayers) {
-      var showGrid = document.getElementById(key + "_gridPref");
-      var gridColor = document.getElementById(key + "_gridColorPref");
-      var selectionColor = document.getElementById(key + "_selectionColorPref");
-      var gapColor = document.getElementById(key + "_gapColorPref");
-      heatMap.setLayerGridPrefs(
-        key,
-        showGrid.checked,
-        gridColor.value,
-        selectionColor.value,
-        gapColor.value,
-      );
-      UPM.prefsApplyBreaks(key, "data");
-      UHM.loadColorPreviewDiv(key);
-    }
-  };
-
-  /**********************************************************************************
-   * FUNCTION - prefsValidate: The purpose of this function is to validate all user
-   * changes to the heatmap properties. When the very first error is found, an error
-   * message (string array containing error information) is created and returned to
-   * the prefsApply function.
-   **********************************************************************************/
-  UPM.prefsValidate = function () {
-    const heatMap = MMGR.getHeatMap();
-
-    return (
-      UPM.prefsValidateForNumeric() ||
-      validateDataLayers() ||
-      validateAxis("row") ||
-      validateAxis("col")
-    );
-
-    function validateDataLayers() {
-      const dataLayers = heatMap.getDataLayers();
-      for (let key in dataLayers) {
-        const errorMsg = prefsValidateBreakPoints("data", key, "layerPrefs");
-        if (errorMsg != null) return errorMsg;
+    /**********************************************************************************
+     * FUNCTION validateAllPreferences: Validate all user changes to the heatmap
+     * properties by checking every tab in turn.
+     **********************************************************************************/
+    function validateAllPreferences() {
+      for (const tab of allTabs) {
+        const errorMsg = tab.validateTab();
+        if (errorMsg) return errorMsg;
       }
       return null;
     }
 
-    function validateAxis(axis) {
-      const covBars = heatMap.getAxisCovariateConfig(axis);
-      for (let [key, config] of Object.entries(covBars)) {
-        if (config.color_map.type == "continuous") {
-          const errorMsg = prefsValidateBreakPoints(axis, key, "classPrefs");
-          if (errorMsg != null) return errorMsg;
-        }
-      }
-      return validateLabelTypeInputs(heatMap, axis);
+    /**********************************************************************************
+     * FUNCTION redrawHeatMap: Redraw the heatmap after it has been updated.
+     **********************************************************************************/
+    function redrawHeatMap() {
+      // Redraw the heat map.
+      UPM.heatMap.initAxisLabels();
+      UPM.heatMap.setUnAppliedChanges(true);
+      SUM.redrawSummaryPanel();
+      DMM.resizeDetailMapCanvases();
+      DET.updateSelections(false); // Do not skip resize: covariate bar changes may require resize
     }
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - prefsValidateInputBoxs: The purpose of this function is to validate
-   * all user text input boxes that require positive numeric values.
-   **********************************************************************************/
-  UPM.prefsValidateForNumeric = function () {
-    const heatMap = MMGR.getHeatMap();
-    var errorMsg = null;
-    var rowClassBars = heatMap.getRowClassificationConfig();
-    for (var key in rowClassBars) {
-      var currentClassBar = rowClassBars[key];
-      var keyrow = key + "_row";
-      var elem = document.getElementById(key + "_row_heightPref");
-      var elemVal = elem.value;
-      var rowBarType = document.getElementById(key + "_row_barTypePref");
-      if (isNaN(elemVal) || parseInt(elemVal) < 0 || elemVal === "") {
-        errorMsg = [
-          "ALL",
-          "classPrefs",
-          "ERROR: Bar heights must be between 0 and 99",
-        ];
-        return errorMsg;
-      }
-      if (rowBarType !== null && rowBarType.value !== "color_plot") {
-        var lowBoundElement = document.getElementById(keyrow + "_lowBoundPref");
-        if (isNaN(lowBoundElement.value)) {
-          errorMsg = [
-            keyrow,
-            "classPrefs",
-            "ERROR: Covariate bar low bound must be numeric",
-          ];
-          return errorMsg;
-        }
-        var highBoundElement = document.getElementById(
-          keyrow + "_highBoundPref",
-        );
-        if (isNaN(highBoundElement.value)) {
-          errorMsg = [
-            keyrow,
-            "classPrefs",
-            "ERROR: Covariate bar high bound must be numeric",
-          ];
-          return errorMsg;
-        }
-        var bgColorElement = document.getElementById(keyrow + "_bgColorPref");
-        var fgColorElement = document.getElementById(keyrow + "_fgColorPref");
-        if (bgColorElement.value === fgColorElement.value) {
-          errorMsg = [
-            keyrow,
-            "classPrefs",
-            "ERROR: Duplicate foreground and background colors found",
-          ];
-          return errorMsg;
-        }
-      }
-    }
-    if (errorMsg === null) {
-      var colClassBars = heatMap.getColClassificationConfig();
-      for (var key in colClassBars) {
-        var keycol = key + "_col";
-        var currentClassBar = colClassBars[key];
-        var elem = document.getElementById(key + "_col_heightPref");
-        var elemVal = elem.value;
-        var colBarType = document.getElementById(key + "_col_barTypePref");
-        if (isNaN(elemVal) || parseInt(elemVal) < 0 || elemVal === "") {
-          errorMsg = [
-            "ALL",
-            "classPrefs",
-            "ERROR: Bar heights must be between 0 and 99",
-          ];
-          return errorMsg;
-        }
-        if (colBarType !== null && colBarType.value !== "color_plot") {
-          var lowBoundElement = document.getElementById(
-            keycol + "_lowBoundPref",
-          );
-          if (isNaN(lowBoundElement.value)) {
-            errorMsg = [
-              keycol,
-              "classPrefs",
-              "ERROR: Covariate bar low bound must be numeric",
-            ];
-            return errorMsg;
-          }
-          var highBoundElement = document.getElementById(
-            keycol + "_highBoundPref",
-          );
-          if (isNaN(highBoundElement.value)) {
-            errorMsg = [
-              keycol,
-              "classPrefs",
-              "ERROR: Covariate bar high bound must be numeric",
-            ];
-            return errorMsg;
-          }
-          var bgColorElement = document.getElementById(keycol + "_bgColorPref");
-          var fgColorElement = document.getElementById(keycol + "_fgColorPref");
-          if (bgColorElement.value === fgColorElement.value) {
-            errorMsg = [
-              keycol,
-              "classPrefs",
-              "ERROR: Duplicate foreground and background colors found",
-            ];
-            return errorMsg;
-          }
-        }
-      }
-    }
-
-    return errorMsg;
-  };
-
-  /**********************************************************************************
-   * FUNCTION - prefsValidateBreakPoints: The purpose of this function is to validate
+   * FUNCTION prefsValidateBreakPoints: The purpose of this function is to validate
    * all user breakpoint and color changes to heatmap data layer properties. When the
    * first error is found, an error  message (string array containing error information)
    * is created and returned to the prefsApply function.
    **********************************************************************************/
   function prefsValidateBreakPoints(colorMapAxis, colorMapName, prefPanel) {
-    const heatMap = MMGR.getHeatMap();
-    var colorMap = heatMap
-      .getColorMapManager()
-      .getColorMap(colorMapAxis, colorMapName);
+    const colorMapMgr = UPM.heatMap.getColorMapManager();
+    const colorMap = colorMapMgr.getColorMap(colorMapAxis, colorMapName);
     var thresholds = colorMap.getThresholds();
-    var colors = colorMap.getColors();
     var charBreak = false;
     var dupeBreak = false;
     var breakOrder = false;
@@ -806,14 +656,15 @@
   }
 
   /**********************************************************************************
-   * FUNCTION - prefsValidateBreakColors: The purpose of this function is to validate
+   * FUNCTION prefsValidateBreakColors: The purpose of this function is to validate
    * all user color changes to heatmap classification and data layer properties. When the
    * first error is found, an error  message (string array containing error information)
    * is created and returned to the prefsApply function.
    **********************************************************************************/
-  UPM.prefsValidateBreakColors = function (colorMapName, type, prefPanel) {
-    const heatMap = MMGR.getHeatMap();
-    var colorMap = heatMap.getColorMapManager().getColorMap(type, colorMapName);
+  // This function isn't being called!!!????
+  function prefsValidateBreakColors(colorMapName, type, prefPanel) {
+    const colorMapMgr = UPM.heatMap.getColorMapManager();
+    const colorMap = colorMapMgr.getColorMap(type, colorMapName);
     var key = colorMapName;
     if (type !== "data") {
       key = key + "_" + type;
@@ -823,7 +674,7 @@
     var dupeColor = false;
     for (var i = 0; i < colors.length; i++) {
       for (var j = 0; j < thresholds.length; j++) {
-        var ce = document.getElementById(key + "_color" + j + "_colorPref");
+        var ce = KAE(key, "color" + j, "colorPref");
         if (i != j) {
           if (colorElement.value === ce.value) {
             dupeColor = true;
@@ -837,69 +688,59 @@
     }
 
     return null;
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - prefsApplyBreaks: The purpose of this function is to apply all
-   * user entered changes to colors and breakpoints.
+   * FUNCTION prefsApplyBreaks: Apply all user entered changes to the colors
+   * and breakpoints of the specified color map.
    **********************************************************************************/
-  UPM.prefsApplyBreaks = function (colorMapName, colorMapAxis) {
-    const heatMap = MMGR.getHeatMap();
-    var colorMap = heatMap
-      .getColorMapManager()
-      .getColorMap(colorMapAxis, colorMapName);
-    var thresholds = colorMap.getThresholds();
-    var colors = colorMap.getColors();
-    var newColors = getNewBreakColors(colorMapAxis, colorMapName);
+  function prefsApplyBreaks(colorMapName, colorMapAxis) {
+    const colorMapMgr = UPM.heatMap.getColorMapManager();
+    const colorMap = colorMapMgr.getColorMap(colorMapAxis, colorMapName);
+    const newColors = getNewBreakColors(colorMapAxis, colorMapName);
     colorMap.setColors(newColors);
-    var key = colorMapName;
     if (colorMap.getType() != "discrete") {
       const newThresholds = getNewBreakThresholds(colorMapAxis, colorMapName);
       colorMap.setThresholds(newThresholds);
     }
-    if (colorMapAxis !== "data") {
-      key += "_" + colorMapAxis;
-    }
-    var missingElement = document.getElementById(key + "_missing_colorPref");
+    const key =
+      colorMapName + (colorMapAxis == "data" ? "" : "_" + colorMapAxis);
+    const missingElement = KAE(key,"missing","colorPref");
     colorMap.setMissingColor(missingElement.value);
-    var colorMapMgr = heatMap.getColorMapManager();
-    colorMapMgr.setColorMap(colorMapName, colorMap, colorMapAxis);
-  };
+    colorMapMgr.setColorMap(colorMapAxis, colorMapName, colorMap);
+  }
 
   /**********************************************************************************
-   * FUNCTION - getNewBreakColors: The purpose of this function is to grab all user
-   * color entries for a given colormap and place them on a string array.  It will
-   * iterate thru the screen elements, pulling the current color entry for each
-   * element, placing it in a new array, and returning that array. This function is
-   * called by the prefsApplyBreaks function.  It is ALSO called from the data layer
-   * addLayerBreak and deleteLayerBreak functions with parameters passed in for
-   * the position to add/delete and the action to be performed (add/delete).
+   * FUNCTION getNewBreakColors: Return an array of colors from the color entries
+   * in the colormap specified by colorMapAxis and colorMapName.  If pos and action
+   * are supplied, it will modify the returned colors by adding or deleting a
+   * color entry.
+   * It iterates thru the screen elements, pulling the current color entry for each
+   * element, placing it in a new array, and returning that array.
+   *
+   * This function is called by the prefsApplyBreaks function.  It is ALSO called from
+   * the data layer modifyDataLayerBreaks function with parameters passed
+   * in for the position to add/delete and the action to be performed (add/delete).
    **********************************************************************************/
   function getNewBreakColors(colorMapAxis, colorMapName, pos, action) {
-    const heatMap = MMGR.getHeatMap();
-    var colorMap = heatMap
-      .getColorMapManager()
-      .getColorMap(colorMapAxis, colorMapName);
-    var thresholds = colorMap.getThresholds();
-    var newColors = [];
-    var key = colorMapName;
-    if (colorMapAxis !== "data") {
-      key = key + "_" + colorMapAxis;
-    }
-    let prevColorElement = document.getElementById(key + "_color0_colorPref");
+    const colorMapMgr = UPM.heatMap.getColorMapManager();
+    const colorMap = colorMapMgr.getColorMap(colorMapAxis, colorMapName);
+    const thresholds = colorMap.getThresholds();
+    const newColors = [];
+    let prevColorElement = getColorPrefElement(colorMapAxis, colorMapName, 0);
     if (pos == 0 && action == "add") {
+      // Insert a color before the first color.
       newColors.push(UTIL.blendTwoColors("#000000", prevColorElement.value));
     }
     if (pos != 0 || action != "delete") {
+      // Copy first color unless it is deleted.
       newColors.push(prevColorElement.value); // color0
     }
     for (let j = 1; j < thresholds.length; j++) {
-      const colorElement = document.getElementById(
-        key + "_color" + j + "_colorPref",
-      );
+      const colorElement = getColorPrefElement(colorMapAxis, colorMapName, j);
       //In case there are now less elements than the thresholds list on Reset.
       if (colorElement !== null) {
-        //If being called from addLayerBreak or deleteLayerBreak
+        //If being called from modifyDataLayerBreaks
         if (typeof pos !== "undefined") {
           if (action === "add") {
             if (j === pos) {
@@ -921,29 +762,26 @@
       prevColorElement = colorElement;
     }
     if (pos == thresholds.length && action == "add") {
+      // Add a new color after the last one.
       newColors.push(UTIL.blendTwoColors("#000000", prevColorElement.value));
     }
 
-    //If this color map is for a row/col class bar AND that bar is a scatter or
+    //If this color map is for an covariate bar AND that bar is a scatter or
     //bar plot (colormap will always be continuous), set the upper colormap color
     //to the foreground color set by the user for the bar/scatter plot. This is
     //default behavior that happens when a map is built but must be managed as
     //users change preferences and bar types.
     if (colorMapAxis !== "data") {
-      var classBar = heatMap.getColClassificationConfig()[colorMapName];
-      if (colorMapAxis === "row") {
-        classBar = heatMap.getRowClassificationConfig()[colorMapName];
-      }
+      const classBar =
+        UPM.heatMap.getAxisCovariateConfig(colorMapAxis)[colorMapName];
       if (classBar.bar_type != "color_plot") {
         newColors[1] = classBar.fg_color;
       }
     } else {
       //Potentially on a data layer reset, there could be more color points than contained in the thresholds object
       //because a user may have deleted a breakpoint and then hit "reset". So we check for up to 50 preferences.
-      for (var k = thresholds.length; k < 50; k++) {
-        var colorElement = document.getElementById(
-          key + "_color" + k + "_colorPref",
-        );
+      for (let k = thresholds.length; k < 50; k++) {
+        const colorElement = getColorPrefElement(colorMapAxis, colorMapName, k);
         if (colorElement !== null) {
           newColors.push(colorElement.value);
         }
@@ -952,24 +790,30 @@
     return newColors;
   }
 
+  // Return the colorPref element at the specified position in the specified
+  // color map (or null if none).
+  function getColorPrefElement(colorMapAxis, colorMapName, position) {
+    let id = colorMapName;
+    if (colorMapAxis != "data") id += "_" + colorMapAxis;
+    return KAE_OPT(id,"color"+position,"colorPref");
+  }
+
   /**********************************************************************************
-   * FUNCTION - getNewBreakThresholds: The purpose of this function is to grab all user
+   * FUNCTION getNewBreakThresholds: The purpose of this function is to grab all user
    * data layer breakpoint entries for a given colormap and place them on a string array.
    * It will  iterate thru the screen elements, pulling the current breakpoint entry for each
    * element, placing it in a new array, and returning that array. This function is
    * called by the prefsApplyBreaks function (only for data layers).  It is ALSO called
-   * from the data layer addLayerBreak and deleteLayerBreak functions with parameters
+   * from the modifyDataLayerBreaks function with parameters
    * passed in for the position to add/delete and the action to be performed (add/delete).
    **********************************************************************************/
   function getNewBreakThresholds(colorMapAxis, colorMapName, pos, action) {
-    const heatMap = MMGR.getHeatMap();
-    var colorMap = heatMap
-      .getColorMapManager()
-      .getColorMap(colorMapAxis, colorMapName);
+    const colorMapMgr = UPM.heatMap.getColorMapManager();
+    const colorMap = colorMapMgr.getColorMap(colorMapAxis, colorMapName);
     let elementIdPrefix = colorMapName;
     if (colorMapAxis != "data") elementIdPrefix += "_" + colorMapAxis;
-    var thresholds = colorMap.getThresholds();
-    var newThresholds = [];
+    const thresholds = colorMap.getThresholds();
+    const newThresholds = [];
     let prevBreakElement = document.getElementById(
       elementIdPrefix + "_breakPt0_breakPref",
     );
@@ -1014,10 +858,8 @@
     }
     //Potentially on a data layer reset, there could be more color points than contained in the thresholds object
     //because a user may have deleted a breakpoint and then hit "reset". So we check for up to 50 preferences.
-    for (var k = thresholds.length; k < 50; k++) {
-      var breakElement = document.getElementById(
-        elementIdPrefix + "_breakPt" + k + "_breakPref",
-      );
+    for (let k = thresholds.length; k < 50; k++) {
+      const breakElement = KAE_OPT(elementIdPrefix,"breakPt" + k,"breakPref");
       if (breakElement !== null) {
         newThresholds.push(breakElement.value);
       }
@@ -1026,41 +868,37 @@
     return newThresholds;
   }
 
-  /*===================================================================================
-  *  DATA LAYER PREFERENCE PROCESSING FUNCTIONS
-  *  
-  *  The following functions are utilized to present heat map data layer 
-  *  configuration options:
-  *  	- setupLayerPrefs
-  *  	- setupLayerBreaks
-  *     - addLayerBreak
-  *     - deleteLayerBreak
-  *     - reloadLayerBreaksColorMap
-  =================================================================================*/
-
   /**********************************************************************************
-   * FUNCTION - setupLayerPrefs: The purpose of this function is to construct a DIV
-   * panel containing all data layer preferences.  A dropdown list containing all
-   * data layers is presented and individual DIVs for each data layer, containing
-   * breakpoints/colors, are added.
+   * CLASS MapLayersTab - a tab for all data layer preferences.
+   *
+   * A dropdown list containing all data layers is presented and individual DIVs
+   * for each data layer, containing breakpoints/colors, are added.
    **********************************************************************************/
-  UPM.setupLayerPrefs = function (e, prefprefs) {
-    const heatMap = MMGR.getHeatMap();
+  function MapLayersTab() {
+    PreferencesTab.call(this, "prefLayer_btn", "layerPrefs");
+  }
+
+  MapLayersTab.prototype.prepareErrorView = function (errorMsg) {
+    // errorMsg[0] : layer name
+    // Show the view of the layer containing the error.
+    showDataLayerPanel(errorMsg[0]);
+  };
+
+  MapLayersTab.prototype.prepareView = function () {
+    // Show the view of the heatMap's current layer.
+    showDataLayerPanel(UPM.heatMap.getCurrentDL());
+  };
+
+  MapLayersTab.prototype.setupTab = function setupLayersTab() {
     const layerprefs = document.getElementById("layerPrefs");
     const prefContents = document.createElement("TABLE");
-    const dataLayers = heatMap.getDataLayers();
+    const dataLayers = UPM.heatMap.getDataLayers();
 
+    // Create the data-layer select dropdown.
     UHM.addBlankRow(prefContents);
     const dlSelect = UTIL.newElement(
-      "SELECT",
-      { name: "dlPref_list", id: "dlPref_list" },
-      null,
-      function (el) {
-        el.onchange = function () {
-          UPM.showLayerBreak();
-        };
-        return el;
-      },
+      "SELECT#dlPref_list",
+      { name: "dlPref_list" },
     );
 
     // Re-order options in datalayer order (which is lost on JSON save)
@@ -1079,84 +917,168 @@
       dlSelect.appendChild(dls[i]);
     }
 
+    // Add the data-layer drop-down.
     UHM.setTableRow(prefContents, ["&nbsp;Data Layer: ", dlSelect]);
     UHM.addBlankRow(prefContents, 2);
     layerprefs.appendChild(prefContents);
     UHM.addBlankRow(prefContents);
 
-    // Loop data layers, setting up a panel div for each layer
+    // Loop over the data layers, creating a panel div for each layer.
     for (let key in dataLayers) {
       const breakprefs = setupLayerBreaks("data", key);
       breakprefs.style.display = "none";
       layerprefs.appendChild(breakprefs);
     }
 
+    // Add a change event handler for this tab.
+    this.tabDiv.addEventListener("change", (ev) => {
+      console.log("DataLayersTab: Change handler", { target: ev.target });
+      for (const target of this.targetGen(ev)) {
+        if (target.id == "dlPref_list") {
+          showDataLayerPanel();
+          break;
+        }
+        if (target.classList.contains('spectrumColor')
+        || target.classList.contains('ngchm-upm-input')) {
+          startChange();
+          break;
+        }
+      }
+    });
+
     return layerprefs;
   };
 
-  /* Generate a color scheme preset element.
-   * It consists of a gradient bar for the colors in the color scheme
-   * followed by a box containing the color for missing values.
-   * When clicked, the layer (based on key, axis, and mapType) breaks
-   * are set to those of the preset.
-   *
-   * A unique id is assigned to each new preset to assist automated tests.
-   */
-  var presetId = 0;
-  function genPreset(key, colors, missingColor, axis, mapType) {
-    ++presetId;
-    const gradient = "linear-gradient(to right, " + colors.join(", ") + ")";
-    const colorsEl = UTIL.newElement(
-      "DIV.presetPalette",
-      { id: "preset" + presetId, style: { background: gradient } },
-      null,
-      function (el) {
-        el.onclick = onclick;
-        return el;
-      },
-    );
-    const missingEl = UTIL.newElement(
-      "DIV.presetPaletteMissingColor",
-      { style: { background: missingColor } },
-      null,
-      function (el) {
-        el.onclick = onclick;
-        return el;
-      },
-    );
-    return UTIL.newElement("DIV", { style: { display: "flex" } }, [
-      colorsEl,
-      missingEl,
-    ]);
-    function onclick(event) {
-      UPM.setupLayerBreaksToPreset(
-        event,
-        key,
-        colors,
-        missingColor,
-        axis,
-        mapType,
-      );
+  // METHOD MapLayersTab.validateTab: validate user preference settings on the
+  // Layers (aka Heat Map Colors) tab.
+  MapLayersTab.prototype.validateTab = function validateLayersTab() {
+    const dataLayers = UPM.heatMap.getDataLayers();
+    for (let key in dataLayers) {
+      const errorMsg = prefsValidateBreakPoints("data", key, "layerPrefs");
+      if (errorMsg != null) return errorMsg;
     }
-  }
+    return null;
+  };
+
+  // METHOD MapLayersTab.resetTabPrefs: reset the Data Layer preference items.
+  //
+  MapLayersTab.prototype.resetTabPrefs = function resetLayersTabPrefs(resetVal) {
+    for (let dl in resetVal.matrix.data_layer) {
+      const layer = resetVal.matrix.data_layer[dl];
+
+      // Reset the color map values.
+      const cm = layer.color_map;
+      const dlTable = KAE("breakPrefsTable",dl);
+      fillBreaksTable(dlTable, "data", dl, cm.thresholds, cm.colors);
+      const missingColor = KAE(dl,"missing","colorPref");
+      missingColor.value = cm.missing;
+
+      // Reset the other data layer values.
+      const gridColor = KAE(dl,"gridColorPref");
+      gridColor.value = layer.grid_color;
+      const gridShow = KAE(dl,"gridPref");
+      gridShow.checked = layer.grid_show == "Y";
+      const selectionColor = KAE(dl,"selectionColorPref");
+      selectionColor.value = layer.selection_color;
+      const gapColor = KAE(dl,"gapColorPref");
+      gapColor.value = layer.cuts_color;
+
+      // Load the preview histogram for the layer.
+      loadColorPreviewDiv(dl);
+    }
+  };
+
+  // METHOD MapLayersTab.applyTabPrefs: Apply all user preference settings on the Layers
+  // (aka Heat Map Colors) tab.
+  //
+  MapLayersTab.prototype.applyTabPrefs = function applyLayersTabPrefs() {
+    // Apply Data Layer Preferences
+    const dataLayers = UPM.heatMap.getDataLayers();
+    for (let key in dataLayers) {
+      // Apply the color map changes.
+      prefsApplyBreaks(key, "data");
+
+      // Apply the other data layer values.
+      const showGrid = KAE(key,"gridPref");
+      const gridColor = KAE(key,"gridColorPref");
+      const selectionColor = KAE(key,"selectionColorPref");
+      const gapColor = KAE(key,"gapColorPref");
+      UPM.heatMap.setLayerGridPrefs(
+        key,
+        showGrid.checked,
+        gridColor.value,
+        selectionColor.value,
+        gapColor.value,
+      );
+
+      // Load the preview histogram for the layer.
+      loadColorPreviewDiv(key);
+    }
+  };
 
   /**********************************************************************************
-   * FUNCTION - setupLayerBreaks: The purpose of this function is to construct a DIV
+   * FUNCTION setupLayerBreaks: Construct a DIV
    * containing a list of breakpoints/colors for a given matrix data layer.
    **********************************************************************************/
   function setupLayerBreaks(colorMapAxis, mapName) {
-    const heatMap = MMGR.getHeatMap();
-    var colorMap = heatMap
-      .getColorMapManager()
-      .getColorMap(colorMapAxis, mapName);
-    var thresholds = colorMap.getThresholds();
-    var colors = colorMap.getColors();
-    var helpprefs = UTIL.newElement("DIV#breakPrefs_" + mapName);
-    var prefContents = document.createElement("TABLE");
-    var dataLayers = heatMap.getDataLayers();
-    var layer = dataLayers[mapName];
-    var gridShow =
-      "<input name='" +
+    const layerPrefs = UTIL.newElement("DIV#breakPrefs_" + mapName);
+    // The layerPrefs division consists of four subparts:
+    // - the layer's continuous color scheme
+    // - a continuous color palette table
+    // - the layer properties table
+    // - the histogram preview.
+
+    const colorMapMgr = UPM.heatMap.getColorMapManager();
+    const colorMap = colorMapMgr.getColorMap(colorMapAxis, mapName);
+
+    const thresholds = colorMap.getThresholds();
+    const colors = colorMap.getColors();
+    const dataLayers = UPM.heatMap.getDataLayers();
+    const layer = dataLayers[mapName];
+
+    const prefTable = TABLE.createTable({ columns: 3 });
+    prefTable.addIndent();
+
+    prefTable.addBlankSpace(2);
+    prefTable.addRow([
+      "Breakpoint",
+      "Color",
+      "&nbsp;",
+    ], { underline: [true,true,false], fontWeight: [ "bold", "bold", "" ] });
+    prefTable.addBlankSpace();
+
+    const breakpts = UTIL.newElement("TABLE#breakPrefsTable_" + mapName);
+    fillBreaksTable(breakpts, "data", mapName, thresholds, colors);
+    prefTable.addRow([breakpts]);
+
+    prefTable.addBlankSpace();
+    prefTable.addRow([
+      "Missing Color:",
+      "<input class='spectrumColor' type='color' name='" +
+        mapName +
+        "_missing_colorPref' id='" +
+        mapName +
+        "_missing_colorPref' value='" +
+        colorMap.getMissingColor() +
+        "'>",
+      "",
+    ]);
+    prefTable.addBlankSpace(2);
+    layerPrefs.appendChild(prefTable.content);
+
+    //-------------------------------------------------------------------------
+    const paletteTable = TABLE.createTable({ columns: 3 });
+    paletteTable.content.style.width = 'fit-content';
+    paletteTable.addIndent();
+    PALETTES.addPredefinedPalettes(paletteTable, mapName, setupLayerBreaksToPreset);
+    layerPrefs.appendChild(paletteTable.content);
+
+    //-------------------------------------------------------------------------
+    const propsTable = TABLE.createTable({ columns: 4 });
+    propsTable.content.style.width = 'fit-content';
+    propsTable.addIndent();
+    let gridShow =
+      "<input class='ngchm-upm-input' name='" +
       mapName +
       "_gridPref' id='" +
       mapName +
@@ -1165,7 +1087,8 @@
       gridShow = gridShow + "checked";
     }
     gridShow = gridShow + " >";
-    var gridColorInput =
+
+    let gridColorInput =
       "<input class='spectrumColor' type='color' name='" +
       mapName +
       "_gridColorPref' id='" +
@@ -1173,7 +1096,8 @@
       "_gridColorPref' value='" +
       layer.grid_color +
       "'>";
-    var selectionColorInput =
+
+    let selectionColorInput =
       "<input class='spectrumColor' type='color' name='" +
       mapName +
       "_selectionColorPref' id='" +
@@ -1181,7 +1105,7 @@
       "_selectionColorPref' value='" +
       layer.selection_color +
       "'>";
-    var gapColorInput =
+    let gapColorInput =
       "<input class='spectrumColor' type='color' name='" +
       mapName +
       "_gapColorPref' id='" +
@@ -1189,74 +1113,28 @@
       "_gapColorPref' value='" +
       layer.cuts_color +
       "'>";
-    UHM.addBlankRow(prefContents, 2);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;<u>Breakpoint</u>",
-      "<u><b>Color</b></u>",
-      "&nbsp;",
-    ]);
-    UHM.setTableRow(prefContents, ["&nbsp;", null, null]);
 
-    const breakpts = UTIL.newElement("TABLE#breakPrefsTable_" + mapName);
-    fillBreaksTable(breakpts, "data", mapName, thresholds, colors);
-    UHM.setTableRow(prefContents, [breakpts], 3);
-    UHM.addBlankRow(prefContents);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;Missing Color:",
-      "<input class='spectrumColor' type='color' name='" +
-        mapName +
-        "_missing_colorPref' id='" +
-        mapName +
-        "_missing_colorPref' value='" +
-        colorMap.getMissingColor() +
-        "'>",
-    ]);
-    UHM.addBlankRow(prefContents, 3);
-    // predefined color schemes put here
-    UHM.setTableRow(
-      prefContents,
-      ["&nbsp;<u>Choose a pre-defined color palette:</u>"],
-      3,
-    );
-    UHM.addBlankRow(prefContents);
-    var rainbow = genPreset(
-      mapName,
-      ["#FF0000", "#FF8000", "#FFFF00", "#00FF00", "#0000FF", "#FF00FF"],
-      "#000000",
-    );
-    var redWhiteBlue = genPreset(
-      mapName,
-      ["#0000FF", "#FFFFFF", "#ff0000"],
-      "#000000",
-    );
-    var redBlackGreen = genPreset(
-      mapName,
-      ["#00FF00", "#000000", "#FF0000"],
-      "#ffffff",
-    );
-    UHM.setTableRow(prefContents, [redWhiteBlue, rainbow, redBlackGreen]);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;Blue Red",
-      "&nbsp;<b>Rainbow</b>",
-      "&nbsp;<b>Green Red</b>",
-    ]);
-    UHM.addBlankRow(prefContents, 3);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;Grid Lines:",
+    propsTable.addBlankSpace(3);
+    propsTable.addRow([
+      "Grid Lines:",
       gridColorInput,
-      "<b>Grid Show:&nbsp;&nbsp;</b>" + gridShow,
-    ]);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;Selection Color:",
+      "Grid Show:",
+      gridShow,
+    ], { fontWeight: [ "bold", "", "bold", "" ] });
+    propsTable.addRow([
+      "Selection Color:",
       selectionColorInput,
-      "<b>Gap Color:&nbsp;&nbsp;</b>" + gapColorInput,
-    ]);
+      "Gap Color:",
+      gapColorInput,
+    ], { fontWeight: [ "bold", "", "bold", "" ] });
+    layerPrefs.appendChild(propsTable.content);
 
-    UHM.addBlankRow(prefContents, 3);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;Color Histogram:",
-      UTIL.newElement(
-        "DIV.buttonGroup",
+    //-------------------------------------------------------------------------
+
+    const header = UTIL.newElement("DIV.histogram-header");
+    header.appendChild(document.createTextNode("Color Histogram:"));
+    const updateButton = UTIL.newElement(
+        "DIV.buttonGroup.histogram-update",
         {},
         UTIL.newElement(
           "BUTTON",
@@ -1264,29 +1142,31 @@
           UTIL.newElement("SPAN.button", {}, "Update"),
           function (el) {
             el.onclick = function () {
-              UHM.loadColorPreviewDiv(mapName);
+              loadColorPreviewDiv(mapName);
             };
             return el;
           },
         ),
-      ),
-    ]);
-    var previewDiv =
-      "<div id='previewWrapper" +
-      mapName +
-      "' style='display:flex; height: 100px; width: 110px;position:relative;' ></div>"; //UHM.loadColorPreviewDiv(mapName,true);
-    UHM.setTableRow(prefContents, [previewDiv]);
-    UHM.addBlankRow(prefContents, 3);
-    helpprefs.style.height = prefContents.rows.length;
-    helpprefs.appendChild(prefContents);
+      );
+
+    const histogram = UTIL.newElement ("DIV.histogram");
+    histogram.appendChild(header);
+    histogram.appendChild(updateButton);
+
+    const previewDiv = UTIL.newElement("DIV.histogram-preview");
+    previewDiv.id = "previewWrapper" + mapName;
+    histogram.appendChild(previewDiv);
+
     setTimeout(
       function (mapName) {
-        UHM.loadColorPreviewDiv(mapName, true);
+        loadColorPreviewDiv(mapName, true);
       },
       100,
       mapName,
     );
-    return helpprefs;
+    layerPrefs.appendChild(histogram);
+
+    return layerPrefs;
   }
 
   function fillBreaksTable(
@@ -1313,7 +1193,8 @@
         function (el) {
           el.onclick = (function (j, layerName) {
             return function () {
-              addLayerBreak(colorMapAxis, j, layerName);
+              startChange();
+              modifyDataLayerBreaks(colorMapAxis, layerName, j, "add");
             };
           })(j, layerName);
           return el;
@@ -1328,7 +1209,7 @@
       var color = colors[j];
       var colorId = elementIdPrefix + "_color" + j;
       var breakPtInput =
-        "&nbsp;&nbsp;<input name='" +
+        "&nbsp;&nbsp;<input class='ngchm-upm-input' name='" +
         threshId +
         "_breakPref' id='" +
         threshId +
@@ -1354,7 +1235,8 @@
           function (el) {
             el.onclick = (function (j, layerName) {
               return function () {
-                deleteLayerBreak(colorMapAxis, j, layerName);
+                startChange();
+                modifyDataLayerBreaks(colorMapAxis, layerName, j, "delete");
               };
             })(j, layerName);
             return el;
@@ -1367,50 +1249,43 @@
   }
 
   /**********************************************************************************
-   * FUNCTION - getTempCM: This function  will create a dummy color map object to be
+   * FUNCTION getTempCM: This function  will create a dummy color map object to be
    * used by loadColorPreviewDiv. If the gear menu has just been opened (firstLoad), the
    * saved values from the color map manager will be used. Otherwise, it will read the
    * values stored in the input boxes, as these values may differ from the ones stored
    * in the color map manager.
    **********************************************************************************/
-  UHM.getTempCM = function (mapName, firstLoad) {
-    var tempCM = { colors: [], missing: "", thresholds: [], type: "linear" };
+  function getTempCM(mapName, firstLoad) {
+    const tempCM = { colors: [], missing: "", thresholds: [], type: "linear" };
     if (firstLoad) {
-      var colorMap = MMGR.getHeatMap()
-        .getColorMapManager()
-        .getColorMap("data", mapName);
+      const colorMapMgr = UPM.heatMap.getColorMapManager();
+      const colorMap = colorMapMgr.getColorMap("data", mapName);
       tempCM.thresholds = colorMap.getThresholds();
       tempCM.colors = colorMap.getColors();
       tempCM.missing = colorMap.getMissingColor();
     } else {
-      var i = 0;
-      var bp = document.getElementById(
-        mapName + "_breakPt" + [i] + "_breakPref",
-      );
-      var color = document.getElementById(
-        mapName + "_color" + [i] + "_colorPref",
-      );
-      while (bp && color) {
+      for (let i = 0; ; i++) {
+        const bp = KAE_OPT(mapName,"breakPt" + i,"breakPref");
+        const color = KAE_OPT(mapName,"color" + i,"colorPref");
+        if (!bp || !color) {
+          // Reached end of breakpoints and/or colors.
+          break;
+        }
         tempCM.colors.push(color.value);
         tempCM.thresholds.push(bp.value);
-        i++;
-        bp = document.getElementById(mapName + "_breakPt" + [i] + "_breakPref");
-        color = document.getElementById(
-          mapName + "_color" + [i] + "_colorPref",
-        );
       }
-      var missing = document.getElementById(mapName + "_missing_colorPref");
+      const missing = KAE(mapName,"missing","colorPref");
       tempCM.missing = missing.value;
     }
     return tempCM;
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - loadColorPreviewDiv: This function will update the color distribution
+   * FUNCTION loadColorPreviewDiv: This function will update the color distribution
    * preview div to the current color palette in the gear panel
    **********************************************************************************/
-  UHM.loadColorPreviewDiv = function (mapName, firstLoad) {
-    var cm = UHM.getTempCM(mapName, firstLoad);
+  function loadColorPreviewDiv(mapName, firstLoad) {
+    var cm = getTempCM(mapName, firstLoad);
     var gradient = "linear-gradient(to right";
     var numBreaks = cm.thresholds.length;
     var highBP = parseFloat(cm.thresholds[numBreaks - 1]);
@@ -1423,15 +1298,13 @@
       gradient += "," + col + " " + pct + "%";
     }
     gradient += ")";
-    var wrapper = document.getElementById("previewWrapper" + mapName);
+    const wrapper = document.getElementById("previewWrapper" + mapName);
 
-    const heatMap = MMGR.getHeatMap();
-
-    heatMap.getSummaryHist(mapName, lowBP, highBP).then((hist) => {
+    UPM.heatMap.getSummaryHist(mapName, lowBP, highBP).then((hist) => {
       var svg =
-        "<svg id='previewSVG" +
+        "<svg class='preview-svg' id='previewSVG" +
         mapName +
-        "' width='110' height='100' style='position:absolute;left:10px;top:20px;'>";
+        "' width='110' height='100'>";
       for (var i = 0; i < hist.bins.length; i++) {
         var rect =
           "<rect x='" +
@@ -1453,548 +1326,524 @@
         "</rect>";
       svg += missingRect;
       svg += "</svg>";
-      var binNums = ""; //"<p class='previewLegend' style='position:absolute;left:0;top:100;font-size:10;'>0</p><p class='previewLegend' style='position:absolute;left:0;top:0;font-size:10;'>"+hist.binMax+"</p>"
-      var boundNums =
-        "<p class='previewLegend' style='position:absolute;left:10px;top:110px;font-size:10px;'>" +
+      const boundNums =
+        "<p class='preview-legend-left'>" +
         lowBP.toFixed(2) +
-        "</p><p class='previewLegend' style='position:absolute;left:90px;top:110px;font-size:10px;'>" +
+        "</p><p class='preview-legend-right'>" +
         highBP.toFixed(2) +
         "</p>";
-
-      var preview =
-        "<div id='previewMainColor" +
+      const mainColor =
+        "<div class='preview-main-color' id='previewMainColor" +
         mapName +
-        "' style='height: 100px; width:100px;background:" +
+        "' style='background:" +
         gradient +
-        ";position:absolute; left: 10px; top: 20px;'></div>" +
-        "<div id='previewMissingColor" +
+        ";'></div>";
+      const missingColor =
+        "<div class='preview-missing-color' id='previewMissingColor" +
         mapName +
-        "'style='height: 100px; width:10px;background:" +
+        "'style='background:" +
         cm.missing +
-        ";position:absolute;left:110px;top:20px;'></div>" +
-        svg +
-        binNums +
-        boundNums;
-      wrapper.innerHTML = preview;
+        ";'></div>";
+      wrapper.innerHTML = mainColor + missingColor + svg + boundNums;
     });
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - setupLayerBreaksToPreset: This function will be executed when the user
+   * FUNCTION setupLayerBreaksToPreset: This function will be executed when the user
    * selects a predefined color scheme. It will fill the first and last breakpoints with the
    * predefined colors and interpolate the breakpoints in between.
    * "preset" is an array of the colors in HEX of the predefined color scheme
    **********************************************************************************/
-  UPM.setupLayerBreaksToPreset = function (
-    e,
-    mapName,
-    preset,
+  function setupLayerBreaksToPreset(
+    key,
+    colors,
     missingColor,
     axis,
     type,
   ) {
-    var elemName = mapName;
-    if (typeof axis != "undefined") {
-      elemName += "_" + axis;
-    }
-    var i = 0; // find number of breakpoints in the
-    while (document.getElementById(elemName + "_color" + ++i + "_colorPref")) {}
-    var lastShown = i - 1;
-    // create dummy colorScheme
-    var thresh = [];
-    const heatMap = MMGR.getHeatMap();
-    if (document.getElementById(elemName + "_breakPt0_breakPref")) {
-      // if the breakpoints are changeable (data layer)...
-      var firstBP = document.getElementById(
-        elemName + "_breakPt0_breakPref",
-      ).value;
-      var lastBP = document.getElementById(
-        elemName + "_breakPt" + lastShown + "_breakPref",
-      ).value;
-      var range = lastBP - firstBP;
-      for (var j = 0; j < preset.length; j++) {
-        thresh[j] = Number(firstBP) + j * (range / (preset.length - 1));
-      }
-      var colorScheme = {
-        missing: missingColor,
-        thresholds: thresh,
-        colors: preset,
-        type: "continuous",
-      };
-      var csTemp = new CMM.ColorMap(heatMap, colorScheme);
+    console.log ("setupLayerBreaksToPreset:", {key, colors, missingColor, axis, type });
+    startChange();
+    const keyaxis = key + (typeof axis == "undefined" ? "" : "_" + axis);
 
-      for (var j = 0; j < i; j++) {
-        var threshId = mapName + "_breakPt" + j;
-        var colorId = mapName + "_color" + j;
-        var breakpoint = document.getElementById(threshId + "_breakPref").value;
-        document.getElementById(colorId + "_colorPref").value =
-          csTemp.getRgbToHex(csTemp.getColor(breakpoint));
+    // Find the number of breakpoints in the color preference.
+    let i = 0;
+    while (KAE_OPT(keyaxis, "color" + ++i, "colorPref")) {}
+    const lastShown = i - 1;
+
+    // create dummy colorScheme
+    const thresh = [];
+    if (KAE_OPT(keyaxis,"breakPt0","breakPref")) {
+      // if the breakpoints are changeable (data layer)...
+      const firstBP = KAE(keyaxis,"breakPt0","breakPref").value;
+      const lastBP = KAE(keyaxis,"breakPt"+lastShown,"breakPref").value;
+      const range = lastBP - firstBP;
+      for (let j = 0; j < colors.length; j++) {
+        thresh[j] = Number(firstBP) + j * (range / (colors.length - 1));
       }
-      document.getElementById(mapName + "_missing_colorPref").value =
+      const colorScheme = {
+        type: "continuous",
+        colors: colors,
+        thresholds: thresh,
+        missing: missingColor,
+      };
+      const csTemp = new CMM.ColorMap(UPM.heatMap, colorScheme);
+
+      for (let j = 0; j < i; j++) {
+        const threshId = "breakPt" + j;
+        const colorId = "color" + j;
+        console.log ("Getting breakpoint value", { elementId: `${keyaxis}_${threshId}_breakPref` });
+        const breakpoint = KAE(keyaxis,threshId,"breakPref").value;
+        KAE(keyaxis,colorId,"colorPref").value = csTemp.getRgbToHex(csTemp.getColor(breakpoint));
+      }
+      console.log ("Getting missing color", { elementId: keyaxis + "_missingColorPref" });
+      KAE(keyaxis,"missing","colorPref").value =
         csTemp.getRgbToHex(csTemp.getColor("Missing"));
     } else {
       // if the breakpoints are not changeable (covariate bar)...
       if (type == "Discrete") {
         // if colors can be mapped directly
-        for (var j = 0; j < i; j++) {
-          var colorId = elemName + "_color" + j;
-          if (j > preset.length) {
-            // in case there are more breakpoints than predef colors, we cycle back
-            document.getElementById(colorId + "_colorPref").value =
-              preset[j % preset.length];
-          } else {
-            document.getElementById(colorId + "_colorPref").value = preset[j];
-          }
+        for (let j = 0; j < i; j++) {
+          // in case there are more breakpoints than predef colors, we cycle back
+          KAE(keyaxis,"color"+j,"colorPref").value = colors[j % colors.length];
         }
-        document.getElementById(elemName + "_missing_colorPref").value =
-          missingColor;
+        KAE(keyaxis,"missing","colorPref").value = missingColor;
       } else {
         // if colors need to be blended
-        var colorMap = heatMap.getColorMapManager().getColorMap(axis, mapName);
-        var thresholds = colorMap.getThresholds();
-        var range = thresholds[thresholds.length - 1] - thresholds[0];
-        for (var j = 0; j < preset.length; j++) {
-          thresh[j] = Number(thresholds[0]) + j * (range / (preset.length - 1));
+        const colorMapMgr = UPM.heatMap.getColorMapManager();
+        const colorMap = colorMapMgr.getColorMap(axis, key);
+        const thresholds = colorMap.getThresholds();
+        const range = thresholds[thresholds.length - 1] - thresholds[0];
+        for (let j = 0; j < colors.length; j++) {
+          thresh[j] = Number(thresholds[0]) + j * (range / (colors.length - 1));
         }
-        var colorScheme = {
-          missing: missingColor,
-          thresholds: thresh,
-          colors: preset,
+        const colorScheme = {
           type: "continuous",
+          colors: colors,
+          thresholds: thresh,
+          missing: missingColor,
         };
-        var csTemp = new CMM.ColorMap(heatMap, colorScheme);
-        for (var j = 0; j < thresholds.length; j++) {
-          var colorId = elemName + "_color" + j;
-          var breakpoint = thresholds[j];
-          document.getElementById(colorId + "_colorPref").value =
+        const csTemp = new CMM.ColorMap(UPM.heatMap, colorScheme);
+        for (let j = 0; j < thresholds.length; j++) {
+          const breakpoint = thresholds[j];
+          KAE(keyaxis,"color"+j,"colorPref").value =
             csTemp.getRgbToHex(csTemp.getColor(breakpoint));
         }
-        document.getElementById(elemName + "_missing_colorPref").value =
+        KAE(keyaxis,"missing","colorPref").value =
           csTemp.getRgbToHex(csTemp.getColor("Missing"));
       }
     }
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - showLayerBreak: The purpose of this function is to show the
-   * appropriate data layer panel based upon the user selection of the
-   * data layer dropdown on the data layer tab of the preferences screen.  This
-   * function is also called when an error is trappped, opening the data layer DIV
-   * that contains the erroneous data entry.
+   * FUNCTION showDataLayerPanel: Show the specified data layer panel.
+   *
+   * If selLayer is specified, set the layer drop down to that value.
+   * Now show the selected layer panel and hide all others.
+   *
    **********************************************************************************/
-  UPM.showLayerBreak = function (selLayer) {
-    var layerBtn = document.getElementById("dlPref_list");
+  function showDataLayerPanel(selLayer) {
+    const layerBtn = document.getElementById("dlPref_list");
+    // Change the selected panel to selLayer if provided.
     if (typeof selLayer != "undefined") {
       layerBtn.value = selLayer;
     }
-    for (var i = 0; i < layerBtn.length; i++) {
-      var layerVal = layerBtn.options[i].value;
-      var layerDiv = document.getElementById("breakPrefs_" + layerVal);
-      var layerSel = layerBtn.options[i].selected;
+    // Show the selected panel. Hide all others.
+    for (let i = 0; i < layerBtn.length; i++) {
+      const layerVal = layerBtn.options[i].value;
+      const layerDiv = KAE("breakPrefs",layerVal);
+      const layerSel = layerBtn.options[i].selected;
       if (layerSel) {
         layerDiv.style.display = "block";
       } else {
         layerDiv.style.display = "none";
       }
     }
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - addLayerBreak: The purpose of this function is to add a breakpoint
-   * row to a data layer colormap. A new row is created using the preceding row as a
-   * template (i.e. breakpt value and color same as row clicked on).
+   * FUNCTION modifyDataLayerBreaks: Add or remove a breakpoint from a data layer
+   * color map.
+   *
+   * - action is either "add" or "delete"
+   * - pos is the index to perform the action.
    **********************************************************************************/
-  function addLayerBreak(colorMapAxis, pos, colorMapName) {
-    //Retrieve colormap for data layer
-    const colorMap = MMGR.getHeatMap()
-      .getColorMapManager()
-      .getColorMap(colorMapAxis, colorMapName);
+  function modifyDataLayerBreaks(colorMapAxis, colorMapName, pos, action) {
+    // Get the modified breaks and colors.
     const newThresholds = getNewBreakThresholds(
       colorMapAxis,
       colorMapName,
       pos,
-      "add",
+      action,
     );
-    const newColors = getNewBreakColors(colorMapAxis, colorMapName, pos, "add");
-    colorMap.setThresholds(newThresholds);
-    colorMap.setColors(newColors);
-    reloadLayerBreaksColorMap(colorMapAxis, colorMapName, colorMap);
-  }
-
-  /**********************************************************************************
-   * FUNCTION - deleteLayerBreak: The purpose of this function is to remove a breakpoint
-   * row from a data layer colormap.
-   **********************************************************************************/
-  function deleteLayerBreak(colorMapAxis, pos, colorMapName) {
-    var colorMap = MMGR.getHeatMap()
-      .getColorMapManager()
-      .getColorMap(colorMapAxis, colorMapName);
-    var thresholds = colorMap.getThresholds();
-    var colors = colorMap.getColors();
-    var newThresholds = getNewBreakThresholds(
+    const newColors = getNewBreakColors(
       colorMapAxis,
       colorMapName,
       pos,
-      "delete",
+      action,
     );
-    var newColors = getNewBreakColors(
-      colorMapAxis,
-      colorMapName,
-      pos,
-      "delete",
-    );
-    //Apply new arrays for thresholds and colors to the datalayer
-    //and reload the colormap.
+    // Change them in the color map.
+    const colorMapMgr = UPM.heatMap.getColorMapManager();
+    const colorMap = colorMapMgr.getColorMap(colorMapAxis, colorMapName);
     colorMap.setThresholds(newThresholds);
     colorMap.setColors(newColors);
-    reloadLayerBreaksColorMap(colorMapAxis, colorMapName, colorMap);
-  }
-
-  /**********************************************************************************
-   * FUNCTION - reloadLayerBreaksColorMap: The purpose of this function is to reload
-   * the colormap for a given data layer.  The add/deleteLayerBreak methods call
-   * this common function.  The layerPrefs DIV is retrieved and the setupLayerBreaks
-   * method is called, passing in the newly edited colormap.
-   **********************************************************************************/
-  function reloadLayerBreaksColorMap(colorMapAxis, colorMapName, colorMap) {
-    const colorMapMgr = MMGR.getHeatMap().getColorMapManager();
-    colorMapMgr.setColorMap(colorMapName, colorMap, colorMapAxis);
-    let breakPrefsId = "breakPrefs_" + colorMapName;
-    if (colorMapAxis != "data") breakPrefsId += "_" + colorMapAxis;
-    let breakPrefs = document.getElementById(breakPrefsId);
-    if (breakPrefs) {
-      breakPrefs.remove();
+    colorMapMgr.setColorMap(colorMapAxis, colorMapName, colorMap);
+    // Remove the old color breaks.
+    const oldBreakPrefs = getDataLayerBreakPrefs(colorMapAxis, colorMapName);
+    if (oldBreakPrefs) {
+      oldBreakPrefs.remove();
     }
+    // Insert a new color break prefs.
     if (colorMapAxis == "data") {
-      breakPrefs = setupLayerBreaks(colorMapAxis, colorMapName);
-      breakPrefs.style.display = "block";
-      document.getElementById("layerPrefs").appendChild(breakPrefs);
+      const newBreakPrefs = setupLayerBreaks(colorMapAxis, colorMapName);
+      newBreakPrefs.style.display = "block";
+      document.getElementById("layerPrefs").appendChild(newBreakPrefs);
     } else {
       setupCovariateBreaks(colorMapAxis, colorMapName);
     }
   }
 
-  /*===================================================================================
- *  COVARIATE CLASSIFICATION PREFERENCE PROCESSING FUNCTIONS
- *  
- *  The following functions are utilized to present heat map covariate classfication
- *  bar configuration options:
- *  	- setupClassPrefs
- *  	- setupClassBreaks
- *  	- setupAllClassesPrefs
- *      - showAllBars
- *      - setShowAll
- =================================================================================*/
+  // Return the break prefs element for the specified colorMapAxis and colorMapName.
+  function getDataLayerBreakPrefs(colorMapAxis, colorMapName) {
+    let breakPrefsId = "breakPrefs_" + colorMapName;
+    if (colorMapAxis != "data") breakPrefsId += "_" + colorMapAxis;
+    return document.getElementById(breakPrefsId);
+  }
+
+  // ===================================================================================
+  // COVARIATE PREFERENCE PROCESSING FUNCTIONS
+  //
+  // CLASS CovariatesPrefsTab - Tab for Showing Covariate Preferences.
+  // - Inherits from class PreferencesTab.
+  //
+  function CovariatesPrefsTab() {
+    PreferencesTab.call(this, "prefClass_btn", "classPrefs");
+  }
+
+  // PROPERTY CovariatesPrefsTab.nextNumber - return a unique value on every access.
+  //
+  {
+    let nextNumber = 0;
+    Object.defineProperty(CovariatesPrefsTab.prototype, "nextNumber", {
+      get: () => nextNumber++,
+    });
+  }
 
   /**********************************************************************************
-   * FUNCTION - setupClassPrefs: The purpose of this function is to construct a DIV
-   * panel containing all covariate bar preferences.  A dropdown list containing all
-   * covariate classification bars is presented and individual DIVs for each data layer,
-   * containing  breakpoints/colors, are added. Additionally, a "front panel" DIV is
-   * created for "ALL" classification bars that contains preferences that are global
-   * to all of the individual bars.
+   * METHOD - CovariatesPrefsTab.setupTab: Populates the covariates preferences tab.
+   *
+   * The covariates tab consists of a filter for subsetting the list of available
+   * covariates.
+   *
+   * Below that is a "covariate dropdown" containing:
+   * - An entry for showing a summary table of all covariates.
+   * - Entries for creating new row or column covariates.
+   * - An entry for each covariate bar that passes the filter.
+   *
+   * After the covariate dropdown there are:
+   * - a "covariate summary" DIV for "ALL" classification bars that contains preferences
+   *   that are global to all of the individual bars.
+   * - individual DIVs for every covariate bar containing detailed preferences for the
+   *   bar concerned.
+   * Exactly one of these DIVs is visible at any time. Which one depends on the
+   * value of the covariate dropdown.
+   *
    **********************************************************************************/
-  UPM.setupClassPrefs = function (e, prefprefs) {
-    const heatMap = MMGR.getHeatMap();
-    var rowClassBars = heatMap.getRowClassificationConfig();
-    var rowClassBarsOrder = heatMap.getRowClassificationOrder();
-    var colClassBars = heatMap.getColClassificationConfig();
-    var colClassBarsOrder = heatMap.getColClassificationOrder();
-    const classprefs = document.getElementById("classPrefs");
-    var prefContents = document.createElement("TABLE");
-    UHM.addBlankRow(prefContents);
-    if (UPM.hasClasses) {
-      var filterInput = "<input name='all_searchPref' id='all_searchPref'>";
-      const filterButton = UTIL.newElement(
-        "BUTTON#all_searchPref_btn.text-button",
-        {
-          align: "top",
-        },
-        [UTIL.newElement("SPAN.button", {}, "Filter Covariates")],
-        function (el) {
-          el.onclick = function () {
-            UPM.filterClassPrefs(true);
-          };
-          return el;
-        },
-      );
-      UHM.setTableRow(prefContents, [filterInput, filterButton], 4, "right");
-      UHM.addBlankRow(prefContents, 2);
-      var classSelect = UTIL.newElement(
-        "SELECT#classPref_list",
-        { name: "classPref_list" },
-        null,
-        function (el) {
-          el.onchange = function () {
-            UPM.showClassBreak();
-          };
-          return el;
-        },
-      );
-      UHM.setTableRow(prefContents, ["&nbsp;Covariate Bar: ", classSelect]);
-      UHM.addBlankRow(prefContents);
-      classprefs.appendChild(prefContents);
-      var i = 0;
-      for (var i = 0; i < rowClassBarsOrder.length; i++) {
-        var key = rowClassBarsOrder[i];
-        var currentClassBar = rowClassBars[key];
-        if (UPM.filterShow(key)) {
-          var breakprefs = UPM.setupClassBreaks(e, key, "row", currentClassBar);
-          breakprefs.style.display = "none";
-          //breakprefs.style.width = 300;
-          classprefs.appendChild(breakprefs);
-        }
+  CovariatesPrefsTab.prototype.setupTab = function setupCovariatesTab() {
+    const prefsTable = TABLE.createTable({ columns: 3 });
+
+    this.tabDiv.appendChild(prefsTable.content);
+    prefsTable.addBlankSpace();
+
+    // Add the covariate filter input.
+    const filterInput = "<input name='all_searchPref' id='all_searchPref'>";
+    const filterButton = UTIL.newElement(
+      "BUTTON#all_searchPref_btn.text-button",
+      {
+        align: "top",
+      },
+      [UTIL.newElement("SPAN.button", {}, "Filter Covariates")],
+    );
+    prefsTable.addRow([filterInput, filterButton], {
+      colSpan: [2, 1],
+      align: ["right", "left"],
+    });
+    prefsTable.addBlankSpace(2);
+
+    // Add the covariate selection dropdown.
+    const classSelect = UTIL.newElement("SELECT#classPref_list", {
+      name: "classPref_list",
+    });
+    prefsTable.addRow(["Covariate Bar: ", classSelect]);
+    prefsTable.addBlankSpace();
+
+    // Add a hidden DIV for every covariate.
+    // The DIV will be displayed if the user selects the covariate from the
+    // covariate selection dropdown.
+    const covariates = {
+      row: UPM.heatMap.getRowClassificationConfig(),
+      col: UPM.heatMap.getColClassificationConfig(),
+    };
+    this.hasClasses = false;
+    for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+      this.hasClasses = true;
+      if (this.filterShow(key)) {
+        const breakprefs = setupClassBreaks(key, axis, covariates[axis][key]);
+        breakprefs.style.display = "none";
+        this.tabDiv.appendChild(breakprefs);
       }
-      for (var i = 0; i < colClassBarsOrder.length; i++) {
-        var key = colClassBarsOrder[i];
-        var currentClassBar = colClassBars[key];
-        if (UPM.filterShow(key)) {
-          var breakprefs = UPM.setupClassBreaks(e, key, "col", currentClassBar);
-          breakprefs.style.display = "none";
-          //breakprefs.style.width = 300;
-          classprefs.appendChild(breakprefs);
-        }
-      }
-      // Append a DIV panel for all of the covariate class bars
-      var allPrefs = UPM.setupAllClassesPrefs();
-      allPrefs.style.display = "block";
-      classprefs.appendChild(allPrefs);
-    } else {
-      UHM.setTableRow(prefContents, [
-        "This Heat Map contains no covariate bars",
-      ]);
-      classprefs.appendChild(prefContents);
     }
 
-    return classprefs;
+    // Append a DIV panel for all of the covariate bars.
+    // The DIV will be displayed if the user selects "ALL" from the
+    // covariate selection dropdown.
+    const allPrefs = this.setupAllClassesPrefs();
+    allPrefs.style.display = this.hasClasses ? "block" : "none";
+    this.tabDiv.appendChild(allPrefs);
+
+    this.emptyNotice = null;
+    if (!this.hasClasses) {
+      this.emptyNotice = prefsTable.addRow([
+        "This Heat Map contains no covariate bars",
+      ]);
+    }
+
+    this.addClassPrefOptions();
+
+    // Add a click handler for the entire tab.
+    this.tabDiv.addEventListener("click", (ev) => {
+      console.log("CovariatesPrefsTab: Click handler", { target: ev.target });
+      for (const target of this.targetGen(ev)) {
+        if (target.id == "all_searchPref_btn") {
+          // The user clicked on the filter covariates button.
+          this.filterClassPrefs();
+          return;
+        }
+      }
+    });
+    // Add a change handler for the entire tab.
+    this.tabDiv.addEventListener("change", (ev) => {
+      console.log("CovariatesPrefsTab: Change handler", { target: ev.target });
+      for (const target of this.targetGen(ev)) {
+        if (target.classList.contains("ngchm-upm-show-covariate")) {
+          // A "Show" checkbox on a covariate row changed.
+          startChange();
+          this.setShowAll();
+          break;
+        } else if (target.id == "classPref_list") {
+          // A new selection was made on the covariate bar dropdown.
+          // Change view to new selection.
+          this.showClassBreak();
+          break;
+        } else if (target.classList.contains('spectrumColor')) {
+          startChange();
+          break;
+        }
+      }
+    });
+    return this.tabDiv;
   };
 
   /**********************************************************************************
-   * FUNCTION - setupAllClassesPrefs: The purpose of this function is to construct a DIV
+   * FUNCTION setupAllClassesPrefs: The purpose of this function is to construct a DIV
    * containing a list of all covariate bars with informational data and user preferences
    * that are common to all bars (show/hide and size).
    **********************************************************************************/
-  UPM.setupAllClassesPrefs = function () {
-    const heatMap = MMGR.getHeatMap();
-    var allprefs = UTIL.newElement("DIV#breakPrefs_ALL");
-    var prefContents = document.createElement("TABLE");
-    prefContents.id = "tableAllClasses";
-    UHM.addBlankRow(prefContents);
-    var rowClassBars = heatMap.getRowClassificationConfig();
-    var rowClassBarsOrder = heatMap.getRowClassificationOrder();
-    var colClassBars = heatMap.getColClassificationConfig();
-    var colClassBarsOrder = heatMap.getColClassificationOrder();
-    const buttons = UTIL.newElement("DIV.icon_group", {}, [
-      UTIL.newSvgButton(
-        "icon-minus",
-        {
-          dataset: {
-            tooltip: "Decrease the size of all selected covariate bars by one",
-          },
-        },
-        function (el) {
-          el.onclick = function () {
-            UPM.decrementAllHeights();
-          };
-          return el;
-        },
-      ),
-      UTIL.newSvgButton(
-        "icon-plus",
-        {
-          dataset: {
-            tooltip: "Increase the size of all selected covariate bars by one",
-          },
-        },
-        function (el) {
-          el.onclick = function () {
-            UPM.incrementAllHeights();
-          };
-          return el;
-        },
-      ),
-    ]);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;&nbsp;&nbsp;",
-      "&nbsp;&nbsp;&nbsp;",
-      "<b>Adjust All Heights: </b>",
-      buttons,
-    ]);
-    const showHeader = UTIL.newFragment([
-      UTIL.newElement(
-        "INPUT#all_showPref",
-        {
-          name: "all_showPref",
-          type: "checkbox",
-        },
-        null,
-        function (el) {
-          el.onchange = function () {
-            UPM.showAllBars();
-          };
-          return el;
-        },
-      ),
-      UTIL.newElement("B", {}, UTIL.newElement("U", {}, "Show")),
-    ]);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;<u>" + "Covariate" + "</u>",
-      "<b><u>" + "Position" + "</u></b>",
-      showHeader,
-      "<b><u>" + "Height" + "</u></b>",
-    ]);
-    var checkState = true;
-    for (var i = 0; i < rowClassBarsOrder.length; i++) {
-      var key = rowClassBarsOrder[i];
-      var currentClassBar = rowClassBars[key];
-      var keyrow = key + "_row";
-      if (UPM.filterShow(key)) {
-        const showPref = keyrow + "_showPref";
-        const colShow = UTIL.newElement(
-          "INPUT",
+  CovariatesPrefsTab.prototype.setupAllClassesPrefs =
+    function setupAllClassesPrefs() {
+      const allprefs = UTIL.newElement("DIV#breakPrefs_ALL");
+      const prefContents = UTIL.newElement("TABLE#tableAllClasses");
+
+      UHM.addBlankRow(prefContents);
+      const thisTab = this;
+
+      // Create a pair of buttons for adjusting the size of all covariates.
+      const buttons = UTIL.newElement("DIV.icon_group", {}, [
+        UTIL.newSvgButton(
+          "icon-minus",
           {
-            id: showPref,
-            name: showPref,
+            dataset: {
+              tooltip:
+                "Decrease the size of all selected covariate bars by one",
+            },
+          },
+          function (el) {
+            el.onclick = function () {
+              startChange();
+              decrementAllHeights();
+            };
+            return el;
+          },
+        ),
+        UTIL.newSvgButton(
+          "icon-plus",
+          {
+            dataset: {
+              tooltip:
+                "Increase the size of all selected covariate bars by one",
+            },
+          },
+          function (el) {
+            el.onclick = function () {
+              startChange();
+              incrementAllHeights();
+            };
+            return el;
+          },
+        ),
+      ]);
+      // Add the pair of size adjusting buttons to the table.
+      UHM.setTableRow(prefContents, [
+        "&nbsp;&nbsp;&nbsp;",
+        "&nbsp;&nbsp;&nbsp;",
+        "<b>Adjust All Heights: </b>",
+        buttons,
+      ]);
+      // Create the header for the "Show" column.
+      // Includes the "all_showPref" checkbox.
+      const showHeader = UTIL.newFragment([
+        UTIL.newElement(
+          "INPUT#all_showPref",
+          {
+            name: "all_showPref",
             type: "checkbox",
           },
           null,
           function (el) {
             el.onchange = function () {
-              UPM.setShowAll();
+              startChange();
+              thisTab.showAllBars();
             };
-            if (currentClassBar.show == "Y") {
-              el.checked = true;
-            }
             return el;
           },
-        );
-        const heightPref = keyrow + "_heightPref";
-        const colHeight = UTIL.newElement("INPUT", {
-          id: heightPref,
-          name: heightPref,
-          maxlength: 2,
-          size: 2,
-          value: currentClassBar.height,
-        });
-
-        var displayName = key;
-        if (key.length > 20) {
-          displayName = key.substring(0, 17) + "...";
+        ),
+        UTIL.newElement("B", {}, UTIL.newElement("U", {}, "Show")),
+      ]);
+      // Add the header row to the table.
+      UHM.setTableRow(prefContents, [
+        "&nbsp;<u>" + "Covariate" + "</u>",
+        "<b><u>" + "Position" + "</u></b>",
+        showHeader,
+        "<b><u>" + "Height" + "</u></b>",
+      ]);
+      // Add a row to the table of all covariates that pass the filter.
+      const covariates = {
+        row: UPM.heatMap.getRowClassificationConfig(),
+        col: UPM.heatMap.getColClassificationConfig(),
+      };
+      for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+        if (this.filterShow(key)) {
+          this.addCovariateRow(prefContents, key, axis, covariates[axis][key]);
         }
-        UHM.setTableRow(prefContents, [
-          "&nbsp;&nbsp;" + displayName,
-          "Row",
-          colShow,
-          colHeight,
-        ]);
       }
-    }
-    for (var i = 0; i < colClassBarsOrder.length; i++) {
-      var key = colClassBarsOrder[i];
-      var currentClassBar = colClassBars[key];
-      var keycol = key + "_col";
-      if (UPM.filterShow(key)) {
-        const showPref = keycol + "_showPref";
-        const colShow = UTIL.newElement(
-          "INPUT",
-          {
-            id: showPref,
-            name: showPref,
-            type: "checkbox",
-          },
-          null,
-          function (el) {
-            el.onchange = function () {
-              UPM.setShowAll();
-            };
-            if (currentClassBar.show == "Y") {
-              el.checked = true;
-            }
-            return el;
-          },
-        );
-        const heightPref = keycol + "_heightPref";
-        const colHeight = UTIL.newElement("INPUT", {
-          id: heightPref,
-          name: heightPref,
-          maxlength: 2,
-          size: 2,
-          value: currentClassBar.height,
-        });
+      allprefs.appendChild(prefContents);
+      return allprefs;
+    };
 
-        var displayName = key;
-        if (key.length > 20) {
-          displayName = key.substring(0, 17) + "...";
+  CovariatesPrefsTab.prototype.addCovariateRow = function addCovariateRow(
+    prefContents,
+    key,
+    axis,
+    currentClassBar,
+  ) {
+    const keyaxis = key + "_" + axis;
+    const showPref = keyaxis + "_showPref";
+    const colShow = UTIL.newElement(
+      "INPUT.ngchm-upm-show-covariate",
+      {
+        id: showPref,
+        name: showPref,
+        type: "checkbox",
+      },
+      null,
+      function (el) {
+        if (currentClassBar.show == "Y") {
+          el.checked = true;
         }
-        UHM.setTableRow(prefContents, [
-          "&nbsp;&nbsp;" + displayName,
-          "Col",
-          colShow,
-          colHeight,
-        ]);
-      }
-    }
-    allprefs.appendChild(prefContents);
+        return el;
+      },
+    );
+    const heightPref = keyaxis + "_heightPref";
+    const colHeight = UTIL.newElement("INPUT", {
+      id: heightPref,
+      name: heightPref,
+      maxlength: 2,
+      size: 2,
+      value: currentClassBar.height,
+    });
 
-    return allprefs;
+    var displayName = key;
+    if (key.length > 20) {
+      displayName = key.substring(0, 17) + "...";
+    }
+    const tr = UHM.setTableRow(prefContents, [
+      "&nbsp;&nbsp;" + displayName,
+      UTIL.toTitleCase(axis),
+      colShow,
+      colHeight,
+    ]);
+    tr.dataset.key = key;
+    tr.dataset.axis = axis;
   };
 
   /**********************************************************************************
-   * FUNCTION - setupClassBreaks: The purpose of this function is to construct a DIV
-   * containing a set informational data and a list of categories/colors for a given
-   * covariate classfication bar.
+   * FUNCTION setupClassBreaks: Construct a covariatePrefPanel DIV that contains
+   * information and preferences for a specific covariate (identified by key and axis).
    **********************************************************************************/
-  UPM.setupClassBreaks = function (e, key, barType, classBar) {
-    //must add barType to key when adding objects to DOM
-    var keyRC = key + "_" + barType;
-    var colorMap = MMGR.getHeatMap()
-      .getColorMapManager()
-      .getColorMap(barType, key);
+  function setupClassBreaks(key, axis, classBar) {
+    // Must add axis to key when adding objects to DOM
+    const keyaxis = key + "_" + axis;
+    const colorMapMgr = UPM.heatMap.getColorMapManager();
+    const colorMap = colorMapMgr.getColorMap(axis, key);
     var thresholds = colorMap.getThresholds();
     var colors = colorMap.getColors();
-    var helpprefs = UTIL.newElement("DIV");
-    helpprefs.id = "breakPrefs_" + keyRC;
 
-    var prefContents = document.createElement("TABLE");
+    // Create the covariatePrefPanel.
+    const covariatePrefPanel = UTIL.newElement("DIV");
+    covariatePrefPanel.id = "breakPrefs_" + keyaxis;
+
+    const prefTable = TABLE.createTable({ columns: 3 });
+    const prefContents = prefTable.content;
     UHM.addBlankRow(prefContents);
-    var pos = UTIL.toTitleCase(barType);
+
+    var pos = UTIL.toTitleCase(axis);
     var typ = UTIL.toTitleCase(colorMap.getType());
-    var barPlot = UTIL.toTitleCase(classBar.bar_type.replace("_", " "));
+    const barPlot = UTIL.toTitleCase(classBar.bar_type.replace("_", " "));
     UHM.setTableRow(prefContents, [
-      "&nbsp;Bar Position: ",
+      "&nbsp;Axis: ",
       "<b>" + pos + "</b>",
     ]);
-    UHM.setTableRow(prefContents, ["&nbsp;Color Type: ", "<b>" + typ + "</b>"]);
-    UHM.addBlankRow(prefContents, 3);
+
+    UHM.setTableRow(prefContents, ["&nbsp;Covariate Type: ", "<b>" + typ + "</b>"]);
+    UHM.addBlankRow(prefContents, 2);
     var bgColorInput =
       "<input class='spectrumColor' type='color' name='" +
-      keyRC +
+      keyaxis +
       "_bgColorPref' id='" +
-      keyRC +
+      keyaxis +
       "_bgColorPref' value='" +
       classBar.bg_color +
       "'>";
     var fgColorInput =
       "<input class='spectrumColor' type='color' name='" +
-      keyRC +
+      keyaxis +
       "_fgColorPref' id='" +
-      keyRC +
+      keyaxis +
       "_fgColorPref' value='" +
       classBar.fg_color +
       "'>";
     var lowBound =
       "<input name='" +
-      keyRC +
+      keyaxis +
       "_lowBoundPref' id='" +
-      keyRC +
+      keyaxis +
       "_lowBoundPref' value='" +
       classBar.low_bound +
       "' maxlength='10' size='8'>&emsp;";
     var highBound =
       "<input name='" +
-      keyRC +
+      keyaxis +
       "_highBoundPref' id='" +
-      keyRC +
+      keyaxis +
       "_highBoundPref' value='" +
       classBar.high_bound +
       "' maxlength='10' size='8'>&emsp;";
@@ -2004,7 +1853,7 @@
         "<b>" + barPlot + "</b>",
       ]);
     } else {
-      const typeOptionsId = keyRC + "_barTypePref";
+      const typeOptionsId = KAID(key,axis,"barTypePref");
       const typeOptionsSelect = UTIL.newElement(
         "SELECT",
         {
@@ -2018,8 +1867,10 @@
         ],
         function (el) {
           el.onchange = function () {
-            UPM.showPlotTypeProperties(keyRC);
+            startChange();
+            showPlotTypeProperties(key, axis);
           };
+          el.value = "color_plot";
           return el;
         },
       );
@@ -2031,8 +1882,9 @@
 
     UHM.addBlankRow(prefContents);
     var helpprefsCB = UTIL.newElement("DIV");
-    helpprefsCB.id = keyRC + "_breakPrefsCB";
-    var prefContentsCB = document.createElement("TABLE");
+    helpprefsCB.id = keyaxis + "_breakPrefsCB";
+    const prefTableCB = TABLE.createTable({ columns: 3 });
+    const prefContentsCB = prefTableCB.content;
     if (typ === "Discrete") {
       UHM.setTableRow(prefContentsCB, [
         "&nbsp;<u>Category</u>",
@@ -2041,8 +1893,8 @@
       for (var j = 0; j < thresholds.length; j++) {
         var threshold = thresholds[j];
         var color = colors[j];
-        var threshId = keyRC + "_breakPt" + j;
-        var colorId = keyRC + "_color" + j;
+        var threshId = keyaxis + "_breakPt" + j;
+        var colorId = keyaxis + "_color" + j;
         var colorInput =
           "<input class='spectrumColor' type='color' name='" +
           colorId +
@@ -2061,142 +1913,30 @@
         "&nbsp;<u>Breakpoint</u>",
         "<b><u>" + "Color" + "</b></u>",
       ]);
+      UHM.addBlankRow(prefContentsCB);
       const colorScheme = document.createElement("TABLE");
-      fillBreaksTable(colorScheme, barType, key, thresholds, colors);
+      fillBreaksTable(colorScheme, axis, key, thresholds, colors);
       UHM.setTableRow(prefContentsCB, [colorScheme], 3);
     }
     UHM.addBlankRow(prefContentsCB);
     UHM.setTableRow(prefContentsCB, [
       "&nbsp;Missing Color:",
       "<input class='spectrumColor' type='color' name='" +
-        keyRC +
+        keyaxis +
         "_missing_colorPref' id='" +
-        keyRC +
+        keyaxis +
         "_missing_colorPref' value='" +
         colorMap.getMissingColor() +
         "'>",
     ]);
-    UHM.addBlankRow(prefContentsCB, 3);
-    UHM.setTableRow(
-      prefContentsCB,
-      ["&nbsp;<u>Choose a pre-defined color palette:</u>"],
-      3,
-    );
-    UHM.addBlankRow(prefContentsCB);
-    if (typ == "Discrete") {
-      var scheme1 = genPreset(
-        key,
-        [
-          "#1f77b4",
-          "#ff7f0e",
-          "#2ca02c",
-          "#d62728",
-          "#9467bd",
-          "#8c564b",
-          "#e377c2",
-          "#7f7f7f",
-          "#bcbd22",
-          "#17becf",
-        ],
-        "#ffffff",
-        barType,
-        typ,
-      );
-      var scheme2 = genPreset(
-        key,
-        [
-          "#1f77b4",
-          "#aec7e8",
-          "#ff7f0e",
-          "#ffbb78",
-          "#2ca02c",
-          "#98df8a",
-          "#d62728",
-          "#ff9896",
-          "#9467bd",
-          "#c5b0d5",
-          "#8c564b",
-          "#c49c94",
-          "#e377c2",
-          "#f7b6d2",
-          "#7f7f7f",
-          "#c7c7c7",
-          "#bcbd22",
-          "#dbdb8d",
-          "#17becf",
-          "#9edae5",
-        ],
-        "#ffffff",
-        barType,
-        typ,
-      );
-      var scheme3 = genPreset(
-        key,
-        [
-          "#393b79",
-          "#637939",
-          "#8c6d31",
-          "#843c39",
-          "#7b4173",
-          "#5254a3",
-          "#8ca252",
-          "#bd9e39",
-          "#ad494a",
-          "#a55194",
-          "#6b6ecf",
-          "#b5cf6b",
-          "#e7ba52",
-          "#d6616b",
-          "#ce6dbd",
-          "#9c9ede",
-          "#cedb9c",
-          "#e7cb94",
-          "#e7969c",
-          "#de9ed6",
-        ],
-        "#ffffff",
-        barType,
-        typ,
-      );
-      UHM.setTableRow(prefContentsCB, [scheme1, scheme2, scheme3]);
-      UHM.setTableRow(prefContentsCB, [
-        "&nbsp;Palette1",
-        "&nbsp;<b>Palette2</b>",
-        "&nbsp;<b>Palette3</b>",
-      ]);
-    } else {
-      var rainbow = genPreset(
-        key,
-        ["#FF0000", "#FF8000", "#FFFF00", "#00FF00", "#0000FF", "#FF00FF"],
-        "#000000",
-        barType,
-        typ,
-      );
-      var greyscale = genPreset(
-        key,
-        ["#FFFFFF", "#000000"],
-        "#FF0000",
-        barType,
-        typ,
-      );
-      var redBlackGreen = genPreset(
-        key,
-        ["#00FF00", "#000000", "#FF0000"],
-        "#ffffff",
-        barType,
-        typ,
-      );
-      UHM.setTableRow(prefContentsCB, [greyscale, rainbow, redBlackGreen]);
-      UHM.setTableRow(prefContentsCB, [
-        "&nbsp;Greyscale",
-        "&nbsp;<b>Rainbow</b>",
-        "&nbsp;<b>Green Red</b>",
-      ]);
-    }
+
+    prefTableCB.addBlankSpace(3);
+    PALETTES.addPredefinedPalettes(prefTableCB, key, setupLayerBreaksToPreset, axis, typ);
+
     helpprefsCB.style.height = prefContentsCB.rows.length;
     helpprefsCB.appendChild(prefContentsCB);
     var helpprefsBB = UTIL.newElement("DIV");
-    helpprefsBB.id = keyRC + "_breakPrefsBB";
+    helpprefsBB.id = keyaxis + "_breakPrefsBB";
     var prefContentsBB = document.createElement("TABLE");
     UHM.setTableRow(prefContentsBB, ["&nbsp;&nbsp;Lower Bound:", lowBound]);
     UHM.setTableRow(prefContentsBB, ["&nbsp;&nbsp;Upper Bound:", highBound]);
@@ -2210,9 +1950,10 @@
     ]);
     UHM.addBlankRow(prefContentsBB);
     helpprefsBB.appendChild(prefContentsBB);
-    helpprefs.appendChild(prefContents);
-    helpprefs.appendChild(helpprefsCB);
-    helpprefs.appendChild(helpprefsBB);
+
+    covariatePrefPanel.appendChild(prefContents);
+    covariatePrefPanel.appendChild(helpprefsCB);
+    covariatePrefPanel.appendChild(helpprefsBB);
     if (classBar.bar_type === "color_plot") {
       helpprefsBB.style.display = "none";
       helpprefsCB.style.display = "block";
@@ -2220,13 +1961,12 @@
       helpprefsCB.style.display = "none";
       helpprefsBB.style.display = "block";
     }
-    return helpprefs;
-  };
+    return covariatePrefPanel;
+  }
 
   function setupCovariateBreaks(colorMapAxis, covariateName) {
-    const bars = NgChm.MMGR.getHeatMap().getAxisCovariateConfig(colorMapAxis);
-    const breakPrefs = UPM.setupClassBreaks(
-      {},
+    const bars = UPM.heatMap.getAxisCovariateConfig(colorMapAxis);
+    const breakPrefs = setupClassBreaks(
       covariateName,
       colorMapAxis,
       bars[covariateName],
@@ -2236,149 +1976,129 @@
     classPrefs.append(breakPrefs);
   }
 
-  UPM.showPlotTypeProperties = function (keyRC) {
-    var barTypeSel = document.getElementById(keyRC + "_barTypePref");
-    var barTypeVal = barTypeSel.value;
-    var bbDiv = document.getElementById(keyRC + "_breakPrefsBB");
-    var cbDiv = document.getElementById(keyRC + "_breakPrefsCB");
-    if (barTypeVal === "color_plot") {
+  // Show the color plot options or the bar/scatter plot options, depending
+  // on the value of the barType preference.
+  function showPlotTypeProperties(key, axis) {
+    const bbDiv = KAE(key,axis,"breakPrefsBB"); // Color plot options.
+    const cbDiv = KAE(key,axis,"breakPrefsCB"); // Bar and scatter plot options.
+    if (KAE(key,axis,"barTypePref").value === "color_plot") {
       bbDiv.style.display = "none";
       cbDiv.style.display = "block";
     } else {
       cbDiv.style.display = "none";
       bbDiv.style.display = "block";
     }
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - showAllBars: The purpose of this function is to set the condition of
-   * the "show" checkbox for all covariate bars on the covariate bars tab of the user
-   * preferences dialog. These checkboxes are located on the DIV that is visible when
-   * the ALL entry of the covariate dropdown is selected. Whenever a  user checks the
-   * show all box, all other boxes are checked.
+   * METHOD CovariatesPrefsTab.showAllBars: Set the "Show" state of all filtered
+   * covariate bars on the covariate bars tab of the user preferences dialog to
+   * equal that of the "Show" checkbox in the table header.
+   *
+   * This method is called whenever the user changes the state of the "Show" checkbox
+   * in the table header.
+   *
+   * These checkboxes are located on the DIV that is visible when the ALL entry of the
+   * covariate dropdown is selected.
+   *
    **********************************************************************************/
-  UPM.showAllBars = function () {
-    const heatMap = MMGR.getHeatMap();
-    var showAllBox = document.getElementById("all_showPref");
-    var checkState = false;
-    if (showAllBox.checked) {
-      checkState = true;
-    }
-    var rowClassBars = heatMap.getRowClassificationConfig();
-    for (var key in rowClassBars) {
-      if (UPM.filterShow(key)) {
-        var colShow = document.getElementById(key + "_row" + "_showPref");
-        colShow.checked = checkState;
-      }
-    }
-    var colClassBars = heatMap.getColClassificationConfig();
-    for (var key in colClassBars) {
-      if (UPM.filterShow(key)) {
-        var colShow = document.getElementById(key + "_col" + "_showPref");
-        colShow.checked = checkState;
-      }
-    }
+  CovariatesPrefsTab.prototype.showAllBars = function showAllBars() {
+    const showAllBox = document.getElementById("all_showPref");
+    const checkState = showAllBox.checked;
 
-    return;
-  };
-
-  UPM.incrementAllHeights = function () {
-    const heatMap = MMGR.getHeatMap();
-    var rowClassBars = heatMap.getRowClassificationConfig();
-    for (var key in rowClassBars) {
-      var heightItem = document.getElementById(key + "_row" + "_heightPref");
-      //increment if value < 100, limit height to 99
-      if (parseInt(heightItem.value) < 99) {
-        heightItem.value = parseInt(heightItem.value) + 1;
-      }
-    }
-    var colClassBars = heatMap.getColClassificationConfig();
-    for (var key in colClassBars) {
-      var heightItem = document.getElementById(key + "_col" + "_heightPref");
-      //increment if value < 100, limit height to 99
-      if (parseInt(heightItem.value) < 99) {
-        heightItem.value = parseInt(heightItem.value) + 1;
+    for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+      if (this.filterShow(key)) {
+        const showItem = document.getElementById(`${key}_${axis}_showPref`);
+        showItem.checked = checkState;
       }
     }
   };
 
-  UPM.decrementAllHeights = function () {
-    const heatMap = MMGR.getHeatMap();
-    var rowClassBars = heatMap.getRowClassificationConfig();
-    for (var key in rowClassBars) {
-      var heightItem = document.getElementById(key + "_row" + "_heightPref");
-      //decrement if value > 0, prevent negative values
-      if (parseInt(heightItem.value) > 0) {
-        heightItem.value = parseInt(heightItem.value) - 1;
+  // FUNCTION incrementAllHeights. Increment the height of all covariate bars, to a
+  // maximum of 99.
+  function incrementAllHeights() {
+    for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+      const heightItem = document.getElementById(`${key}_${axis}_heightPref`);
+      const value = parseInt(heightItem.value);
+      // Increment if value < 99, limit maximum height to 99.
+      if (value < 99) {
+        heightItem.value = value + 1;
       }
     }
-    var colClassBars = heatMap.getColClassificationConfig();
-    for (var key in colClassBars) {
-      var heightItem = document.getElementById(key + "_col" + "_heightPref");
-      //decrement if value > 0, prevent negative values
-      if (parseInt(heightItem.value) > 0) {
-        heightItem.value = parseInt(heightItem.value) - 1;
+  }
+
+  // FUNCTION decrementAllHeights. Decrement the height of all covariate bars, to a
+  // minimum of 0.
+  function decrementAllHeights() {
+    for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+      const heightItem = document.getElementById(`${key}_${axis}_heightPref`);
+      const value = parseInt(heightItem.value);
+      // Decrement if value > 0, prevent negative values.
+      if (value > 0) {
+        heightItem.value = value - 1;
       }
     }
+  }
+
+  /**********************************************************************************
+   * METHOD CovariatesPrefsTab.prepareView: sets the default view
+   */
+  CovariatesPrefsTab.prototype.prepareView = function () {
+    this.filterVal = null;
+    this.setShowAll();
+  };
+
+  CovariatesPrefsTab.prototype.prepareErrorView = function (errorMsg) {
+    this.filterVal = null;
+    // errorMsg[0] : covariate selector
+    // errorMsg[3] : axis
+    this.showClassBreak(errorMsg[0], errorMsg[3]); // Switch to the covariate view containing the error.
   };
 
   /**********************************************************************************
-   * FUNCTION - setShowAll: The purpose of this function is to set the condition of
+   * METHOD CovariatesPrefsTab.setShowAll: This function sets the condition of
    * the "show all" checkbox on the covariate bars tab of the user preferences dialog.
    * This checkbox is located on the DIV that is visible when the ALL entry of the
    * covariate dropdown is selected. If a user un-checks a single box in the list of
    * covariate bars, the show all box is un-checked. Conversely, if a user checks a box
    * resulting in all of the boxes being selected, the show all box will be checked.
    **********************************************************************************/
-  UPM.setShowAll = function () {
-    const heatMap = MMGR.getHeatMap();
-    var rowClassBarsOrder = heatMap.getRowClassificationOrder();
-    var colClassBarsOrder = heatMap.getColClassificationOrder();
-    if (UPM.hasClasses) {
-      var checkState = true;
-      var rowClassBars = heatMap.getRowClassificationConfig();
-      for (var key in rowClassBars) {
-        var colShow = document.getElementById(key + "_row" + "_showPref");
-        if (UPM.filterShow(key)) {
-          if (!colShow.checked) {
-            checkState = false;
-            break;
-          }
+  CovariatesPrefsTab.prototype.setShowAll = function setShowAll() {
+    let allChecked = true;
+    for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+      if (this.filterShow(key)) {
+        const showItem = document.getElementById(`${key}_${axis}_showPref`);
+        if (!showItem) {
+          console.error("setShowAll: showItem missing", { key, axis });
+        } else if (!showItem.checked) {
+          allChecked = false;
+          break;
         }
       }
-      var colClassBars = heatMap.getColClassificationConfig();
-      for (var key in colClassBars) {
-        var colShow = document.getElementById(key + "_col" + "_showPref");
-        if (UPM.filterShow(key)) {
-          if (colShow && !colShow.checked) {
-            checkState = false;
-            break;
-          }
-        }
-      }
-      var showAllBox = document.getElementById("all_showPref");
-      showAllBox.checked = checkState;
     }
-
-    return;
+    const showAllBox = document.getElementById("all_showPref");
+    showAllBox.checked = allChecked;
   };
 
   /**********************************************************************************
-   * FUNCTION - showClassBreak: The purpose of this function is to show the
+   * METHOD - CovariatesPrefsTab.showClassBreak: The purpose of this function is to show the
    * appropriate classification bar panel based upon the user selection of the
    * covariate dropdown on the covariates tab of the preferences screen.  This
    * function is also called when an error is trappped, opening the covariate DIV
    * that contains the erroneous data entry.
    **********************************************************************************/
-  UPM.showClassBreak = function (selClass, selAxis) {
-    var classBtn = document.getElementById("classPref_list");
+  CovariatesPrefsTab.prototype.showClassBreak = function showClassBreak(
+    selClass,
+    selAxis,
+  ) {
+    const classBtn = document.getElementById("classPref_list");
     if (typeof selClass != "undefined") {
       classBtn.value = selClass + (selAxis ? "_" + selAxis : "");
     }
-    for (var i = 0; i < classBtn.length; i++) {
-      var classVal = "breakPrefs_" + classBtn.options[i].value;
-      var classDiv = document.getElementById(classVal);
-      var classSel = classBtn.options[i].selected;
+    for (let i = 0; i < classBtn.length; i++) {
+      const classVal = "breakPrefs_" + classBtn.options[i].value;
+      const classDiv = document.getElementById(classVal);
+      const classSel = classBtn.options[i].selected;
       if (classSel) {
         classDiv.style.display = "block";
       } else {
@@ -2388,177 +2108,311 @@
   };
 
   /**********************************************************************************
-   * FUNCTION - filterClassPrefs: The purpose of this function is to initiate the
+   * METHOD CovariatesPrefsTab.filterClassPrefs: The purpose of this function is to initiate the
    * process of filtering option choices for classifications. It is fired when either
    * the "Filter Covariates" or "Clear Filters" button is pressed on the covariates
    * preferences dialog.  The global filter value variable is set when filtering and
    * cleared when clearing and the editPreferences function is called to reload all
    * preferences.
    **********************************************************************************/
-  UPM.filterClassPrefs = function (filterOn) {
-    UPM.searchPerformed = true;
-    UPM.showClassBreak("ALL");
+  CovariatesPrefsTab.prototype.filterClassPrefs = function filterClassPrefs() {
+    this.showClassBreak("ALL");
     const filterButton = document.getElementById("all_searchPref_btn");
     const textSpan = filterButton.querySelector("span");
     if (!textSpan) return;
-    var searchPrefSelect = document.getElementById("all_searchPref");
-    var searchPrefVal = searchPrefSelect.value;
-    if (filterOn) {
-      if (searchPrefVal != "") {
-        UPM.filterVal = searchPrefVal;
-        textSpan.innerText = "Remove filter";
-        filterButton.onclick = function () {
-          UPM.filterClassPrefs(false);
-        };
-      }
-    } else {
+    const searchPrefSelect = document.getElementById("all_searchPref");
+    if (filterButton.dataset.buttonStatus == "RemoveFilter") {
+      // Button shows "Remove Filter".
+      // - Clear search results.
+      // - Reset button to "Filter covariates".
+      delete filterButton.dataset.buttonStatus;
       textSpan.innerText = "Filter covariates";
-      filterButton.onclick = function () {
-        UPM.filterClassPrefs(true);
-      };
       searchPrefSelect.value = "";
-      UPM.filterVal = null;
+      this.filterVal = null;
+    } else {
+      // Button shows "Filter covariates".
+      // - Filter covariates.
+      // - Change button to "Remove Filter".
+      const searchPrefVal = searchPrefSelect.value;
+      if (searchPrefVal != "") {
+        this.filterVal = searchPrefVal;
+        filterButton.dataset.buttonStatus = "RemoveFilter";
+        textSpan.innerText = "Remove filter";
+      }
     }
-    var allprefs = document.getElementById("breakPrefs_ALL");
-    var hiddenItems = UPM.addClassPrefOptions();
-    UPM.filterAllClassesTable(hiddenItems);
-    UPM.showClassBreak("ALL");
+    const hiddenItems = this.addClassPrefOptions();
+    filterAllClassesTable(hiddenItems);
+    this.showClassBreak("ALL");
   };
 
   /**********************************************************************************
-   * FUNCTION - filterAllClassesTable: The purpose of this function is to assign option
-   * values to the Covariates dropdown control on the Covariates preferences tab.  All
-   * covariates will be loaded at startup.  The filter control, however, is used to
-   * limit the visible options in this dropdown.
+   * FUNCTION filterAllClassesTable: make the visibility of the covariates in
+   * the table of all covariates match those that pass the covariate filter.
+   *
+   * hiddenItems contains those covariates that did not pass the filter.
+   * - it includes two arrays, one for each axis. Each array contains the
+   *   hidden keys for that axis.
+   *
+   * Note: only those rows in tableAllClasses that have the axis and key dataset properties
+   * contain covariates. Other rows contain headers, spacing, etc. and are always visible.
+   *
    **********************************************************************************/
-  UPM.filterAllClassesTable = function (hiddenItems) {
-    var table = document.getElementById("tableAllClasses");
-    for (var i = 0; i < table.rows.length; i++) {
-      var row = table.rows[i];
-      var td = row.cells[0];
-      var tdText = td.innerHTML.replace(/&nbsp;/g, "");
-      let hidden = false;
-      for (var j = 0; j < hiddenItems.length; j++) {
-        if (hiddenItems[j] === tdText) {
-          hidden = true;
-          break;
-        }
-      }
+  function filterAllClassesTable(hiddenItems) {
+    const table = document.getElementById("tableAllClasses");
+    for (let i = 0; i < table.rows.length; i++) {
+      const row = table.rows[i];
+      const hidden =
+        row.dataset.axis &&
+        hiddenItems[row.dataset.axis].includes(row.dataset.key);
       if (hidden) {
         row.classList.add("hide");
       } else {
         row.classList.remove("hide");
       }
     }
-  };
+  }
 
   /**********************************************************************************
-   * FUNCTION - addClassPrefOptions: The purpose of this function is to assign option
+   * FUNCTION addClassPrefOptions: The purpose of this function is to assign option
    * values to the Covariates dropdown control on the Covariates preferences tab.  All
    * covariates will be loaded at startup.  The filter control, however, is used to
    * limit the visible options in this dropdown.  This function returns a string
    * array containing a list of all options that are NOT being displayed.  This list
    * is used to hide rows on the ALL covariates panel.
    **********************************************************************************/
-  UPM.addClassPrefOptions = function () {
-    const heatMap = MMGR.getHeatMap();
-    var rowClassBars = heatMap.getRowClassificationConfig();
-    var colClassBars = heatMap.getColClassificationConfig();
-    var rowClassBarsOrder = heatMap.getRowClassificationOrder();
-    var colClassBarsOrder = heatMap.getColClassificationOrder();
-    var hiddenOpts = new Array();
-    if (UPM.hasClasses) {
-      var classSelect = document.getElementById("classPref_list");
+  CovariatesPrefsTab.prototype.addClassPrefOptions =
+    function addClassPrefOptions() {
+      // Empty covariate dropdown.
+      const classSelect = document.getElementById("classPref_list");
       classSelect.options.length = 0;
+
+      // Initialize the lists of hidden covariates to return.
+      const hiddenOpts = {
+        row: new Array(),
+        col: new Array(),
+      };
+
       classSelect.options[classSelect.options.length] = new Option(
         "ALL",
         "ALL",
       );
-      for (var i = 0; i < rowClassBarsOrder.length; i++) {
-        var key = rowClassBarsOrder[i];
-        var keyrow = key + "_row";
-        var displayName = key;
-        if (key.length > 20) {
-          displayName = key.substring(0, 20) + "...";
-        }
-        if (UPM.filterShow(key)) {
-          classSelect.options[classSelect.options.length] = new Option(
-            displayName,
-            keyrow,
-          );
-        } else {
-          hiddenOpts.push(displayName);
-        }
-        var barType = document.getElementById(keyrow + "_barTypePref");
-        if (barType !== null) {
-          var currentClassBar = rowClassBars[key];
-          barType.value = currentClassBar.bar_type;
-        }
-      }
-      for (var i = 0; i < colClassBarsOrder.length; i++) {
-        var key = colClassBarsOrder[i];
-        var keycol = key + "_col";
-        var displayName = key;
-        if (key.length > 20) {
-          displayName = key.substring(0, 20) + "...";
-        }
-        if (UPM.filterShow(key)) {
-          classSelect.options[classSelect.options.length] = new Option(
-            displayName,
-            keycol,
-          );
-        } else {
-          hiddenOpts.push(displayName);
-        }
-        var barType = document.getElementById(keycol + "_barTypePref");
-        if (barType !== null) {
-          var currentClassBar = colClassBars[key];
-          barType.value = currentClassBar.bar_type;
+      // Add options for every covariate that passes the filter.
+      // Add covariates that don't pass the filter to hiddenOpts.
+      //
+      if (this.hasClasses) {
+        for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+          if (this.filterShow(key)) {
+            const displayName =
+              key.length <= 20 ? key : key.substring(0, 17) + "...";
+            classSelect.options[classSelect.options.length] = new Option(
+              displayName,
+              key+"_"+axis,
+            );
+          } else {
+            hiddenOpts[axis].push(key);
+          }
+          const barTypeEl = KAE_OPT(key,axis,"barTypePref");
+          if (barTypeEl) {
+            const classBars = UPM.heatMap.getAxisConfig(axis).classifications;
+            barTypeEl.value = classBars[key].bar_type;
+          }
         }
       }
-    }
-
-    return hiddenOpts;
-  };
+      return hiddenOpts;
+    };
 
   /**********************************************************************************
-   * FUNCTION - filterShow: The purpose of this function is to determine whether a
+   * FUNCTION filterShow: The purpose of this function is to determine whether a
    * given covariates bar is to be shown given the state of the covariates filter
    * search text box.
    **********************************************************************************/
-  UPM.filterShow = function (key) {
-    var filterShow = false;
-    var lowerkey = key.toLowerCase();
-    if (UPM.filterVal != null) {
-      if (lowerkey.indexOf(UPM.filterVal.toLowerCase()) >= 0) {
-        filterShow = true;
-      }
-    } else {
-      filterShow = true;
+  CovariatesPrefsTab.prototype.filterShow = function filterShow(key) {
+    if (this.filterVal == null) {
+      // Show all bars if no filter.
+      return true;
     }
-
-    return filterShow;
+    return key.toLowerCase().indexOf(this.filterVal.toLowerCase()) >= 0;
   };
 
-  /*===================================================================================
- *  ROW COLUMN PREFERENCE PROCESSING FUNCTIONS
- *  
- *  The following functions are utilized to present heat map covariate classification
- *  bar configuration options:
- *  	- setupRowColPrefs
- *  	- showDendroSelections
- *      - dendroRowShowChange
- *      - dendroColShowChange
- =================================================================================*/
+  // METHOD CovariatesPrefsTab.validateTab: Validate Covariate Bar Preferences.
+  //
+  CovariatesPrefsTab.prototype.validateTab = function validateCovariatesTab() {
+    return validateAxis("row") || validateAxis("col");
 
-  UPM.setupMapInfoPrefs = function (e, prefprefs) {
-    const heatMap = MMGR.getHeatMap();
-    const mapInfo = heatMap.getMapInformation();
+    // Helper functions.
+
+    // Validate one axis.
+    function validateAxis(axis) {
+      const covBars = UPM.heatMap.getAxisCovariateConfig(axis);
+      let errorMsg = prefsValidateForNumeric(axis, covBars);
+      if (errorMsg != null) return errorMsg;
+      for (let [key, config] of Object.entries(covBars)) {
+        if (config.color_map.type == "continuous") {
+          errorMsg = prefsValidateBreakPoints(axis, key, "classPrefs");
+          if (errorMsg != null) return errorMsg;
+        }
+      }
+      return null;
+    }
+
+    /**********************************************************************************
+     * FUNCTION prefsValidateInputBoxs: Validate all user text input boxes that
+     * require positive numeric values.
+     **********************************************************************************/
+    function prefsValidateForNumeric(axis, axisClassBars) {
+      for (let key in axisClassBars) {
+        const keyaxis = key + "_" + axis;
+        const heightPref = parseInt(KAE(keyaxis, "heightPref").value);
+        if (isNaN(heightPref) || heightPref < 0 || heightPref > 100) {
+          return [
+            "ALL",
+            "classPrefs",
+            "ERROR: Bar heights must be between 0 and 100",
+          ];
+        }
+        const barType = KAE_OPT(keyaxis, "barTypePref");
+        if (barType !== null && barType.value !== "color_plot") {
+          const lowBoundElement = KAE(keyaxis, "lowBoundPref");
+          if (isNaN(lowBoundElement.value)) {
+            return [
+              keyaxis,
+              "classPrefs",
+              "ERROR: Covariate bar low bound must be numeric",
+            ];
+          }
+          const highBoundElement = KAE(keyaxis, "highBoundPref");
+          if (isNaN(highBoundElement.value)) {
+            return [
+              keyaxis,
+              "classPrefs",
+              "ERROR: Covariate bar high bound must be numeric",
+            ];
+          }
+          const bgColorElement = KAE(keyaxis, "bgColorPref");
+          const fgColorElement = KAE(keyaxis, "fgColorPref");
+          if (bgColorElement.value === fgColorElement.value) {
+            return [
+              keyaxis,
+              "classPrefs",
+              "ERROR: Duplicate foreground and background colors found",
+            ];
+          }
+        }
+      }
+      return null;
+    }
+  };
+
+  CovariatesPrefsTab.prototype.resetTabPrefs = function resetCovariateTabPrefs(resetVal) {
+    // Reset the Covariate preference items.
+    for (const axis of [ "row", "col" ]) {
+      const axisSavedCovariate = resetVal[axis+"Config"].classifications;
+      for (let key in axisSavedCovariate) {
+        const bar = axisSavedCovariate[key];
+        KAE(key,axis,"showPref").checked = bar.show == "Y";
+        KAE(key,axis,"heightPref").value = bar.height;
+        KAE(key,axis,"missing_colorPref").value = bar.color_map.missing;
+
+        if (bar.color_map.type == "discrete") {
+          for (let i = 0; i < bar.color_map.colors.length; i++) {
+            KAE(key,axis,"color"+i,"colorPref").value = bar.color_map.colors[i];
+          }
+        } else {
+          KAE(key,axis,"barTypePref").value = bar.bar_type;
+          showPlotTypeProperties(key,axis);
+          if (["bar_plot","scatter_plot"].includes(bar.bar_type)) {
+            KAE(key,axis,"lowBoundPref").value = bar.low_bound;
+            KAE(key,axis,"highBoundPref").value = bar.high_bound;
+            KAE(key,axis,"fgColorPref").value = bar.fg_color;
+            KAE(key,axis,"bgColorPref").value = bar.bg_color;
+          } else {
+            // It's a normal color plot.
+            for (let i = 0; i < bar.color_map.colors.length; i++) {
+              KAE(key,axis,"color"+i,"colorPref").value = bar.color_map.colors[i];
+            }
+          }
+        }
+      }
+    }
+  };
+
+  // METHOD CovariatesPrefsTab.applyTabPrefs: Apply Covariate Bar Preferences.
+  //
+  CovariatesPrefsTab.prototype.applyTabPrefs = function applyCovariatesPrefs() {
+    const colorMapMan = UPM.heatMap.getColorMapManager();
+    for (const { axis, key } of UPM.heatMap.genAllCovars()) {
+      const showElement = KAE(key,axis,"showPref");
+      const heightElement = KAE(key,axis,"heightPref");
+      console.log ("applyTabPrefs: ", { key, axis, show: showElement.value, height:heightElement.value, type: colorMapMan.getColorMap(axis,key).getType() });
+      if (heightElement.value === "0") {
+        showElement.checked = false;
+      }
+      UPM.heatMap.setClassificationPrefs(
+        key,
+        axis,
+        showElement.checked,
+        heightElement.value,
+      );
+      if (colorMapMan.getColorMap(axis, key).getType() === "continuous") {
+        UPM.heatMap.setClassBarScatterPrefs(
+          key,
+          axis,
+          KAE(key,axis,"barTypePref").value,
+          KAE(key,axis,"lowBoundPref").value,
+          KAE(key,axis,"highBoundPref").value,
+          KAE(key,axis,"fgColorPref").value,
+          KAE(key,axis,"bgColorPref").value,
+        );
+      }
+      prefsApplyBreaks(key, axis);
+    }
+  };
+
+  // Helper FUNCTION KAE: Return the "Key-Axis Element" whose id consists of
+  // the specified parts, joined by underscores.
+  // `
+  // For example, KAE("key","axis","name") returns the DOM element whose id
+  // is "key_axis_name".
+  //
+  // It was created to simplify access to document elements with structured names.
+  // Originally, it was just for elements consisting of a key, an axis, and a name,
+  // but it now works for any ID structured into parts separated by underscores.
+  //
+  // This function also checks that the requested element actually exists and throws
+  // an error if it doesn't.
+  function KAE(...parts) {
+    const id = parts.join("_");
+    const el = document.getElementById(id);
+    if (el) return el;
+    console.error ("KAE: Could not find element " + id);
+    throw new Error ("KAE: Could not find element " +id);
+  }
+  // Like KAE, but just return null if no such element. The caller is expected
+  // to handle a null return.
+  function KAE_OPT(...parts) {
+    const id = parts.join("_");
+    return document.getElementById(id);
+  }
+  // Just return the "Key-Axis" Id.
+  function KAID(...parts) {
+    return parts.join("_");
+  }
+
+  /*===================================================================================
+   *  CLASS MapInfoTab - Implements a tab containing summary information about the map.
+   *
+   =================================================================================*/
+
+  function MapInfoTab() {
+    PreferencesTab.call(this, "prefMapInfo_btn", "infoPrefs");
+  }
+  MapInfoTab.prototype.setupTab = function setupMapInfoTab() {
+    const mapInfo = UPM.heatMap.getMapInformation();
     const mapInfoPrefs = document.getElementById("infoPrefs");
     const prefContents = document.createElement("TABLE");
 
-    const totalRows = heatMap.getTotalRows() - mapInfo.map_cut_rows;
-    const totalCols = heatMap.getTotalCols() - mapInfo.map_cut_cols;
+    const totalRows = UPM.heatMap.getTotalRows() - mapInfo.map_cut_rows;
+    const totalCols = UPM.heatMap.getTotalCols() - mapInfo.map_cut_cols;
 
     UHM.setTableRowX(prefContents, ["ABOUT:"], ["header"], [{ colSpan: 2 }]);
     UHM.setTableRowX(prefContents, ["Name:", mapInfo.name]);
@@ -2611,6 +2465,8 @@
 
     return mapInfoPrefs;
 
+    // Helper function.
+    // Return true iff str matches any regexp in regExpArray.
     function matchAny(str, regExpArray) {
       for (let regExp of regExpArray) {
         if (regExp.test(str)) return true;
@@ -2618,27 +2474,144 @@
       return false;
     }
   };
+  MapInfoTab.prototype.validateTab = function () {
+    // Nothing to validate.
+    return null;
+  };
+  MapInfoTab.prototype.resetTabPrefs = function resetInfoTabPrefs() {
+    // Nothing to reset.
+  };
+
+  MapInfoTab.prototype.applyTabPrefs = function () {
+    // Nothing to update.
+  };
+  MapInfoTab.prototype.prepareView = function () {
+    // Nothing to do.
+  };
 
   /**********************************************************************************
-   * FUNCTION - setupRowColPrefs: The purpose of this function is to construct a DIV
-   * panel containing all row & col preferences.  Two sections are presented, one for
-   * rows and the other for cols.  Informational data begins each section and
-   * properties for modifying the appearance of row/col dendograms appear at the end.
+   * CLASS RowsColsTab - A tab for all row & column preferences.
+   *
+   * Two sections are presented, one for rows and the other for cols.
+   *
+   * Informational data begins each section and properties for modifying the
+   * appearance of row/col dendograms appear at the end.
    **********************************************************************************/
-  UPM.setupRowColPrefs = function (e, prefprefs) {
-    const heatMap = MMGR.getHeatMap();
+  function RowsColsTab() {
+    PreferencesTab.call(this, "prefRowsCols_btn", "rowsColsPrefs");
+  }
+  RowsColsTab.prototype.prepareView = function () {
+    this.showDendroSelections();
+    showLabelSelections();
+  };
+  RowsColsTab.prototype.setupTab = function setupRowsColsTab() {
     const rowcolprefs = document.getElementById("rowsColsPrefs");
-    var prefContents = document.createElement("TABLE");
-    UHM.addBlankRow(prefContents);
-    UHM.setTableRow(prefContents, ["ROW INFORMATION:"], 3);
-    var rowLabels = heatMap.getRowLabels();
-    var rowOrganization = heatMap.getRowOrganization();
-    var rowOrder = rowOrganization["order_method"];
-    var totalRows =
-      heatMap.getTotalRows() - heatMap.getMapInformation().map_cut_rows;
-    UHM.setTableRow(prefContents, ["&nbsp;&nbsp;Total Rows:", totalRows]);
-    addLabelTypeInputs(prefContents, heatMap, "Row");
-    UHM.setTableRow(prefContents, ["&nbsp;&nbsp;Ordering Method:", rowOrder]);
+    const prefContents = document.createElement("TABLE");
+
+    const mapInfo = UPM.heatMap.getMapInformation();
+    const dendroHeightOptions =
+      "<option value='50'>50%</option><option value='75'>75%</option><option value='100'>100%</option><option value='125'>125%</option><option value='150'>150%</option><option value='200'>200%</option>";
+    for (const axis of ["row", "col"]) {
+      const camelAxis = axis == "row" ? "Row" : "Column";
+      UHM.addBlankRow(prefContents);
+      UHM.setTableRow(prefContents, [camelAxis.toUpperCase() + " INFORMATION:"], 3);
+      const axisConfig = UPM.heatMap.getAxisConfig(axis);
+      const axisOrganization = axisConfig.organization;
+      const axisOrder = axisOrganization["order_method"];
+      const totalElements =
+        UPM.heatMap.getTotalElementsForAxis(axis) -
+        mapInfo["map_cut_" + axis + "s"];
+      UHM.setTableRow(prefContents, [
+        `&nbsp;&nbsp;Total ${camelAxis}s:`,
+        totalElements,
+      ]);
+      addLabelTypeInputs(prefContents, UPM.heatMap, axis);
+      UHM.setTableRow(prefContents, [
+        "&nbsp;&nbsp;Ordering Method:",
+        axisOrder,
+      ]);
+      if (axisOrder === "Hierarchical") {
+        UHM.setTableRow(prefContents, [
+          "&nbsp;&nbsp;Agglomeration Method:",
+          axisOrganization["agglomeration_method"],
+        ]);
+        UHM.setTableRow(prefContents, [
+          "&nbsp;&nbsp;Distance Metric:",
+          axisOrganization["distance_metric"],
+        ]);
+        const dendroShowSelect = UTIL.newElement(
+          "SELECT.ngchm-upm-input",
+          { name: axis + "_DendroShowPref", id: axis + "_DendroShowPref" },
+          dendroShowOptions(),
+          function (el) {
+            el.dataset.axis = axis;
+            return el;
+          },
+        );
+        UHM.setTableRow(prefContents, [
+          "&nbsp;&nbsp;Show Dendrogram:",
+          dendroShowSelect,
+        ]);
+        const dendroHeightSelect =
+          `<select class='ngchm-upm-input' name='${axis}_DendroHeightPref' id='${axis}_DendroHeightPref'>` +
+          dendroHeightOptions +
+          "</select>";
+        UHM.setTableRow(prefContents, [
+          "&nbsp;&nbsp;Dendrogram Height:",
+          dendroHeightSelect,
+        ]);
+      }
+      UHM.setTableRow(prefContents, [
+        "&nbsp;&nbsp;Maximum Label Length:",
+        genLabelSizeSelect(axis),
+      ]);
+      UHM.setTableRow(prefContents, [
+        "&nbsp;&nbsp;Trim Label Text From:",
+        genLabelAbbrevSelect(axis),
+      ]);
+
+      addTopItemsSelector(prefContents, axis, camelAxis+"s");
+      UHM.addBlankRow(prefContents);
+    }
+
+    rowcolprefs.appendChild(prefContents);
+
+    this.tabDiv.addEventListener("change", (ev) => {
+      console.log("RowsColsTab: Change handler", { target: ev.target });
+      for (const target of this.targetGen(ev)) {
+        if (["row_DendroShowPref", "col_DendroShowPref"].includes(target.id)) {
+          startChange();
+          dendroShowChange(target.dataset.axis);
+        }
+        if (target.classList.contains('ngchm-upm-input')) {
+          startChange();
+          break;
+        }
+      }
+    });
+    return rowcolprefs;
+
+    // ------------------------------------------------------------------------
+    // Helper functions.
+
+    function addTopItemsSelector(prefContents, axis, pluralAxisName) {
+      const covars = UPM.heatMap.getAxisCovariateConfig(axis, {
+        type: "continuous",
+      });
+      const covarNames = Object.keys(covars);
+      const selector = UTIL.newSelect(
+        [""].concat(covarNames),
+        ["Not Selected"].concat(covarNames),
+      );
+      selector.id = KAID(axis,"TopItems");
+      selector.classList.add('ngchm-upm-input');
+      selector.value = UPM.heatMap.getAxisConfig(axis).top_items_cv;
+      UHM.setTableRow(prefContents, [
+        `&nbsp;&nbsp;Top ${pluralAxisName}:`,
+        selector,
+      ]);
+    }
+
     function dendroShowOptions() {
       return [
         UTIL.newElement("OPTION", { value: "ALL" }, "Summary and Detail"),
@@ -2646,453 +2619,219 @@
         UTIL.newElement("OPTION", { value: "NONE" }, "Hide"),
       ];
     }
-    var dendroHeightOptions =
-      "<option value='50'>50%</option><option value='75'>75%</option><option value='100'>100%</option><option value='125'>125%</option><option value='150'>150%</option><option value='200'>200%</option></select>";
-    if (rowOrder === "Hierarchical") {
-      UHM.setTableRow(prefContents, [
-        "&nbsp;&nbsp;Agglomeration Method:",
-        rowOrganization["agglomeration_method"],
-      ]);
-      UHM.setTableRow(prefContents, [
-        "&nbsp;&nbsp;Distance Metric:",
-        rowOrganization["distance_metric"],
-      ]);
-      const rowDendroShowSelect = UTIL.newElement(
-        "SELECT",
-        { name: "rowDendroShowPref", id: "rowDendroShowPref" },
-        dendroShowOptions(),
-        function (el) {
-          el.onchange = function () {
-            UPM.dendroRowShowChange();
-          };
-          return el;
-        },
+
+    function genLabelSizeSelect(axis) {
+      const sizes = [10, 15, 20, 25, 30, 35, 40];
+      return (
+        `<select class='ngchm-upm-input' name='${axis}_LabelSizePref' id='${axis}_LabelSizePref'>` +
+        sizes
+          .map((size) => `<option value='${size}'>${size} Characters</option>`)
+          .join() +
+        "</select>"
       );
-      UHM.setTableRow(prefContents, [
-        "&nbsp;&nbsp;Show Dendrogram:",
-        rowDendroShowSelect,
-      ]);
-      var rowDendroHeightSelect =
-        "<select name='rowDendroHeightPref' id='rowDendroHeightPref'>";
-      rowDendroHeightSelect = rowDendroHeightSelect + dendroHeightOptions;
-      UHM.setTableRow(prefContents, [
-        "&nbsp;&nbsp;Dendrogram Height:",
-        rowDendroHeightSelect,
-      ]);
     }
-    var rowLabelSizeSelect =
-      "<select name='rowLabelSizePref' id='rowLabelSizePref'><option value='10'>10 Characters</option><option value='15'>15 Characters</option><option value='20'>20 Characters</option><option value='25'>25 Characters</option><option value='30'>30 Characters</option><option value='35'>35 Characters</option><option value='40'>40 Characters</option>";
-    var rowLabelAbbrevSelect =
-      "<select name='rowLabelAbbrevPref' id='rowLabelAbbrevPref'><option value='START'>Beginning</option><option value='MIDDLE'>Middle</option><option value='END'>End</option>";
-    UHM.setTableRow(prefContents, [
-      "&nbsp;&nbsp;Maximum Label Length:",
-      rowLabelSizeSelect,
-    ]);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;&nbsp;Trim Label Text From:",
-      rowLabelAbbrevSelect,
-    ]);
-
-    addTopItemsSelector (prefContents, heatMap, "row", "Rows");
-
-    UHM.addBlankRow(prefContents);
-    UHM.setTableRow(prefContents, ["COLUMN INFORMATION:"], 3);
-
-    var colLabels = heatMap.getColLabels();
-    var colOrganization = heatMap.getColOrganization();
-    var colOrder = colOrganization["order_method"];
-    var totalCols =
-      heatMap.getTotalCols() - heatMap.getMapInformation().map_cut_cols;
-    UHM.setTableRow(prefContents, ["&nbsp;&nbsp;Total Columns:", totalCols]);
-    addLabelTypeInputs(prefContents, heatMap, "Col");
-    UHM.setTableRow(prefContents, ["&nbsp;&nbsp;Ordering Method:", colOrder]);
-    if (colOrder === "Hierarchical") {
-      UHM.setTableRow(prefContents, [
-        "&nbsp;&nbsp;Agglomeration Method:",
-        colOrganization["agglomeration_method"],
-      ]);
-      UHM.setTableRow(prefContents, [
-        "&nbsp;&nbsp;Distance Metric:",
-        colOrganization["distance_metric"],
-      ]);
-      const colDendroShowSelect = UTIL.newElement(
-        "SELECT",
-        { name: "colDendroShowPref", id: "colDendroShowPref" },
-        dendroShowOptions(),
-        function (el) {
-          el.onchange = function () {
-            UPM.dendroColShowChange();
-          };
-          return el;
-        },
+    function genLabelAbbrevSelect(axis) {
+      return (
+        `<select class='ngchm-upm-input' name='${axis}_LabelAbbrevPref' id='${axis}_LabelAbbrevPref'>` +
+        "<option value='START'>Beginning</option><option value='MIDDLE'>Middle</option><option value='END'>End</option>" +
+        "</select>"
       );
-      var colDendroHeightSelect =
-        "<select name='colDendroHeightPref' id='colDendroHeightPref'>";
-      colDendroHeightSelect = colDendroHeightSelect + dendroHeightOptions;
-      UHM.setTableRow(prefContents, [
-        "&nbsp;&nbsp;Show Dendrogram:",
-        colDendroShowSelect,
-      ]);
-      UHM.setTableRow(prefContents, [
-        "&nbsp;&nbsp;Dendrogram Height:",
-        colDendroHeightSelect,
-      ]);
-    }
-    var colLabelSizeSelect =
-      "<select name='colLabelSizePref' id='colLabelSizePref'><option value='10'>10 Characters</option><option value='15'>15 Characters</option><option value='20'>20 Characters</option><option value='25'>25 Characters</option><option value='30'>30 Characters</option><option value='35'>35 Characters</option><option value='40'>40 Characters</option>";
-    var colLabelAbbrevSelect =
-      "<select name='colLabelAbbrevPref' id='colLabelAbbrevPref'><option value='START'>Beginning</option><option value='MIDDLE'>Middle</option><option value='END'>End</option>";
-    UHM.setTableRow(prefContents, [
-      "&nbsp;&nbsp;Maximum Label Length:",
-      colLabelSizeSelect,
-    ]);
-    UHM.setTableRow(prefContents, [
-      "&nbsp;&nbsp;Trim Label Text From:",
-      colLabelAbbrevSelect,
-    ]);
-
-    addTopItemsSelector (prefContents, heatMap, "col", "Columns");
-
-    rowcolprefs.appendChild(prefContents);
-
-    return rowcolprefs;
-
-    function addTopItemsSelector (prefContents, heatMap, axis, pluralAxisName) {
-      const covars = heatMap.getAxisCovariateConfig (axis, { type: "continuous" });
-      const covarNames = Object.keys(covars);
-      const selector = UTIL.newSelect ([""].concat(covarNames), ["Not Selected"].concat(covarNames));
-      selector.id = axis+"TopItems";
-      selector.value = heatMap.getAxisConfig(axis).top_items_cv;
-      UHM.setTableRow(prefContents, [`&nbsp;&nbsp;Top ${pluralAxisName}:`, selector]);
     }
   };
 
   // Add Label Type rows for the specified axis of heatMap to the userPreferencesTable.
-  function addLabelTypeInputs (userPreferencesTable, heatMap, axisName) {
+  function addLabelTypeInputs(userPreferencesTable, heatMap, axisName) {
     axisName = MMGR.isRow(axisName) ? "Row" : "Col";
-    const axisTypes = heatMap.getLabelTypes (axisName);
-    axisTypes.forEach((type,idx) => {
+    const axisTypes = heatMap.getLabelTypes(axisName);
+    axisTypes.forEach((type, idx) => {
       const idbase = `upm_${axisName}_label_part_${idx}`;
-      const typeInput = UTIL.newElement('INPUT.upm_label_type', {
+      const typeInput = UTIL.newElement("INPUT.ngchm-upm-input.upm_label_type", {
         type: "text",
         name: idbase + "_type",
         id: idbase + "_type",
-        value: type.type
+        value: type.type,
       });
-      const showType = UTIL.newElement('INPUT', {
+      const showType = UTIL.newElement("INPUT.ngchm-upm-input", {
         type: "checkbox",
         name: idbase + "_show",
         id: idbase + "_show",
       });
       showType.checked = type.visible;
-      UHM.setTableRow(userPreferencesTable, [idx == 0 ? "&nbsp;&nbsp;Labels Type(s):" : "", typeInput, showType]);
+      UHM.setTableRow(userPreferencesTable, [
+        idx == 0 ? "&nbsp;&nbsp;Labels Type(s):" : "",
+        typeInput,
+        showType,
+      ]);
     });
   }
 
   // Reset the label type inputs to the values in savedLabelTypes.
-  function resetLabelTypeInputs (axisName, savedLabelTypes) {
+  function resetLabelTypeInputs(axisName, savedLabelTypes) {
     axisName = MMGR.isRow(axisName) ? "Row" : "Col";
     savedLabelTypes.forEach((type, idx) => {
       const idbase = `upm_${axisName}_label_part_${idx}`;
-      const typeInput = document.getElementById(idbase+"_type");
+      const typeInput = KAE(idbase,"type");
       typeInput.value = type.type;
-      const checkBox = document.getElementById(idbase+"_show");
+      const checkBox = KAE(idbase,"show");
       checkBox.checked = type.visible;
     });
   }
 
-  // Validate the label type inputs for the specified axis.
-  // Returns null if the label type inputs pass all checks.
-  // Returns an error message with relevant details if at least one check fails.
-  function validateLabelTypeInputs (heatMap, axisName) {
-    axisName = MMGR.isRow(axisName) ? "Row" : "Col";
-    const axisLabelTypes = heatMap.getLabelTypes(axisName);
-    let foundEmpty = false;
-    const checkedParts = axisLabelTypes.filter((type,idx) => {
-      const idbase = `upm_${axisName}_label_part_${idx}`;
-      if (document.getElementById(idbase+"_type").value == "") {
-        foundEmpty = true;
-      }
-      const checkBox = document.getElementById(idbase+"_show");
-      return checkBox.checked;
-    });
-    let errMsg = "";
-    if (foundEmpty) errMsg += " None can be empty.";
-    if (checkedParts.length == 0) errMsg += " At least one must be visible.";
-    if (errMsg) {
-      return [ "ALL", "rowsColsPrefs", `ERROR: ${axisName} types: ${errMsg}` ];
+  RowsColsTab.prototype.validateTab = function validateRowsColsTab() {
+    for (const axis of ["row", "col"]) {
+      let errorMsg = validateLabelTypeInputs(axis);
+      if (errorMsg) return errorMsg;
     }
     return null;
-  }
 
-  // Saves the values of the label type inputs for the specified axis to heatMap.
-  // Only call this function if validateLabelTypeInputs has been called and no
-  // issues were found.
-  function applyLabelTypeInputs (heatMap, axisName) {
-    axisName = MMGR.isRow(axisName) ? "Row" : "Col";
-    const axisLabelTypes = heatMap.getLabelTypes(axisName);
-    axisLabelTypes.forEach((type,idx) => {
-      const idbase = `upm_${axisName}_label_part_${idx}`;
-      type.type = document.getElementById(idbase+"_type").value;
-      type.visible = document.getElementById(idbase+"_show").checked;
-    });
-    heatMap.setLabelTypes(axisName, axisLabelTypes);
-  }
+    // ------------------------------------------------------------------------
+    // Helper functions.
 
+    // Validate the label type inputs for the specified axis.
+    // Returns null if the label type inputs pass all checks.
+    // Returns an error message with relevant details if at least one check fails.
+    function validateLabelTypeInputs(axisName) {
+      axisName = MMGR.isRow(axisName) ? "Row" : "Col";
+      const axisLabelTypes = UPM.heatMap.getLabelTypes(axisName);
+      let foundEmpty = false;
+      const checkedParts = axisLabelTypes.filter((type, idx) => {
+        const idbase = `upm_${axisName}_label_part_${idx}`;
+        if (KAE(idbase,"type").value == "") {
+          foundEmpty = true;
+        }
+        return KAE(idbase,"show").checked;
+      });
+      let errMsg = "";
+      if (foundEmpty) errMsg += " None can be empty.";
+      if (checkedParts.length == 0) errMsg += " At least one must be visible.";
+      if (errMsg) {
+        return ["ALL", "rowsColsPrefs", `ERROR: ${axisName} types: ${errMsg}`];
+      }
+      return null;
+    }
+  };
+
+  RowsColsTab.prototype.resetTabPrefs = function resetRowsColsTabPrefs(resetVal) {
+    // Reset the Row/Col preference items.
+    for (const axis of ["row", "col"]) {
+      resetLabelTypeInputs(axis, resetVal[axis + "LabelTypes"]);
+      const axisResetVal = resetVal[axis + "Config"];
+      // Reset dendrogram options.
+      if (KAE_OPT(axis,"DendroShowPref") !== null) {
+        const dendroSaveVals = axisResetVal.dendrogram;
+        KAE(axis,"DendroShowPref").value = dendroSaveVals.show;
+        KAE(axis,"DendroHeightPref").value = dendroSaveVals.height;
+        dendroShowChange(axis);
+      }
+      // Reset axis label options.
+      KAE(axis,"LabelSizePref").value = axisResetVal.label_display_length;
+      KAE(axis,"LabelAbbrevPref").value = axisResetVal.label_display_method;
+      KAE(axis,"TopItems").value = axisResetVal.top_items_cv;
+    }
+  };
+
+  RowsColsTab.prototype.applyTabPrefs = function applyRowsColsPrefs() {
+    // Apply the Row/Col preference items.
+    for (const axis of ["row", "col"]) {
+      const axisConfig = UPM.heatMap.getAxisConfig(axis);
+      // Label type preferences.
+      applyLabelTypeInputs(axis);
+      // Dendrogram preferences.
+      if (axisConfig.organization.order_method === "Hierarchical") {
+        axisConfig.dendrogram.show = KAE(axis,"DendroShowPref").value;
+        axisConfig.dendrogram.height = KAE(axis,"DendroHeightPref").value;
+      }
+      // Apply Label Sizing Preferences.
+      axisConfig.label_display_length = KAE(axis,"LabelSizePref").value;
+      axisConfig.label_display_method = KAE(axis,"LabelAbbrevPref").value;
+      // Top items preferences.
+      axisConfig.top_items_cv = KAE(axis,"TopItems").value;
+    }
+
+    // ------------------------------------------------------------------------
+    // Helper functions.
+
+    // Saves the values of the label type inputs for the specified axis to heatMap.
+    // Only call this function if validateLabelTypeInputs has been called and no
+    // issues were found.
+    function applyLabelTypeInputs(axisName) {
+      axisName = MMGR.isRow(axisName) ? "Row" : "Col";
+      const axisLabelTypes = UPM.heatMap.getLabelTypes(axisName);
+      axisLabelTypes.forEach((type, idx) => {
+        const idbase = `upm_${axisName}_label_part_${idx}`;
+        type.type = KAE(idbase,"type").value;
+        type.visible = KAE(idbase,"show").checked;
+      });
+      UPM.heatMap.setLabelTypes(axisName, axisLabelTypes);
+    }
+  };
 
   /**********************************************************************************
-   * FUNCTION - showDendroSelections: The purpose of this function is to set the
+   * FUNCTION showDendroSelections: The purpose of this function is to set the
    * states of the row/column dendrogram show and height preferences.
    **********************************************************************************/
-  UPM.showDendroSelections = function () {
-    const heatMap = MMGR.getHeatMap();
-    var rowDendroConfig = heatMap.getRowDendroConfig();
-    var rowOrganization = heatMap.getRowOrganization();
-    var rowOrder = rowOrganization["order_method"];
-    if (rowOrder === "Hierarchical") {
-      var dendroShowVal = rowDendroConfig.show;
-      document.getElementById("rowDendroShowPref").value = dendroShowVal;
-      var rowHeightPref = document.getElementById("rowDendroHeightPref");
-      if (dendroShowVal === "NONE") {
-        var opt = rowHeightPref.options[6];
-        if (typeof opt != "undefined") {
-          rowHeightPref.options[6].remove();
-        }
-        var option = document.createElement("option");
-        option.text = "NA";
-        option.value = "10";
-        rowHeightPref.add(option);
-        rowHeightPref.disabled = true;
-        rowHeightPref.value = option.value;
-      } else {
-        rowHeightPref.value = rowDendroConfig.height;
-      }
-    }
-    var colOrganization = heatMap.getColOrganization();
-    var colOrder = colOrganization["order_method"];
-    var colDendroConfig = heatMap.getColDendroConfig();
-    if (colOrder === "Hierarchical") {
-      var dendroShowVal = colDendroConfig.show;
-      document.getElementById("colDendroShowPref").value = dendroShowVal;
-      var colHeightPref = document.getElementById("colDendroHeightPref");
-      if (dendroShowVal === "NONE") {
-        var opt = colHeightPref.options[6];
-        if (typeof opt != "undefined") {
-          colHeightPref.options[6].remove();
-        }
-        var option = document.createElement("option");
-        option.text = "NA";
-        option.value = "10";
-        colHeightPref.add(option);
-        colHeightPref.disabled = true;
-        colHeightPref.value = option.value;
-      } else {
-        colHeightPref.value = colDendroConfig.height;
-      }
-    }
-  };
-
-  /**********************************************************************************
-   * FUNCTION - showLabelSelections: The purpose of this function is to set the
-   * states of the label length and truncation preferences.
-   **********************************************************************************/
-  UPM.showLabelSelections = function () {
-    const heatMap = MMGR.getHeatMap();
-    document.getElementById("colLabelSizePref").value =
-      heatMap.getColConfig().label_display_length;
-    document.getElementById("colLabelAbbrevPref").value =
-      heatMap.getColConfig().label_display_method;
-    document.getElementById("rowLabelSizePref").value =
-      heatMap.getRowConfig().label_display_length;
-    document.getElementById("rowLabelAbbrevPref").value =
-      heatMap.getRowConfig().label_display_method;
-  };
-
-  /**********************************************************************************
-   * FUNCTION - dendroRowShowChange: The purpose of this function is to respond to
-   * a change event on the show row dendrogram dropdown.  If the change is to Hide,
-   * the row dendro height is set to 10 and the dropdown disabled. If the change is to
-   * one of the 2 Show options AND was previously Hide, set height to the default
-   * value of 100 and enable the dropdown.
-   **********************************************************************************/
-  UPM.dendroRowShowChange = function () {
-    var newValue = document.getElementById("rowDendroShowPref").value;
-    var rowHeightPref = document.getElementById("rowDendroHeightPref");
-    if (newValue === "NONE") {
-      var option = document.createElement("option");
-      option.text = "NA";
-      option.value = "10";
-      rowHeightPref.add(option);
-      rowHeightPref.value = "10";
-      rowHeightPref.disabled = true;
-    } else if (rowHeightPref.disabled) {
-      var opt = rowHeightPref.options[6];
-      if (typeof opt != "undefined") {
-        rowHeightPref.options[6].remove();
-      }
-      rowHeightPref.value = "100";
-      rowHeightPref.disabled = false;
-    }
-  };
-
-  /**********************************************************************************
-   * FUNCTION - dendroColShowChange: The purpose of this function is to respond to
-   * a change event on the show row dendrogram dropdown.  If the change is to Hide,
-   * the row dendro height is set to 10 and the dropdown disabled. If the change is to
-   * one of the 2 Show options AND was previously Hide, set height to the default
-   * value of 100 and enable the dropdown.
-   **********************************************************************************/
-  UPM.dendroColShowChange = function () {
-    var newValue = document.getElementById("colDendroShowPref").value;
-    var colHeightPref = document.getElementById("colDendroHeightPref");
-    if (newValue === "NONE") {
-      var option = document.createElement("option");
-      option.text = "NA";
-      option.value = "10";
-      colHeightPref.add(option);
-      colHeightPref.value = "10";
-      colHeightPref.disabled = true;
-    } else if (colHeightPref.disabled) {
-      var opt = colHeightPref.options[6];
-      if (typeof opt != "undefined") {
-        colHeightPref.options[6].remove();
-      }
-      colHeightPref.value = "100";
-      colHeightPref.disabled = false;
-    }
-  };
-
-  UPM.getResetVals = function () {
-    const heatMap = MMGR.getHeatMap();
-    var rowDendroConfig = heatMap.getRowDendroConfig();
-    var colDendroConfig = heatMap.getColDendroConfig();
-    var rowConfig = heatMap.getRowConfig();
-    var colConfig = heatMap.getColConfig();
-    var matrix = heatMap.getMapInformation();
-    var rowClassification = heatMap.getRowClassificationConfig();
-    var colClassification = heatMap.getColClassificationConfig();
-    var returnObj = {
-      rowDendroConfig: rowDendroConfig,
-      colDendroConfig: colDendroConfig,
-      rowConfig: rowConfig,
-      colConfig: colConfig,
-      rowLabelTypes: heatMap.getLabelTypes('row'),
-      colLabelTypes: heatMap.getLabelTypes('col'),
-      matrix: matrix,
-      rowClassification: rowClassification,
-      colClassification: colClassification,
-    };
-    returnObj = JSON.stringify(returnObj); // turn the object into a string so the values don't change as the user changes stuff in the pref manager
-    return returnObj;
-  };
-
-  UPM.prefsResetButton = function () {
-    var resetVal = JSON.parse(UPM.resetVal);
-    // Reset the Row/Col panel items
-    if (document.getElementById("rowDendroShowPref") !== null) {
-      document.getElementById("rowDendroShowPref").value =
-        resetVal.rowDendroConfig.show;
-      document.getElementById("rowDendroHeightPref").value =
-        resetVal.rowDendroConfig.height;
-      UPM.dendroRowShowChange();
-    }
-    if (document.getElementById("colDendroShowPref") !== null) {
-      document.getElementById("colDendroShowPref").value =
-        resetVal.colDendroConfig.show;
-      document.getElementById("colDendroHeightPref").value =
-        resetVal.colDendroConfig.height;
-      UPM.dendroColShowChange();
-    }
-
-    for (let axis of [ "row", "col" ]) {
-      const axisResetVal = resetVal[axis+"Config"];
-      document.getElementById(axis+"LabelSizePref").value = axisResetVal.label_display_length;
-      document.getElementById(axis+"LabelAbbrevPref").value = axisResetVal.label_display_method;
-      document.getElementById(axis+"TopItems").value = axisResetVal.top_items_cv;
-      resetLabelTypeInputs(axis, resetVal[axis+"LabelTypes"]);
-    }
-
-    // Reset the Data Matrix panel items
-    for (var dl in resetVal.matrix.data_layer) {
-      var layer = resetVal.matrix.data_layer[dl];
-      var cm = layer.color_map;
-      const dlTable = document.getElementById("breakPrefsTable_" + dl);
-      fillBreaksTable(dlTable, "data", dl, cm.thresholds, cm.colors);
-      var gridColor = document.getElementById(dl + "_gridColorPref");
-      gridColor.value = layer.grid_color;
-      var gridShow = document.getElementById(dl + "_gridPref");
-      gridShow.checked = layer.grid_show == "Y";
-      var selectionColor = document.getElementById(dl + "_selectionColorPref");
-      selectionColor.value = layer.selection_color;
-      var gapColor = document.getElementById(dl + "_gapColorPref");
-      gapColor.value = layer.cuts_color;
-      UHM.loadColorPreviewDiv(dl);
-    }
-
-    // Reset the Covariate bar panel items
-    for (var name in resetVal.colClassification) {
-      var bar = resetVal.colClassification[name];
-      var show = document.getElementById(name + "_col_showPref");
-      show.checked = bar.show == "Y";
-      var height = document.getElementById(name + "_col_heightPref");
-      height.value = bar.height;
-
-      if (bar.color_map.type == "discrete") {
-        for (var i = 0; i < bar.color_map.colors.length; i++) {
-          var prefcolor = document.getElementById(
-            name + "_col_color" + i + "_colorPref",
-          );
-          prefcolor.value = bar.color_map.colors[i];
-        }
-      } else {
-        var type = document.getElementById(name + "_col_barTypePref");
-        type.value = bar.bar_type;
-        UPM.showPlotTypeProperties(name + "_col");
-        if (bar.bar_type == "bar_plot" || bar.bar_type == "scatter_plot") {
-          var lowBound = document.getElementById(name + "_col_lowBoundPref");
-          lowBound.value = bar.low_bound;
-          var highBound = document.getElementById(name + "_col_highBoundPref");
-          highBound.value = bar.high_bound;
-          var fgColor = document.getElementById(name + "_col_fgColorPref");
-          fgColor.value = bar.fg_color;
-          var bgColor = document.getElementById(name + "_col_bgColorPref");
-          bgColor.value = bar.bg_color;
-        } else {
-          // it's a normal color plot
-          for (var i = 0; i < bar.color_map.colors.length; i++) {
-            var prefcolor = document.getElementById(
-              name + "_col_color" + i + "_colorPref",
-            );
-            prefcolor.value = bar.color_map.colors[i];
+  RowsColsTab.prototype.showDendroSelections = function showDendroSelections() {
+    for (const axis of ["row", "col"]) {
+      const axisConfig = UPM.heatMap.getAxisConfig(axis);
+      const rowOrder = axisConfig.organization.order_method;
+      if (rowOrder === "Hierarchical") {
+        const dendroShowVal = axisConfig.dendrogram.show;
+        KAE(axis,"DendroShowPref").value = dendroShowVal;
+        const heightPref = KAE(axis,"DendroHeightPref");
+        if (dendroShowVal === "NONE") {
+          const opt = heightPref.options[6];  // options[6] is what the NA option below becomes.
+          if (typeof opt != "undefined") {
+            heightPref.options[6].remove();
           }
+          const option = document.createElement("option");
+          option.text = "NA";
+          option.value = "10";
+          heightPref.add(option);
+          heightPref.disabled = true;
+          heightPref.value = option.value;
+        } else {
+          heightPref.value = axisConfig.dendrogram.height;
         }
       }
     }
-    for (var name in resetVal.rowClassification) {
-      var bar = resetVal.rowClassification[name];
-      var show = document.getElementById(name + "_row_showPref");
-      show.checked = bar.show == "Y";
-      var height = document.getElementById(name + "_row_heightPref");
-      height.value = bar.height;
-      if (bar.bar_type == "bar_plot" || bar.bar_type == "scatter_plot") {
-        var lowBound = document.getElementById(name + "_row_lowBoundPref");
-        lowBound.value = bar.low_bound;
-        var highBound = document.getElementById(name + "_row_highBoundPref");
-        highBound.value = bar.high_bound;
-        var fgColor = document.getElementById(name + "_row_fgColorPref");
-        fgColor.value = bar.fg_color;
-        var bgColor = document.getElementById(name + "_row_bgColorPref");
-        bgColor.value = bar.bg_color;
-      } else {
-        // it's a normal color plot
-        for (var i = 0; i < bar.color_map.colors.length; i++) {
-          var prefcolor = document.getElementById(
-            name + "_row_color" + i + "_colorPref",
-          );
-          prefcolor.value = bar.color_map.colors[i];
-        }
-      }
-    }
-    UPM.prefsApplyButton(1);
   };
+
+  /**********************************************************************************
+   * FUNCTION showLabelSelections: Set the label length and truncation preferences.
+   **********************************************************************************/
+  function showLabelSelections() {
+    for (const axis of [ "row", "col" ]) {
+      const axisConfig = UPM.heatMap.getAxisConfig(axis);
+      KAE(axis,"LabelSizePref").value = axisConfig.label_display_length;
+      KAE(axis,"LabelAbbrevPref").value = axisConfig.label_display_method;
+    }
+  }
+
+  /**********************************************************************************
+   * FUNCTION dendroShowChange(axis): This function responds to change event on the
+   * row/column show dendrogram dropdowns.
+   * - If the change is to Hide, the dendro height is set to 10 and the dropdown disabled.
+   * - If the change is to one of the 2 Show options AND was previously Hide, set height
+   *   to the default value of 100 and enable the dropdown.
+   **********************************************************************************/
+  function dendroShowChange(axis) {
+    const newValue = KAE(axis,"DendroShowPref").value;
+    const heightPref = KAE(axis,"DendroHeightPref");
+    if (newValue === "NONE") {
+      // Append an NA option (becomes options[6]) to the height-pref dropdown.
+      const option = document.createElement("option");
+      option.text = "NA";
+      option.value = "10";
+      heightPref.add(option);
+      heightPref.value = "10";
+      heightPref.disabled = true;
+    } else if (heightPref.disabled) {
+      const opt = heightPref.options[6];  // options[6] is what the NA element becomes.
+      if (typeof opt != "undefined") {
+        heightPref.options[6].remove();
+      }
+      heightPref.value = "100";
+      heightPref.disabled = false;
+    }
+  }
 })();

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -463,17 +463,7 @@
         "rowDendroHeightPref",
       ).value;
     }
-    var rowTopItems = document
-      .getElementById("rowTopItems")
-      .value.split(/[;, \r\n]+/);
-    //Flush top items array
-    heatMap.getRowConfig().top_items = [];
-    //Fill top items array from prefs element contents
-    for (var i = 0; i < rowTopItems.length; i++) {
-      if (rowTopItems[i] !== "") {
-        heatMap.getRowConfig().top_items.push(rowTopItems[i]);
-      }
-    }
+
     var colDendroConfig = heatMap.getColDendroConfig();
     var colOrganization = heatMap.getColOrganization();
     var colOrder = colOrganization["order_method"];
@@ -484,15 +474,11 @@
         "colDendroHeightPref",
       ).value;
     }
-    var colTopItems = document
-      .getElementById("colTopItems")
-      .value.split(/[;, \r\n]+/);
-    heatMap.getColConfig().top_items = [];
-    for (var i = 0; i < colTopItems.length; i++) {
-      if (colTopItems[i] !== "") {
-        heatMap.getColConfig().top_items.push(colTopItems[i]);
-      }
+
+    for (let axis of [ "row", "col" ]) {
+      heatMap.getAxisConfig(axis).top_items_cv = document.getElementById(axis+"TopItems").value;
     }
+
     // Apply Covariate Bar Preferences
     var rowClassBars = heatMap.getRowClassificationConfig();
     for (var key in rowClassBars) {
@@ -2729,13 +2715,7 @@
       rowLabelAbbrevSelect,
     ]);
 
-    var topRowItemData = heatMap.getRowConfig().top_items.toString();
-    var topRowItems =
-      "<textarea name='rowTopItems' id='rowTopItems' rows='3' cols='80'>" +
-      topRowItemData +
-      "</textarea>";
-    UHM.setTableRow(prefContents, ["&nbsp;&nbsp;Top Rows:"]);
-    UHM.setTableRow(prefContents, [topRowItems], 2);
+    addTopItemsSelector (prefContents, heatMap, "row", "Rows");
 
     UHM.addBlankRow(prefContents);
     UHM.setTableRow(prefContents, ["COLUMN INFORMATION:"], 2);
@@ -2795,16 +2775,22 @@
       "&nbsp;&nbsp;Trim Label Text From:",
       colLabelAbbrevSelect,
     ]);
-    var topColItemData = heatMap.getColConfig().top_items.toString();
-    var topColItems =
-      "<textarea name='colTopItems' id='colTopItems' rows='3' cols='80'>" +
-      topColItemData +
-      "</textarea>";
-    UHM.setTableRow(prefContents, ["&nbsp;&nbsp;Top Columns:"]);
-    UHM.setTableRow(prefContents, [topColItems], 2);
+
+    addTopItemsSelector (prefContents, heatMap, "col", "Columns");
+
     rowcolprefs.appendChild(prefContents);
 
     return rowcolprefs;
+
+    function addTopItemsSelector (prefContents, heatMap, axis, pluralAxisName) {
+      const covars = heatMap.getAxisCovariateConfig (axis, { type: "continuous" });
+      const covarNames = Object.keys(covars);
+      const selector = UTIL.newSelect ([""].concat(covarNames), ["Not Selected"].concat(covarNames));
+      selector.id = axis+"TopItems";
+      selector.value = heatMap.getAxisConfig(axis).top_items_cv;
+      UHM.setTableRow(prefContents, [`&nbsp;&nbsp;Top ${pluralAxisName}:`, selector]);
+    }
+
   };
 
   /**********************************************************************************
@@ -2968,18 +2954,13 @@
         resetVal.colDendroConfig.height;
       UPM.dendroColShowChange();
     }
-    document.getElementById("rowLabelSizePref").value =
-      resetVal.rowConfig.label_display_length;
-    document.getElementById("colLabelSizePref").value =
-      resetVal.colConfig.label_display_length;
-    document.getElementById("rowLabelAbbrevPref").value =
-      resetVal.rowConfig.label_display_method;
-    document.getElementById("colLabelAbbrevPref").value =
-      resetVal.colConfig.label_display_method;
-    document.getElementById("rowTopItems").value =
-      resetVal.rowConfig.top_items.toString();
-    document.getElementById("colTopItems").value =
-      resetVal.colConfig.top_items.toString();
+
+    for (let axis of [ "row", "col" ]) {
+      const axisResetVal = resetVal[axis+"Config"];
+      document.getElementById(axis+"LabelSizePref").value = axisResetVal.label_display_length;
+      document.getElementById(axis+"LabelAbbrevPref").value = axisResetVal.label_display_method;
+      document.getElementById(axis+"TopItems").value = axisResetVal.top_items_cv;
+    }
 
     // Reset the Data Matrix panel items
     for (var dl in resetVal.matrix.data_layer) {

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -21,6 +21,8 @@
   const CMM = NgChm.importNS("NgChm.CMM");
   const COMPAT = NgChm.importNS("NgChm.CM");
 
+  const debug = UTIL.getDebugFlag("upm");
+
   // The DIV that contains the entire Preferences Manager.
   const prefspanel = document.getElementById("prefs");
 
@@ -932,7 +934,7 @@
 
     // Add a change event handler for this tab.
     this.tabDiv.addEventListener("change", (ev) => {
-      console.log("DataLayersTab: Change handler", { target: ev.target });
+      if (debug) console.log("DataLayersTab: Change handler", { target: ev.target });
       for (const target of this.targetGen(ev)) {
         if (target.id == "dlPref_list") {
           showDataLayerPanel();
@@ -1361,7 +1363,7 @@
     axis,
     type,
   ) {
-    console.log ("setupLayerBreaksToPreset:", {key, colors, missingColor, axis, type });
+    if (debug) console.log ("setupLayerBreaksToPreset:", {key, colors, missingColor, axis, type });
     startChange();
     const keyaxis = key + (typeof axis == "undefined" ? "" : "_" + axis);
 
@@ -1391,11 +1393,11 @@
       for (let j = 0; j < i; j++) {
         const threshId = "breakPt" + j;
         const colorId = "color" + j;
-        console.log ("Getting breakpoint value", { elementId: `${keyaxis}_${threshId}_breakPref` });
+        if (debug) console.log ("Getting breakpoint value", { elementId: `${keyaxis}_${threshId}_breakPref` });
         const breakpoint = KAE(keyaxis,threshId,"breakPref").value;
         KAE(keyaxis,colorId,"colorPref").value = csTemp.getRgbToHex(csTemp.getColor(breakpoint));
       }
-      console.log ("Getting missing color", { elementId: keyaxis + "_missingColorPref" });
+      if (debug) console.log ("Getting missing color", { elementId: keyaxis + "_missingColorPref" });
       KAE(keyaxis,"missing","colorPref").value =
         csTemp.getRgbToHex(csTemp.getColor("Missing"));
     } else {
@@ -1611,7 +1613,7 @@
 
     // Add a click handler for the entire tab.
     this.tabDiv.addEventListener("click", (ev) => {
-      console.log("CovariatesPrefsTab: Click handler", { target: ev.target });
+      if (debug) console.log("CovariatesPrefsTab: Click handler", { target: ev.target });
       for (const target of this.targetGen(ev)) {
         if (target.id == "all_searchPref_btn") {
           // The user clicked on the filter covariates button.
@@ -1622,7 +1624,7 @@
     });
     // Add a change handler for the entire tab.
     this.tabDiv.addEventListener("change", (ev) => {
-      console.log("CovariatesPrefsTab: Change handler", { target: ev.target });
+      if (debug) console.log("CovariatesPrefsTab: Change handler", { target: ev.target });
       for (const target of this.targetGen(ev)) {
         if (target.classList.contains("ngchm-upm-show-covariate")) {
           // A "Show" checkbox on a covariate row changed.
@@ -2343,7 +2345,7 @@
     for (const { axis, key } of UPM.heatMap.genAllCovars()) {
       const showElement = KAE(key,axis,"showPref");
       const heightElement = KAE(key,axis,"heightPref");
-      console.log ("applyTabPrefs: ", { key, axis, show: showElement.value, height:heightElement.value, type: colorMapMan.getColorMap(axis,key).getType() });
+      if (debug) console.log ("applyTabPrefs: ", { key, axis, show: showElement.value, height:heightElement.value, type: colorMapMan.getColorMap(axis,key).getType() });
       if (heightElement.value === "0") {
         showElement.checked = false;
       }
@@ -2577,7 +2579,7 @@
     rowcolprefs.appendChild(prefContents);
 
     this.tabDiv.addEventListener("change", (ev) => {
-      console.log("RowsColsTab: Change handler", { target: ev.target });
+      if (debug) console.log("RowsColsTab: Change handler", { target: ev.target });
       for (const target of this.targetGen(ev)) {
         if (["row_DendroShowPref", "col_DendroShowPref"].includes(target.id)) {
           startChange();

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -2641,13 +2641,15 @@
 
     function genLabelSizeSelect(axis) {
       const sizes = [10, 15, 20, 25, 30, 35, 40];
-      return (
-        `<select class='ngchm-upm-input' name='${axis}_LabelSizePref' id='${axis}_LabelSizePref'>` +
-        sizes
-          .map((size) => `<option value='${size}'>${size} Characters</option>`)
-          .join() +
-        "</select>"
-      );
+      const id = KAID(axis,"LabelSizePref");
+      const sizeInput = UTIL.newElement('INPUT.ngchm-upm-input', {
+        type: "number",
+        id: id,
+        name: id,
+        min: 10,
+        max: 99,
+      });
+      return sizeInput;
     }
     function genLabelAbbrevSelect(axis) {
       return (
@@ -2700,6 +2702,13 @@
     for (const axis of ["row", "col"]) {
       let errorMsg = validateLabelTypeInputs(axis);
       if (errorMsg) return errorMsg;
+      const sizePref = KAE(axis,"LabelSizePref").value;
+      if (sizePref < 10) {
+        return ["ALL", "rowsColsPrefs", `ERROR: ${axis} label size too small (min: 10)`];
+      }
+      if (sizePref > 99) {
+        return ["ALL", "rowsColsPrefs", `ERROR: ${axis} label size too large (max: 99)`];
+      }
     }
     return null;
 

--- a/NGCHM/WebContent/javascript/custom/custom.js
+++ b/NGCHM/WebContent/javascript/custom/custom.js
@@ -561,6 +561,16 @@ function linkoutHelp () {
     );
   }
 
+  function openEnsemblGene(names) {
+    const ensgid = names[0];
+    const species = linkouts.getAttribute("bio.species") || "Homo_sapiens";
+    linkouts.openUrl(
+      "https://ensembl.org/" + species + "/Gene/Summary?db=core;g=" + ensgid,
+      "Ensembl",
+      { noframe: true },
+    );
+  }
+
   function searchEnsemblForTranscript(names) {
     const tname = names[0];
     const species = linkouts.getAttribute("bio.species") || "Homo_sapiens";
@@ -587,6 +597,13 @@ function linkoutHelp () {
         typeName: "bio.gene.hugo",
         selectMode: linkouts.SINGLE_SELECT,
         linkoutFn: searchEnsemblForGene,
+      },
+      // linkout for ensembl gene id
+      {
+        menuEntry: "Open Ensembl Page",
+        typeName: "bio.gene.ensembl",
+        selectMode: linkouts.SINGLE_SELECT,
+        linkoutFn: openEnsemblGene,
       },
       // linkouts for transcript ids
       {


### PR DESCRIPTION
- Enable the user to select a continuous covariate for the "top items" on an axis.
  - The entries with the largest values of that covariate will be the top items.
  - Allows for simpler and more flexible ways of picking the top items and provides for expanded capabilities in the future.
  - This originally removed the ability to specify the top items directly.
  - Following discussion in the group meeting, that ability was added back.
  - Too much code changed between the original removal and subsequent restoration to remove that from the commit history.

Many changes aimed at improving the readability and maintainability of the CompatibilityManager. and the UserPreference Manager.
- There is still more that could be done.

Added the ability for users to edit the types and visibility of label parts.

Fixed bugs:
- Error when clicking very close to the edge of a covariate bar.
- Suppress unnecessary warnings in PdfGenerator due to missing values in numeric covariates.
- Fix NG-CHMs generated by R with bad label types.
- Require user to change something before Apply/Reset buttons enabled in UserPreferenceManager.
- Fixed several bugs with values not resetting properly in UserPreferenceManager.

Allow label length to be any integer value between 10 and 99 for compatibility with Mary's R updates.

