### PR TITLE
Bump version number: 2.25.0 -> 2.26.0

### DIFF
--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -22,7 +22,7 @@
   // CURRENT VERSION NUMBER
   // WARNING: The line starting with 'CM.version = ' is used by .github/workflows/create-build-tag.yml for creating build tags
   // If making changes to the string 'CM.version = ', make corresponding changes to the 'start_string' in that action.
-  CM.version = "2.25.0"; // Please increment rightmost digit for each interim version
+  CM.version = "2.26.0"; // Please increment rightmost digit for each interim version
   CM.versionCheckUrl =
     "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
   CM.viewerAppUrl =


### PR DESCRIPTION
We have added a backwards-compatible feature: allowing for multi-panel initialization from the R package (#553)