### PR TITLE
Allow loading of multiple ngchms

### DIFF
--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -81,7 +81,7 @@
    * This callback draws the summary heat map.
    *********************************************************************************************/
   DET.processDetailMapUpdate = function (event, tile) {
-    if (event !== HEAT.Event_INITIALIZED) {
+    if (event === HEAT.Event_NEWDATA) {
       DET.flushDrawingCache(tile);
     }
   };

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -805,22 +805,4 @@
     createWebLoader(MMGR.WEB_SOURCE);
   }
 
-  // Special tooltip with content populated from the loaded heat map.
-  document.getElementById("mapName").addEventListener(
-    "mouseover",
-    (ev) => {
-      const heatMap = MMGR.getHeatMap();
-      UHM.hlp(
-        ev.target,
-        "Map Name: " +
-          (heatMap !== null
-            ? heatMap.getMapInformation().name
-            : "Not yet available") +
-          "<br><br>Description: " +
-          (heatMap !== null ? heatMap.getMapInformation().description : "N/A"),
-        350,
-      );
-    },
-    { passive: true },
-  );
 })();

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -4,10 +4,7 @@
 
   // MatrixManager is responsible for retrieving clustered heat maps.
   //
-  // NG-CHMs can be loaded from either:
-  // - the network, or
-  // - an ngchm (zip) file.
-  //
+
   // Once the maps have been loaded,
   // - MMGR.getAllHeatMaps() returns all maps.
   // - MMGR.getHeatMap() returns the current map.
@@ -16,23 +13,33 @@
   const MMGR = NgChm.createNS("NgChm.MMGR");
 
   const UTIL = NgChm.importNS("NgChm.UTIL");
-  const FLICK = NgChm.importNS("NgChm.FLICK");
   const HEAT = NgChm.importNS("NgChm.HEAT");
-  const CFG = NgChm.importNS("NgChm.CFG");
 
   const UHM = NgChm.importNS("NgChm.UHM");
   const COMPAT = NgChm.importNS("NgChm.CM");
 
-  //For web-based NGCHMs, we will create a Worker process to overlap I/O and computation.
-  MMGR.webLoader = null;
+  const debugMMGR = UTIL.getDebugFlag("mmgr");
+  const debugWorker = UTIL.getDebugFlag("mmgr-worker");
 
-  MMGR.WEB_SOURCE = "W";
-  MMGR.LOCAL_SOURCE = "L";
-  MMGR.FILE_SOURCE = "F";
+  // NG-CHMs can be loaded from the following types of sources:
+  //
+  MMGR.API_SOURCE = "api"; // NG-CHM can be accessed via API (e.g. shaidy server).
+  MMGR.WEB_SOURCE = "web"; // NG-CHM can be accessed in a web folder.
+  MMGR.ZIP_SOURCE = "zip"; // NG-CHM is stored in a zip archive.
 
-  MMGR.embeddedMapName = null;
-  MMGR.localRepository = "/NGCHM";
+  // The loader we are using to access all NG-CHMs. It will be created and
+  // initialized when we know the type of the source.
+  var ngchmLoader = null;
 
+  MMGR.getSource = function getSource() {
+    if (!ngchmLoader) {
+      throw `trying to get NG-CHM source before it has been determined`;
+    }
+    return ngchmLoader.fileSrc;
+  };
+
+  // Send request to a server (not necessarily the API server).
+  MMGR.callServlet = callServlet;
   function callServlet(verb, url, data) {
     const form = document.createElement("form");
     form.action = url;
@@ -49,37 +56,70 @@
     form.submit();
   }
 
-  //Create a worker thread to request/receive json data and tiles.  Using a separate
-  //thread allows the large I/O to overlap extended periods of heavy computation.
-  function createWebLoader (fileSrc) {
-    const debug = false;
-    const baseURL = getLoaderBaseURL(fileSrc);
+  // For both API_SOURCE and WEB_SOURCE, we will create a Worker process to overlap I/O and computation.
+  function WebLoader () {
+    this.worker = null;
+    this.mapsInitialized = 0;
+  }
 
-    var nameLookupURL = undefined;
-    if (UTIL.mapNameRef !== "") {
-      nameLookupURL = baseURL + "GetMapByName/" + UTIL.mapNameRef;
+  // Return the API endpoint for NG-CHMs loaded from an API endpoint.
+  MMGR.getApi = function () {
+    if (!ngchmLoader) {
+      throw `cannot get API before ngchmLoader defined`;
     }
+    if (ngchmLoader.fileSrc != MMGR.API_SOURCE) {
+      throw `cannot get API for source type ${ngchmLoader.fileSrc}`;
+    }
+    return ngchmLoader.baseURL;
+  };
+
+  // Create a worker thread to request/receive json data and tiles.  Using a separate
+  // thread allows large I/O to overlap extended periods of heavy computation.
+  //
+  // srcInfo.fileSrc determines the type of URLs used to load data/tiles.
+  // API_SOURCE:
+  // - The baseURL is srcInfo.options.api, which may be absolute or relative to document.location.origin.
+  // - Tile URLs look like "${baseURL}/GetTile?map=" + mapId + "&datalayer=" + job.layer + "&level=" + job.level + "&tile=" + job.tileName
+  // - JSON URLS look like "${baseURL}/GetDescriptor?map=" + mapId + "&type=" + name
+  // - API servers can also be used to lookup NG-CHMs by name
+  // WEB_SOURCE:
+  // - spec can be a comma-separated list of mapIds
+  // - For each NG-CHM, the baseURL is srcInfo.options.repository + "/"
+  // - Tile URLs look like "${baseURL}/" + mapId + "/" + job.layer + "/" + job.level + "/" + job.tileName+".tile"'
+  //   - (A very long time ago, tiles had .bin extensions. When we discoved many ngchm files were being blocked by
+  //     security scanners because of this, the extension was changed to .tile. If you look inside a very old ngchm file,
+  //     you might find tiles named .bin.  You will have to rename all such files from <x>.bin to <x>.tile.
+  // - JSON URLS look like "${baseURL}/" + name + ".json"
+  //
+  // ngChmsLoaded is a function that will be called when all requested NG-CHMs have loaded.
+  // updateCallbacks is an array of callbacks that will be passed to every heatmap created by
+  // the loader.
+  WebLoader.prototype.createWorker = function createWorker (srcInfo, updateCallbacks, ngChmsLoaded) {
+    const fileSrc = srcInfo.fileSrc;
+    this.baseURL = getLoaderBaseURL(fileSrc);
+    this.fileSrc = fileSrc;
+    this.updateCallbacks = updateCallbacks;
+    this.ngChmsLoaded = ngChmsLoaded;
 
     // Define worker script.
     // (it was seen to cause problems to include "use strict" in wS [code string passed to web worker])
-    let wS = `const debug = ${debug};`;
+    let wS = `const debug = ${debugWorker};`;
     wS += `const maxActiveRequests = 2;`; // Maximum number of tile requests that can be in flight concurrently
     wS += `var active = 0;`; // Number of tile requests in flight
     wS += `const pending = [];`; // Additional tile requests
-    wS += `const baseURL = "${baseURL}";`; // Base URL to prepend to requests.
-    wS += `var mapId = "${UTIL.mapId}";`; // Map ID.
-    //wS += `const mapNameRef = "${UTIL.mapNameRef}";`; // Map name (if specified).
-    wS += `const nameLookupURL = "${nameLookupURL}";`;
+    wS += `const baseURL = "${this.baseURL}";`; // Base URL to prepend to requests.
+    if (fileSrc == MMGR.API_SOURCE) {
+      wS += `const nameLookupURL = "${this.baseURL}/GetMapByName/";`;
+    }
 
     // Create a function that determines the get tile request.
-    // Body of function depends on the fileSrc of the NG-CHM.
+    // Body of function depends on fileSrc.
     wS += "function tileURL(job){return baseURL+";
-    if (fileSrc === MMGR.WEB_SOURCE) {
+    if (fileSrc === MMGR.API_SOURCE) {
       wS +=
-        '"GetTile?map=" + mapId + "&datalayer=" + job.layer + "&level=" + job.level + "&tile=" + job.tileName';
+        '"GetTile?map=" + job.mapId + "&datalayer=" + job.layer + "&level=" + job.level + "&tile=" + job.tileName';
     } else {
-      // [bmb] Is LOCAL_SOURCE ever used?  ".bin" files were obsoleted years ago.
-      wS += 'job.layer+"/"+job.level+"/"+job.tileName+".bin"';
+      wS += 'job.mapId+"/"+job.layer+"/"+job.level+"/"+job.tileName+".tile"';
     }
     wS += ";}";
 
@@ -100,10 +140,10 @@
             loadTile(pending.shift());
           }
           if (req.status != 200) {
-            postMessage({ op: "tileLoadFailed", job });
+            postMessage({ op: "tileLoadFailed", mapId: job.mapId, job });
           } else {
             // Transfer buffer to main thread.
-            postMessage({ op: "tileLoaded", job, buffer: req.response }, [
+            postMessage({ op: "tileLoaded", mapId: job.mapId, job, buffer: req.response }, [
               req.response,
             ]);
           }
@@ -115,26 +155,26 @@
 
     // Create a function that determines the get JSON file request.
     // Body of function depends on the fileSrc of the NG-CHM.
-    wS += "function jsonFileURL(name){return baseURL+";
-    if (fileSrc === MMGR.WEB_SOURCE) {
+    wS += "function jsonFileURL(name, mapId){return baseURL+";
+    if (fileSrc === MMGR.API_SOURCE) {
       wS += '"GetDescriptor?map=" + mapId + "&type=" + name';
     } else {
-      wS += 'name+".json"';
+      wS += 'mapId+"/"+name+".json"';
     }
     wS += ";}";
 
     // The following function is stringified and sent to the web loader.
-    function loadJson(name) {
+    function loadJson(name, mapId, mapName) {
       const req = new XMLHttpRequest();
-      req.open("GET", jsonFileURL(name), true);
+      req.open("GET", jsonFileURL(name, mapId), true);
       req.responseType = "json";
       req.onreadystatechange = function () {
         if (req.readyState == req.DONE) {
           if (req.status != 200) {
-            postMessage({ op: "jsonLoadFailed", name });
+            postMessage({ op: "jsonLoadFailed", mapName, mapId, name });
           } else {
             // Send json to main thread.
-            postMessage({ op: "jsonLoaded", name, json: req.response });
+            postMessage({ op: "jsonLoaded", mapName, mapId, name, json: req.response });
           }
         }
       };
@@ -148,322 +188,282 @@
         console.log({ m: "Worker: got message", e, t: performance.now() });
       if (e.data.op === "loadTile") {
         loadTile(e.data.job);
-      } else if (e.data.op === "loadJSON") {
-        loadJson(e.data.name);
+      } else if (e.data.op === "loadMapById") {
+        getConfigAndData(e.data.mapId, "");
+      } else if (e.data.op === "loadMapByName") {
+        getMapId(e.data.mapName);
+      } else {
+        console.error ("WebWorker: Unknown message received", { message: e.data });
       }
     }
     wS += handleMessage.toString();
 
     // This function will be stringified and sent to the web loader.
-    function getConfigAndData() {
+    function getConfigAndData(mapId, mapName) {
       // Retrieve all map configuration data.
-      loadJson("mapConfig");
+      loadJson("mapConfig", mapId, mapName);
       // Retrieve all map supporting data (e.g. labels, dendros) from JSON.
-      loadJson("mapData");
+      loadJson("mapData", mapId, mapName);
     }
     wS += getConfigAndData.toString();
 
     // If the map was specified by name, send the code to find the
     // map's id by name.  Otherwise just get the map's config
     // and data.
-
-    function getMapId(url) {
+    function getMapId(mapName) {
+      const url = nameLookupURL + mapName;
       fetch(url).then((res) => {
         if (res.status === 200) {
           res.json().then((mapinfo) => {
             mapId = mapinfo.data.id;
-            getConfigAndData();
+            getConfigAndData(mapId, mapName);
           });
         } else {
-          postMessage({ op: "jsonLoadFailed", name: "GetMapByName" });
+          postMessage({ op: "jsonLoadFailed", name: "GetMapByName", mapName });
         }
       });
     }
-    wS += getMapId.toString();
-
-    if (UTIL.mapId === "" && UTIL.mapNameRef !== "") {
-      wS += getMapId.name + "(nameLookupURL);";
-    } else {
-      wS += getConfigAndData.name + "();";
+    if (fileSrc == MMGR.API_SOURCE) {
+      wS += getMapId.toString();
     }
 
     wS += `onmessage = ${handleMessage.name};`;
-    if (debug)
+    if (debugWorker)
       wS += `console.log ({ m:'TileLoader loaded', t: performance.now() });`;
 
     // Create blob and start worker.
     const blob = new Blob([wS], { type: "application/javascript" });
-    if (debug) console.log({ m: "MMGR.createWebLoader", blob, wS });
-    MMGR.webLoader = new Worker(URL.createObjectURL(blob));
+    if (debugWorker) console.log({ m: "WebLoader.createWorker", blob, wS });
+    this.worker = new Worker(URL.createObjectURL(blob));
     // It is possible for the web worker to post a reply to the main thread
     // before the message handler is defined.  Stash any such messages away
     // and play them back once it has been.
-    const pendingMessages = [];
-    MMGR.webLoader.onmessage = function (e) {
-      pendingMessages.push(e);
-    };
-    MMGR.webLoader.setMessageHandler = function (mh) {
-      // Run asychronously so that the heatmap can be defined before processing messages.
-      setTimeout(function () {
-        while (pendingMessages.length > 0) {
-          mh(pendingMessages.shift());
+    {
+      const thisLoader = this;
+      const pendingMessages = [];
+
+      // Create a temporary message handler that will buffer messages until the
+      // application can set the actual message handler (via setMessageHandler).
+      thisLoader.worker.onmessage = function (e) {
+        if (debugWorker) {
+          console.log ('Saving pending message', { data: e.data });
         }
-        MMGR.webLoader.onmessage = mh;
-      }, 0);
-    };
+        if (e.data.op === "jsonLoaded" && e.data.name == "mapConfig") {
+          if (debugWorker) {
+            console.log ('Peeking at mapConfig', { data: e.data });
+          }
+          // Currently need this to create the first HeatMap, which will
+          // initialize the broader environment, which will then initiate
+          // creation of the full message handler.  Not ideal.
+          thisLoader.getHeatMap (e.data);
+        }
+        pendingMessages.push(e);
+      };
+
+      // Define an instance method for setting the message handler. The instance
+      // method has access to pendingMessages, which is not otherwise accessible.
+      //
+      // When the specified messageHandler is set, it is first called with each of
+      // the messages in pendingMessages, so that all messages are processed in
+      // order of receipt.
+      thisLoader.setMessageHandler = function (mh) {
+        // Run asychronously so that the heatmap can be defined before processing messages.
+        setTimeout(function () {
+          while (pendingMessages.length > 0) {
+            mh(pendingMessages.shift());
+          }
+          thisLoader.worker.onmessage = mh;
+        }, 0);
+      };
+    }
 
     // Called locally.
-    function getLoaderBaseURL(fileSrc) {
-      var URL;
-      if (fileSrc == MMGR.WEB_SOURCE) {
+    function getLoaderBaseURL() {
         // Because a tile worker thread doesn't share our origin, we have to pass it
-        // an absolute URL, and to substitute in the CFG.api variable, we want to
+        // an absolute URL, and to substitute in the srcInfo.options.api variable, we want to
         // build the URL using the same logic as a browser for relative vs. absolute
         // paths.
-        URL = document.location.origin;
-        if (CFG.api[0] !== "/") {
-          // absolute
+      let URL = document.location.origin;
+      const api = srcInfo.options.repository;
+      if (api.substring(0,4) == "http") {
+        if (!UTIL.isValidURL(api)) {
+          throw `badly formed URL ${api}`;
+        }
+        URL = api;
+      } else {
+        if (api[0] !== "/") {
+          // Convert a path relative to the document location to an absolute path
+          // on the same server.
           URL +=
             "/" +
-            window.location.pathname.substr(
+            window.location.pathname.substring(
               1,
-              window.location.pathname.lastIndexOf("/"),
+              window.location.pathname.lastIndexOf("/")+1,
             );
         }
-        URL += CFG.api;
-      } else {
-        console.log(`getLoaderBaseURL: fileSrc==${fileSrc}`);
-        URL = MMGR.localRepository + "/" + MMGR.embeddedMapName + "/";
+        URL += api;
+      }
+      // Ensure URL is terminated by a slash.
+      if (URL[URL.length-1] != "/") {
+        URL += "/";
       }
       return URL;
     }
-  }
+    this.connectMessageHandler();
+  };
+
+  WebLoader.prototype.openMapsById = function (ids) {
+    for (const mapId of ids) {
+      this.worker.postMessage({ op: "loadMapById", mapId });
+    }
+  };
+  WebLoader.prototype.openMapsByName = function (names) {
+    for (const mapName of names) {
+      this.worker.postMessage({ op: "loadMapByName", mapName });
+    }
+  };
+
+  const heatMapCache = new Map();
+  WebLoader.prototype.getHeatMap = function getHeatMap (msgData) {
+    let map;
+    if (heatMapCache.has(msgData.mapId)) {
+      map = heatMapCache.get(msgData.mapId);
+    } else {
+      map = new HEAT.HeatMap(
+        msgData.mapName,  // Speculative.
+        this.updateCallbacks,
+        this.getTileLoaderGetter(msgData.mapId),
+        () => this.noteInitialized(),
+      );
+      // Save loadSpec details in case we can and want to save it later.
+      map.loadSpec = { mapId: msgData.mapId, mapName: msgData.mapName };
+      heatMapCache.set(msgData.mapId, map);
+    }
+    if (msgData.op == "jsonLoaded" && msgData.name == "mapConfig") {
+      map.mapName = msgData.json.data_configuration.map_information.name;
+    }
+    return map;
+  };
+
+  // Returns a function that
+  // - takes a HeatMap as a parameter, and
+  // - returns a function that will load a tile
+  //   for that HeatMap.
+  //
+  // In this case, the mapId is not known to the
+  // HeatMap, so we have an extra level of
+  // encapsulation and the HeatMap parameter is
+  // not used.
+  //
+  WebLoader.prototype.getTileLoaderGetter = function getTileLoaderGetter (mapId) {
+    const worker = this.worker;
+    return function getTileLoader (heatMap) {
+      return function loadTile (job) {
+        if (debugWorker) {
+          console.log ("loadTile " + mapId, { job });
+        }
+        // Inject the mapId into the job.
+        job.mapId = mapId;
+        worker.postMessage({ op: "loadTile", job });
+      };
+    };
+  };
+
+  WebLoader.prototype.noteInitialized = function () {
+    this.mapsInitialized++;
+    if (debugWorker) {
+      console.log (`WebLoader: ${this.mapsInitialized}/${this.mapCount} maps initialized`);
+    }
+    if (this.mapsInitialized == this.mapCount) {
+      this.ngChmsLoaded.call(null, [...heatMapCache.values()]);
+    }
+  };
 
   // Handle replies from tileio worker.
-  function connectWebLoader(heatMap, addMapConfig, addMapData) {
-    const debug = false;
-    const jsonSetterFunctions = {
-      mapConfig: addMapConfig,
-      mapData: addMapData,
-    };
-    MMGR.webLoader.setMessageHandler(function (e) {
-      if (debug) console.log({ m: "Received message from webLoader", e });
+  WebLoader.prototype.connectMessageHandler = function connectMessageHandler() {
+    if (debugWorker) console.log("Connecting worker message handler");
+    const theLoader= this;
+    this.setMessageHandler(function (e) {
+      if (debugWorker) console.log("Received message from WebLoader: " + e.data.op, { data: e.data });
+      if (!e.data.mapId) {
+        console.warn ('webworker message does not have expected heatmap id');
+      }
+      if (!e.data.mapName && !["tileLoaded","tileLoadFailed"].includes(e.data.op)) {
+        console.warn ('webworker message does not have expected heatmap name');
+      }
+      const heatMap = theLoader.getHeatMap (e.data);
       if (e.data.op === "tileLoaded") {
         const tiledata = new Float32Array(e.data.buffer);
         heatMap.tileRequestComplete(e.data.job.tileCacheName, tiledata);
       } else if (e.data.op === "tileLoadFailed") {
         heatMap.tileRequestComplete(e.data.job.tileCacheName, null);
       } else if (e.data.op === "jsonLoaded") {
-        if (!jsonSetterFunctions.hasOwnProperty(e.data.name)) {
-          console.log({ m: "connectWebLoader: unknown JSON request", e });
-          return;
-        }
-        jsonSetterFunctions[e.data.name](heatMap, e.data.json);
+        heatMap.addJson (e.data.name, e.data.json);
       } else if (e.data.op === "jsonLoadFailed") {
         console.error(
-          `Failed to get JSON file ${e.data.name} for ${heatMap.mapName} from server`,
+          `Failed to get JSON file ${e.data.name} for ${e.data.mapName} (${heatMap.mapName}) from server`,
         );
         UHM.mapNotFound(heatMap.mapName);
       } else {
-        console.log({ m: "connectWebLoader: unknown op", e });
+        console.error("connectWebLoader: unknown op", { data: e.data });
       }
     });
-  }
+  };
 
-  /**********************************************************************************
-   * FUNCTION - zipAppDownload: The user clicked on the "Download Viewer" button.
-   * Hide the button and initiate download of the NG-CHM Viewer application.
-   **********************************************************************************/
-  MMGR.zipAppDownload = zipAppDownload;
-  function zipAppDownload() {
-    downloadFileApplication();
-  }
-
-  // Initiate download of NGCHM File Viewer application zip
-  function downloadFileApplication() {
-    const heatMap = MMGR.getHeatMap();
-    if (typeof NgChm.galaxy !== "undefined") {
-      // Current viewer is embedded within Galaxy.
-      // FIXME: BMB: Use a better way to determine Galaxy embedding.
-      window.open(
-        "/plugins/visualizations/mda_heatmap_viz/static/ngChmApp.zip",
-      );
-    } else if (!heatMap || heatMap.source() === MMGR.FILE_SOURCE) {
-      // Heat map came from a disk file, not from a server.
-      // (This does not mean the viewer is not from a server, so this could be
-      // refined further for that case i.e. the "api" condition might be more appropriate)
-      // Use full URL, which must be complete!
-      callServlet("GET", COMPAT.viewerAppUrl, false);
-    } else {
-      // Heat map came from a server.
-      // Use server "api" + special endpoint name
-      callServlet("GET", CFG.api + "ZipAppDownload", false);
-    }
-  }
-
-  /**********************************************************************************
-   * FUNCTION - viewerAppVersionExpiredNotification: This function handles all of the tasks
-   * necessary display a modal window whenever a user's version of the file application
-   * has been superceded and a new version of the file application should be downloaded.
-   **********************************************************************************/
-  function viewerAppVersionExpiredNotification(oldVersion, newVersion) {
-    const title = "New NG-CHM File Viewer Version Available";
-    const text =
-      "<br>The version of the NG-CHM File Viewer application that you are running (" +
-      oldVersion +
-      ") has been superceded by a newer version (" +
-      newVersion +
-      "). You will be able to view all pre-existing heat maps with this new backward-compatible version. However, you may wish to download the latest version of the viewer.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>";
-    showDownloadViewerNotification(title, text);
-  }
-
-  MMGR.showDownloadViewerNotification = showDownloadViewerNotification;
-  function showDownloadViewerNotification(title, bodyText) {
-    const msgBox = UHM.initMessageBox();
-    msgBox.classList.add("file-viewer");
-    UHM.setMessageBoxHeader(title);
-    UHM.setMessageBoxText(bodyText);
-    UHM.setMessageBoxButton(
-      "download",
-      { type: "text", text: "Download Viewer" },
-      "Download viewer button",
-      () => {
-        MMGR.zipAppDownload();
-        UHM.messageBoxCancel();
-      },
-    );
-    UHM.setMessageBoxButton(
-      "cancel",
-      { type: "text", text: "Cancel", default: true },
-      "Cancel button",
-      UHM.messageBoxCancel,
-    );
-    UHM.displayMessageBox();
-  }
-
-  // Compare the version of this NG-CHM viewer to the one recent available.
-  // Notify the user if they're using a standalone viewer and it is out of date.
+  // Create
+  // Determine whether srcInfo specifies that the NG-CHM(s) will be loaded from the
+  // network.
   //
-  function checkViewerVersion(heatMap) {
-    const debug = false;
-    const req = new XMLHttpRequest();
-    const baseVersion = COMPAT.version.replace(/-.*$/, "");
-    req.open("GET", COMPAT.versionCheckUrl + baseVersion, true);
-    req.onreadystatechange = function () {
-      if (req.readyState == req.DONE) {
-        if (req.status != 200) {
-          //Log failure, otherwise, do nothing.
-          console.log("Failed to get software version: " + req.status);
-        } else {
-          const latestVersion = req.response;
-          if (debug)
-            console.log("Compare versions", {
-              latestVersion,
-              thisVersion: COMPAT.version,
-              newer: newer(latestVersion, baseVersion),
-            });
-          if (
-            newer(latestVersion, baseVersion) &&
-            typeof NgChm.galaxy === "undefined" &&
-            MMGR.embeddedMapName === null &&
-            heatMap.source() != MMGR.WEB_SOURCE
-          ) {
-            viewerAppVersionExpiredNotification(COMPAT.version, latestVersion);
-          }
-        }
-      }
-    };
-    req.send();
-
-    // v1 and v2 are version numbers consisting of integers separated by periods.
-    // This function returns true if v1 is greater than v2.
-    function newer(v1, v2) {
-      // Split each into fields and convert each field to integer.
-      v1 = v1.split(".").map((v) => v | 0);
-      v2 = v2.split(".").map((v) => v | 0);
-      for (let i = 0; ; i++) {
-        if (i == v1.length && i == v2.length) return false; // Reached end of both with no differences.
-        if (i == v2.length) return true; // Exhausted v2 (we treat 2.21.0 > 2.21)
-        if (i == v1.length) return false; // Exhausted v1.
-        if (v1[i] > v2[i]) return true;
-        if (v1[i] < v2[i]) return false;
+  // If not, the function returns false and no further actions are taken.
+  // - Determine
+  //
+  // Otherwise:
+  // - A web worker is created.
+  // - Loading of the map(s)' configuration and data is initiated.
+  // - The function returns true.
+  //
+  WebLoader.prototype.loadWebMaps =
+  function loadWebMaps (srcInfo, updateCallbacks, mapsReady) {
+    if (debugMMGR || debugWorker) {
+      console.log ("Loading web maps", { srcInfo });
+    }
+    let reason = 'Trying to load web maps but ';
+    // - Embedded && sourceType == WEB_SOURCE.
+    // - Not embedded && either ?map or ?name options specified.
+    if (srcInfo.embedded) {
+      if (srcInfo.options.sourceType == MMGR.WEB_SOURCE) {
+        srcInfo.fileSrc = MMGR.WEB_SOURCE;
+        srcInfo.mapIds = srcInfo.spec.split(',');
+        srcInfo.mapNames = [];
+        ngchmLoader.createWorker(srcInfo, updateCallbacks, mapsReady);
+        ngchmLoader.mapCount = srcInfo.mapIds.length;
+        ngchmLoader.openMapsById (srcInfo.mapIds);
+        return;
+      } else {
+        reason += `sourceType ${srcInfo.options.sourceType} is not an option for embedded maps.`;
       }
     }
-  }
-
-  // Load the JSON files from the heatMap's zip file.
-  // First constructs an index of the zip file entries in fileInfo.zipFiles.
-  // Then loads the mapConfig and mapData json files and calls
-  // addMapConfig and addMapData respectively to load them into
-  // the heatMap.
-  //
-  // On success, returns fileInfo object for fetching tiles.
-  function loadNgChmFromZip(chmFile, heatMap, addMapConfig, addMapData) {
-    if (chmFile.size === 0) {
-      UHM.mapLoadError(chmFile.name, "File is empty (zero bytes)");
+    else if (srcInfo.mapIds.length + srcInfo.mapNames.length > 0) {
+      srcInfo.fileSrc = srcInfo.options.sourceType == MMGR.API_SOURCE ? MMGR.API_SOURCE : MMGR.WEB_SOURCE;
+      ngchmLoader.mapCount = srcInfo.mapIds.length + srcInfo.mapNames.length;
+      ngchmLoader.createWorker(srcInfo, updateCallbacks, mapsReady);
+      if (srcInfo.mapIds.length > 0) {
+        ngchmLoader.openMapsById (srcInfo.mapIds);
+      }
+      if (srcInfo.mapNames.length > 0) {
+        ngchmLoader.openMapsByName (srcInfo.mapNames);
+      }
       return;
+    } else {
+      reason += `no mapIds or mapNames were specified`;
     }
-    const reader = new zip.ZipReader(new zip.BlobReader(chmFile));
-    const fileInfo = {};
-    // get all entries from the zip
-    reader
-      .getEntries()
-      .then(function (entries) {
-        //Inspect the first entry path to grab the true heatMapName.
-        //The user may have renamed the zip file OR it was downloaded
-        //as a second+ generation of a file by the same name (e.g. with a " (1)"
-        //in the name).
-        if (entries.length == 0) {
-          UHM.mapLoadError(chmFile.name, "Empty zip file");
-          return;
-        }
-        const entryName = entries[0].filename;
-        const slashIdx = entryName.indexOf("/");
-        if (slashIdx < 0) {
-          UHM.mapLoadError(chmFile.name, "File format not recognized");
-          return;
-        }
-        fileInfo.mapName = entryName.substring(0, slashIdx);
-        fileInfo.zipFiles = {};
-        for (let i = 0; i < entries.length; i++) {
-          fileInfo.zipFiles[entries[i].filename] = entries[i];
-        }
-        const mapConfigName = fileInfo.mapName + "/mapConfig.json";
-        const mapDataName = fileInfo.mapName + "/mapData.json";
-        if (
-          mapConfigName in fileInfo.zipFiles &&
-          mapDataName in fileInfo.zipFiles
-        ) {
-          heatMap.mapName = fileInfo.mapName;
-          setTimeout(() => {
-            zipFetchJson(
-              heatMap,
-              fileInfo.zipFiles[mapConfigName],
-              addMapConfig,
-            );
-          });
-          setTimeout(() => {
-            zipFetchJson(heatMap, fileInfo.zipFiles[mapDataName], addMapData);
-          });
-          return fileInfo;
-        } else {
-          UHM.mapLoadError(chmFile.name, "Missing NGCHM content");
-        }
-      })
-      .catch(function (error) {
-        console.log("Zip file read error " + error);
-        UHM.mapLoadError(chmFile.name, error);
-      });
-    return fileInfo;
-
-      // Helper function to fetch a json file from zip file using a zip file entry.
-      function zipFetchJson(heatMap, entry, setterFunction) {
-        entry.getData(new zip.TextWriter(), {}).then((text) => {
-          setterFunction(heatMap, JSON.parse(text));
-        });
-      }
+    UHM.mapLoadError("", reason);
   }
 
+  // Save an NG-CHM loaded from a zip file.
+  //
+  // heatMap is current heatMap.
+  // mapConfig is mapConfig of current map with current state.
   MMGR.zipSaveMapProperties = zipSaveMapProperties;
   function zipSaveMapProperties(heatMap, mapConf, progressMeter) {
     // Start the zip file creation process by instantiating a
@@ -505,7 +505,7 @@
     // to the zipWriter.
     function addAllZipEntries(zipWriter) {
       return new Promise((resolve, reject) => {
-        const zipKeys = Object.keys(heatMap.zipFiles);
+        const zipKeys = Object.keys(ngchmLoader.zipFiles);
 
         // Add the first entry in zipFiles.  It will add
         // the next entry when it completes and so on,
@@ -529,22 +529,26 @@
           } else {
             // Get a promise to add the zip entry depending on its type.
             const keyVal = zipKeys[fileIndex];
-            const entry = heatMap.zipFiles[keyVal];
+            const entry = ngchmLoader.zipFiles[keyVal];
             let promise;
             if (keyVal.indexOf("bin") >= 0 || keyVal.indexOf("tile") >= 0) {
               // Directly add all binary zip entries directly to the new zip file
               promise = zipCopyBin(entry);
-            } else if (keyVal.indexOf("mapConfig") >= 0) {
-              // For mapConfig, add the modified config data.
+            } else if (keyVal.indexOf("/mapConfig.json") > 0) {
+              const mapName = keyVal.substring(0, keyVal.indexOf("/mapConfig.json"));
+              const map = getHeatMapByName (mapName);
+              // Add the modified config data.
               promise = addTextContents(
                 entry.filename,
-                JSON.stringify(mapConf || heatMap.mapConfig),
+                JSON.stringify(heatMap == map ? (mapConf || heatMap.mapConfig) : map.mapConfig),
               );
-            } else if (keyVal.indexOf("mapData") >= 0) {
-              // For mapData, add the potentially modified data.
+            } else if (keyVal.indexOf("/mapData.json") >= 0) {
+              // Add the potentially modified data.
+              const mapName = keyVal.substring(0, keyVal.indexOf("/mapData.json"));
+              const map = getHeatMapByName (mapName);
               promise = addTextContents(
                 entry.filename,
-                JSON.stringify(heatMap.mapData),
+                JSON.stringify(map.mapData),
               );
             } else {
               // Directly add all other text zip entries to the new zip file.
@@ -555,6 +559,16 @@
           }
         }
       });
+
+      function getHeatMapByName (name) {
+        for (const heatMap of MMGR.getAllHeatMaps()) {
+          const info = heatMap.getMapInformation();
+          if (info.name == name) {
+            return heatMap;
+          }
+        }
+        return null;
+      }
 
       // Return a promise to copy the text zip entry
       // to the new zip file.
@@ -588,7 +602,7 @@
   function webSaveMapProperties(heatMap) {
     const jsonData = JSON.stringify(heatMap.getMapConfig());
     var success = "false";
-    var name = CFG.api + "SaveMapProperties?map=" + heatMap.mapName;
+    var name = MMGR.getApi() + "SaveMapProperties?map=" + heatMap.mapName;
     var req = new XMLHttpRequest();
     req.open("POST", name, false);
     req.setRequestHeader("Content-Type", "application/json");
@@ -596,7 +610,7 @@
       if (req.readyState == req.DONE) {
         if (req.status != 200) {
           console.log(
-            "Failed in call to save propeties from server: " + req.status,
+            "Failed in call to save properties from server: " + req.status,
           );
           success = "false";
         } else {
@@ -610,123 +624,195 @@
 
   MMGR.zipMapProperties = zipMapProperties;
   function zipMapProperties(heatMap, jsonData) {
-    var success = "";
-    var name = CFG.api + "ZippedMap?map=" + heatMap.mapName;
-    callServlet("POST", name, jsonData);
+    const url = MMGR.getApi() + "ZippedMap?map=" + heatMap.loadSpec.mapId;
+    callServlet("POST", url, jsonData);
     return true;
   }
 
+  // CLASS ZipFileLoader.
+  //
+  function ZipFileLoader() {
+    this.fileSrc = MMGR.ZIP_SOURCE;
+    this.mapNames = [];
+    this.zipFiles = {};
+  }
+
+  // Load the NG-CHMs contained in an open zip file.
+  //
+  // - Adds an entry for each file in the zip file to zipFiles.
+  // - Determines all the top-level directories in zipFiles.
+  // - Determines which directories contain an NG-CHM.
+  // - Initiates loading of those NG-CHMs.
+  // - Returns.
+  //
+  // - Later, when all the maps have been initialized, an array
+  //   containing the loaded maps is passed to ngChmsLoaded().
+  //
+  ZipFileLoader.prototype.readZipFile = async function readZipFile (chmFile, updateCallbacks, ngChmsLoaded) {
+    if (chmFile.size === 0) {
+      UHM.mapLoadError(chmFile.name, "File is empty (zero bytes)");
+      return;
+    }
+    const reader = new zip.ZipReader(new zip.BlobReader(chmFile));
+    const loader = this;
+    // get all entries from the zip
+    return reader
+      .getEntries()
+      .then(function (entries) {
+        //Inspect the first entry path to grab the true heatMapName.
+        //The user may have renamed the zip file OR it was downloaded
+        //as a second+ generation of a file by the same name (e.g. with a " (1)"
+        //in the name).
+        if (entries.length == 0) {
+          throw "Empty zip file";
+        }
+        const dirs = [];
+        for (let i = 0; i < entries.length; i++) {
+          // Save entry to zipFiles.
+          const entryName = entries[i].filename;
+          loader.zipFiles[entryName] = entries[i];
+          // Collect all top-level directory names.
+          const slashIdx = entryName.indexOf("/");
+          if (slashIdx > 0) {
+            const dirName = entryName.substring(0,slashIdx);
+            if (!dirs.includes(dirName)) {
+              dirs.push (dirName);
+            }
+          }
+        }
+        // Determine which directories contain an NGCHM.
+        for (const dir of dirs) {
+          const mapConfigName = dir + "/mapConfig.json";
+          if (mapConfigName in loader.zipFiles) {
+            loader.mapNames.push (dir);
+          }
+        }
+        // If none do, it's not an ngchm file.
+        if (loader.mapNames.length == 0) {
+          throw "File format not recognized";
+        }
+        // Create the heatmaps.
+        loader.createHeatMaps(updateCallbacks, ngChmsLoaded);
+      })
+      .catch(function (error) {
+        console.error ("Error opening zip file: " + error);
+        UHM.mapLoadError(chmFile.name, error);
+      });
+  };
+
+  // Create the heat maps that were found in the zip file.
+  // - Keeps track of the created maps and how many have been
+  //   initialized.
+  // - When all maps have been initialized, passes the array of
+  //   maps to ngChmsLoaded.
+  ZipFileLoader.prototype.createHeatMaps =
+    function createHeatMaps(updateCallbacks, ngChmsLoaded) {
+      // zipFile might contain multiple maps.
+      const numMaps = this.mapNames.length;
+      const maps = [];
+      let numInitialized = 0;
+      // Maps will initialize asynchronously.
+      for (const heatMapName of this.mapNames) {
+        maps.push (new HEAT.HeatMap(
+          heatMapName,
+          updateCallbacks,
+          this.getTileLoaderGetter(),
+          noteInitialized
+        ));
+      }
+      // Helper function.
+      function noteInitialized () {
+        numInitialized++;
+        if (numInitialized == numMaps) {
+          // All maps initialized.
+          ngChmsLoaded(maps);
+        }
+      }
+    };
+
+  // Initiates loading of the heatMap's configuration files from the zip file.
+  ZipFileLoader.prototype.loadConfigFiles = function loadNgChmFromZip(heatMap) {
+    const mapConfigName = heatMap.mapName + "/mapConfig.json";
+    const mapDataName = heatMap.mapName + "/mapData.json";
+    if (mapConfigName in this.zipFiles && mapDataName in this.zipFiles) {
+      setTimeout(() => { this.zipFetchJson(heatMap, "mapConfig"); });
+      setTimeout(() => { this.zipFetchJson(heatMap, "mapData"); });
+    } else {
+      UHM.mapLoadError(heatMap.mapName, "Missing NG-CHM content");
+    }
+  };
+
+  // Fetch a json file "${name}.json" for ${heatMap} from the zip file
+  // and add it to the heatmap.
+  ZipFileLoader.prototype.zipFetchJson = function zipFetchJson(heatMap, name) {
+    const entry = this.zipFiles[`${heatMap.mapName}/${name}.json`];
+    entry.getData(new zip.TextWriter(), {}).then((text) => {
+      heatMap.addJson (name, JSON.parse(text));
+    });
+  };
+
+  // Returns a function that
+  // - takes a HeatMap as a parameter.
+  // - initiates loading of the HeatMap's configuration files.
+  // - returns a function for loading tiles for that HeatMap
+  //   from the zip file.
+  //
+  ZipFileLoader.prototype.getTileLoaderGetter = function getTileLoaderGetter() {
+    const loader = this;
+    return function getTileLoader (heatMap) {
+      loader.loadConfigFiles(heatMap);
+      return function loadTile (job) {
+        loader.fetchTile (heatMap, job);
+      };
+    };
+  };
+
+  // Read the tile specified by job from the HeatMap's zip file.
+  //
+  // Calls heatMap.tileRequestComplete when done.
+  //
+  ZipFileLoader.prototype.fetchTile = function zipFetchTile(heatMap, job) {
+    const debug = false;
+    const baseName =
+      heatMap.mapName + "/" + job.layer + "/" + job.level + "/" + job.tileName;
+    let entry = this.zipFiles[baseName + ".tile"];
+    if (typeof entry === "undefined") {
+      // Tiles in ancient NG-CHMs had a .bin extension.
+      entry = this.zipFiles[baseName + ".bin"];
+    }
+    if (typeof entry === "undefined") {
+      console.error("Request for unknown zip tile: " + baseName);
+      heatMap.tileRequestComplete(job.tileCacheName, null);
+    } else {
+      setTimeout(function getEntryData() {
+        entry
+          .getData(new zip.BlobWriter())
+          .then(function (blob) {
+            if (debug) console.log("Got blob for tile " + job.tileCacheName);
+            const fr = new FileReader();
+
+            fr.onerror = function () {
+              console.error("Error in zip file reader", fr.error);
+              heatMap.tileRequestComplete(job.tileCacheName, null);
+            };
+            fr.onload = function (e) {
+              const arrayBuffer = fr.result;
+              const far32 = new Float32Array(arrayBuffer);
+              heatMap.tileRequestComplete(job.tileCacheName, far32);
+            };
+            fr.readAsArrayBuffer(blob);
+          })
+          .catch((error) => {
+            console.error("Error getting zip tile data", error);
+          });
+      }, 1);
+    }
+  };
+
   // Matrix Manager block.
   {
+    var allHeatMaps = [];
     var heatMap = null;
-    var mapStatusDB = new WeakMap();
-
-    function getMapStatus(heatMap) {
-      let status = mapStatusDB.get(heatMap);
-      if (!status) {
-        status = {
-          flickInitialized: false,
-        };
-        mapStatusDB.set(heatMap, status);
-      }
-      return status;
-    }
-
-    MMGR.mapUpdatedOnLoad = function (heatMap) {
-      return heatMap.mapUpdatedOnLoad;
-    };
-
-    //Main function of the matrix manager - create a heat map object.
-    //mapFile parameter is only used for local file based heat maps.
-    //This function is called from a number of places:
-    //It is called from UIMGR.onLoadCHM when displaying a map in the NG-CHM Viewer and for embedded NG-CHM maps
-    //It is called from displayFileModeCHM (in UIMGR) when displaying a map in the stand-alone NG-CHM Viewer
-    //It is called in script in the mda_heatmap_viz.mako file when displaying a map in the Galaxy NG-CHM Viewer
-    MMGR.createHeatMap = function createHeatMap(
-      fileSrc,
-      heatMapName,
-      updateCallbacks,
-      mapFile,
-    ) {
-      heatMap = new HEAT.HeatMap(
-        heatMapName,
-        updateCallbacks,
-        fileSrc,
-        mapFile ? createFileLoader (mapFile) : connectLoader,
-        onMapReady,
-      );
-    };
-
-    function connectLoader (heatMap, addMapConfig, addMapData) {
-      if (heatMap.source() === MMGR.FILE_SOURCE) {
-        throw `Trying to connect web loader to a file`;
-      }
-      // WEB_SOURCE created the WebLoader on module initialization.
-      if (heatMap.source() !== MMGR.WEB_SOURCE) createWebLoader(heatMap.source());
-      connectWebLoader(heatMap, addMapConfig, addMapData);
-      return {
-        loadTile: function (job) {
-          MMGR.webLoader.postMessage({ op: "loadTile", job });
-        },
-      };
-    }
-
-    function createFileLoader (mapFile) {
-      //Check file mode viewer software version (excepting when using embedded widget)
-      return function (heatMap, addMapConfig, addMapData) {
-        if (typeof embedDiv === "undefined") {
-          checkViewerVersion(heatMap);
-        }
-        const fileInfo = loadNgChmFromZip(mapFile, heatMap, addMapConfig, addMapData);
-        return {
-          loadTile: function (job) {
-            zipFetchTile (fileInfo, heatMap, job);
-          },
-        };
-      };
-    }
-
-    // Read the tile specified by job from the HeatMap's zip file.
-    //
-    // Calls heatMap.tileRequestComplete when done.
-    //
-    function zipFetchTile(fileInfo, heatMap, job) {
-      const debug = false;
-      const baseName =
-        fileInfo.mapName + "/" + job.layer + "/" + job.level + "/" + job.tileName;
-      let entry = fileInfo.zipFiles[baseName + ".tile"];
-      if (typeof entry === "undefined") {
-        // Tiles in ancient NG-CHMs had a .bin extension.
-        entry = fileInfo.zipFiles[baseName + ".bin"];
-      }
-      if (typeof entry === "undefined") {
-        console.error("Request for unknown zip tile: " + baseName);
-        heatMap.tileRequestComplete(job.tileCacheName, null);
-      } else {
-        setTimeout(function getEntryData() {
-          entry
-            .getData(new zip.BlobWriter())
-            .then(function (blob) {
-              if (debug) console.log("Got blob for tile " + job.tileCacheName);
-              const fr = new FileReader();
-
-              fr.onerror = function () {
-                console.error("Error in zip file reader", fr.error);
-                heatMap.tileRequestComplete(job.tileCacheName, null);
-              };
-              fr.onload = function (e) {
-                const arrayBuffer = fr.result;
-                const far32 = new Float32Array(arrayBuffer);
-                heatMap.tileRequestComplete(job.tileCacheName, far32);
-              };
-              fr.readAsArrayBuffer(blob);
-            })
-            .catch((error) => {
-              console.error("Error getting zip tile data", error);
-            });
-        }, 1);
-      }
-    }
 
     // Return the current heat map.
     MMGR.getHeatMap = function getHeatMap() {
@@ -735,74 +821,79 @@
 
     // Return all heat maps.
     MMGR.getAllHeatMaps = function getAllHeatMaps() {
-      return [heatMap];  // Only 1 for now.
+      return allHeatMaps;
     };
 
-    /*
-     * Set the 'flick' control and data layer
-     */
-    function onMapReady(heatMap) {
-      const status = getMapStatus(heatMap);
-      if (!status.flickInitialized) {
-        configurePageHeader(heatMap);
-        const dl = heatMap.getDataLayers();
-        const numLayers = Object.keys(dl).length;
-        if (numLayers > 1) {
-          const dls = new Array(numLayers);
-          const orderedKeys = new Array(numLayers);
-          for (let key in dl) {
-            const dlNext = +key.substring(2, key.length); // Requires data layer ids to be dl1, dl2, etc.
-            orderedKeys[dlNext - 1] = key;
-            let displayName = dl[key].name;
-            if (displayName.length > 20) {
-              displayName = displayName.substring(0, 17) + "...";
-            }
-            dls[dlNext - 1] =
-              '<option value="' + key + '">' + displayName + "</option>";
-          }
-          const panelConfig = heatMap.getPanelConfiguration();
-          const flickInfo =
-            panelConfig && panelConfig.flickInfo ? panelConfig.flickInfo : {};
-          const layer = FLICK.enableFlicks(
-            orderedKeys,
-            dls.join(""),
-            flickInfo,
-          );
-          heatMap.setCurrentDL(layer);
-        } else {
-          heatMap.setCurrentDL("dl1");
-          FLICK.disableFlicks();
+    // Return true iff any heatmap has unsaved changes.
+    MMGR.hasUnsavedChanges = function () {
+      for (const heatmap of allHeatMaps) {
+        if (heatmap.getUnAppliedChanges()) {
+          return true;
         }
-        status.flickInitialized = true;
       }
+      return false;
+    };
+
+    // Return true iff any read-only heatmap has unsaved changes.
+    MMGR.hasReadOnlyChanges = function () {
+      for (const heatmap of allHeatMaps) {
+        if (heatMap.isReadOnly() && heatmap.getUnAppliedChanges()) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    // Clear unsaved changes flag on all heat maps.
+    MMGR.clearUnsavedChanges = function () {
+      for (const heatmap of allHeatMaps) {
+        heatmap.setUnAppliedChanges(false);
+      }
+    };
+
+    // Return true if any heatmap was updated on load.
+    MMGR.mapUpdatedOnLoad = function () {
+      for (const heatmap of allHeatMaps) {
+        if (heatmap.mapUpdatedOnLoad) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    // Initiates loading NG-CHM(s) from either a web or api source.
+    // - srcInfo specifies source details.
+    //
+    // - When all maps have completed loading, ngChmsLoaded() is called.
+    //
+    MMGR.loadWebMaps = function loadWebMaps (srcInfo, updateCallbacks, ngChmsLoaded) {
+      ngchmLoader = new WebLoader();
+      ngchmLoader.loadWebMaps (srcInfo, updateCallbacks, saveMaps(ngChmsLoaded));
+    };
+
+    // Initiates loading NG-CHM(s) from an open zip file.
+    // - mapFile is an open zip file.
+    //
+    // - When all maps have completed loading, ngChmsLoaded() is called.
+    //
+    MMGR.loadZipMaps = function loadZipMaps (mapFile, updateCallbacks, ngChmsLoaded) {
+      ngchmLoader = new ZipFileLoader ();
+      ngchmLoader.readZipFile (mapFile, updateCallbacks, saveMaps(ngChmsLoaded));
+    };
+
+    // Helper function.
+    // Create an onMapsLoaded function that can be passed to
+    // createWebWorker/loadZipMaps that:
+    // - saves the loaded maps to allHeatMaps.
+    // - picks the initial heatMap.
+    // - calls the callback function to indicate that all maps have loaded.
+    function saveMaps (callback) {
+      return function onMapsLoaded (maps) {
+        allHeatMaps = maps;
+        heatMap = allHeatMaps[0];
+        callback();
+      };
     }
+
   }
-
-  // Configure elements of the page header and top bar that depend on the
-  // loaded NGCHM.
-  function configurePageHeader(heatMap) {
-    // Set document title if not a local file.
-    if (heatMap.source() !== MMGR.LOCAL_SOURCE) {
-      document.title = heatMap.getMapInformation().name;
-    }
-
-    // Populate the header's nameDiv.
-    const nameDiv = document.getElementById("mapName");
-    nameDiv.innerHTML = heatMap.getMapInformation().name;
-  }
-
-  /**********************************************************************************
-   * Perform Early Initializations.
-   *
-   * Perform latency sensitive initializations.  Note that the complete sources
-   * have not loaded yet.
-   **********************************************************************************/
-
-  if (
-    MMGR.embeddedMapName === null &&
-    (UTIL.mapId !== "" || UTIL.mapNameRef !== "")
-  ) {
-    createWebLoader(MMGR.WEB_SOURCE);
-  }
-
 })();

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -947,7 +947,6 @@
    * We only only load once.
    *
    **********************************************************************************/
-  UTIL.embedLoaded = false;
   UTIL.embedThumbWidth = "150px";
   UTIL.embedThumbHeight = "150px";
   UTIL.defaultNgchmWidget = "ngchmWidget-min.js";

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -637,7 +637,6 @@
     return valArr;
   };
 
-  UTIL.isBuilderView = false;
   UTIL.containerElement = document.getElementById("ngChmContainer");
 
   /**********************************************************************************

--- a/NGCHM/WebContent/javascript/PaneControl.js
+++ b/NGCHM/WebContent/javascript/PaneControl.js
@@ -144,14 +144,12 @@
       p = p.parentElement;
     }
     if (!res.pane) {
-      if (UTIL.isBuilderView !== true) {
-        // Should have found the pane element.
-        console.error({
-          m: "findPaneLocation: could not find pane",
-          element,
-          res,
-        });
-      }
+      // Should have found the pane element.
+      console.error({
+        m: "findPaneLocation: could not find pane",
+        element,
+        res,
+      });
       return res;
     }
     if (!res.container) {

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -1940,4 +1940,23 @@
     SRCH.showSearchResults();
     SUM.redrawSelectionMarks();
   });
+
+  // Special tooltip with content populated from the loaded heat map.
+  document.getElementById("mapName").addEventListener(
+    "mouseover",
+    (ev) => {
+      const heatMap = MMGR.getHeatMap();
+      UHM.hlp(
+        ev.target,
+        "Map Name: " +
+          (heatMap !== null
+            ? heatMap.getMapInformation().name
+            : "Not yet available") +
+          "<br><br>Description: " +
+          (heatMap !== null ? heatMap.getMapInformation().description : "N/A"),
+        350,
+      );
+    },
+    { passive: true },
+  );
 })();

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -9,11 +9,11 @@
   //Define Namespace for NgChm UI Manager.
   const UIMGR = NgChm.createNS("NgChm.UI-Manager");
 
+  const CFG = NgChm.importNS("NgChm.CFG");
   const UTIL = NgChm.importNS("NgChm.UTIL");
   const COMPAT = NgChm.importNS("NgChm.CM");
   const FLICK = NgChm.importNS("NgChm.FLICK");
   const MAPREP = NgChm.importNS("NgChm.MAPREP");
-  const HEAT = NgChm.importNS("NgChm.HEAT");
   const SUM = NgChm.importNS("NgChm.SUM");
   const SMM = NgChm.importNS("NgChm.SMM");
   const PDF = NgChm.importNS("NgChm.PDF");
@@ -38,10 +38,12 @@
   const debugEmbed = UTIL.getDebugFlag("ui-embed");
   const srcInfo = {
     embedded: false,
+    spec: "",
     options: {},
   };
 
   const localFunctions = {};
+  const updateCallbacks = [ SUM.processSummaryMapUpdate, DET.processDetailMapUpdate ];
 
   /***
    *  Functions related to saving Ng-Chms.
@@ -50,7 +52,7 @@
     const heatMap = MMGR.getHeatMap();
     PIM.requestDataFromPlugins();
     var success = true;
-    if (heatMap.source() === MMGR.WEB_SOURCE) {
+    if (MMGR.getSource() === MMGR.API_SOURCE) {
       success = MMGR.zipMapProperties(heatMap, JSON.stringify(heatMap.mapConfig));
       showViewerSaveNotification();
       UHM.messageBoxCancel();
@@ -83,13 +85,21 @@
     if (!srcInfo.embedded) {
       heatMap.setRowClassificationOrder();
       heatMap.setColClassificationOrder();
-      if (heatMap.source() !== MMGR.FILE_SOURCE) {
-        // FIXME: BMB. Verify this does what it's required to do.
-        // This appears to only be saving mapConfig.
-        // What about mapData?
-        success = MMGR.webSaveMapProperties(heatMap);
-      } else {
-        zipSaveOutdated(heatMap);
+      switch (MMGR.getSource()) {
+        case MMGR.API_SOURCE:
+          // FIXME: BMB. Verify this does what it's required to do.
+          // This appears to only be saving mapConfig.
+          // What about mapData?
+          success = MMGR.webSaveMapProperties(heatMap);
+          break;
+        case MMGR.ZIP_SOURCE:
+          zipSaveOutdated(heatMap);
+          break;
+        case MMGR.WEB_SOURCE:
+          // Don't bug user with an error message they can't do anything about.
+          break;
+        default:
+          throw `UIMGR.autoSaveHeatMap: Unknown NG-CHM source ${MMGR.getSource()}`;
       }
     }
     return success;
@@ -203,7 +213,71 @@
     const title = "NG-CHM File Viewer";
     const text =
       "<br>You have just saved a heat map as a NG-CHM file.  To open this new file you will need the NG-CHM File Viewer application.  To get the lastest version, press the Download Viewer button.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you can run the application by double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>";
-    MMGR.showDownloadViewerNotification(title, text);
+    showDownloadViewerNotification(title, text);
+  }
+
+  /**********************************************************************************
+   * FUNCTION - viewerAppVersionExpiredNotification: This function handles all of the tasks
+   * necessary display a modal window whenever a user's version of the file application
+   * has been superceded and a new version of the file application should be downloaded.
+   **********************************************************************************/
+  function viewerAppVersionExpiredNotification(oldVersion, newVersion) {
+    const title = "New NG-CHM File Viewer Version Available";
+    const text =
+      "<br>The version of the NG-CHM File Viewer application that you are running (" +
+      oldVersion +
+      ") has been superceded by a newer version (" +
+      newVersion +
+      "). You will be able to view all pre-existing heat maps with this new backward-compatible version. However, you may wish to download the latest version of the viewer.<br><br>The application downloads as a single HTML file (ngchmApp.html).  When the download completes, you may run the application by simply double-clicking on the downloaded file.  You may want to save this file to a location of your choice on your computer for future use.<br><br>";
+    showDownloadViewerNotification(title, text);
+  }
+
+  function showDownloadViewerNotification(title, bodyText) {
+    const msgBox = UHM.initMessageBox();
+    msgBox.classList.add("file-viewer");
+    UHM.setMessageBoxHeader(title);
+    UHM.setMessageBoxText(bodyText);
+    UHM.setMessageBoxButton(
+      "download",
+      { type: "text", text: "Download Viewer" },
+      "Download viewer button",
+      () => {
+        downloadFileApplication();
+        UHM.messageBoxCancel();
+      },
+    );
+    UHM.setMessageBoxButton(
+      "cancel",
+      { type: "text", text: "Cancel", default: true },
+      "Cancel button",
+      UHM.messageBoxCancel,
+    );
+    UHM.displayMessageBox();
+  }
+
+  // Initiate download of NGCHM File Viewer application zip
+  // If the NG-CHMs were loaded from an API_SOURCE, download from there.
+  // If the NG-CHMs were loaded in Galaxy, download from there.
+  // Otherwise, download from the NG-CHM website.
+  //
+  function downloadFileApplication() {
+    if (typeof NgChm.galaxy !== "undefined") {
+      // Current viewer is embedded within Galaxy.
+      // FIXME: BMB: Use a better way to determine Galaxy embedding.
+      window.open(
+        "/plugins/visualizations/mda_heatmap_viz/static/ngChmApp.zip",
+      );
+    } else if (MMGR.getSource() !== MMGR.API_SOURCE) {
+      // Heat map came from a zip file or a web folder, not from an api server.
+      // (This does not mean the viewer is not from a server, so this could be
+      // refined further for that case i.e. the "api" condition might be more appropriate)
+      // Use full URL, which must be complete!
+      MMGR.callServlet("GET", COMPAT.viewerAppUrl, false);
+    } else {
+      // Heat map came from a server.
+      // Use server "api" + special endpoint name
+      MMGR.callServlet("GET", MMGR.getApi() + "ZipAppDownload", false);
+    }
   }
 
   function saveHeatMapToServer() {
@@ -292,23 +366,21 @@
     const debug = false;
     var firstTime = true;
 
-    UIMGR.configurePanelInterface = function configurePanelInterface(event) {
-      if (event !== HEAT.Event_INITIALIZED) {
-        return;
-      }
+    UIMGR.configurePanelInterface = function configurePanelInterface() {
 
       const heatMap = MMGR.getHeatMap();
+      onMapReady (heatMap);
       UIMGR.initializeSummaryWindows(heatMap);
 
       //If any new configs were added to the heatmap's config, save the config file.
-      if (MMGR.mapUpdatedOnLoad(heatMap) && heatMap.getMapInformation().read_only !== "Y") {
-        var success = autoSaveHeatMap(heatMap);
+      if (MMGR.mapUpdatedOnLoad() && heatMap.getMapInformation().read_only !== "Y") {
+        autoSaveHeatMap(heatMap);
       }
       heatMap.setSelectionColors();
       SRCH.configSearchInterface(heatMap);
 
       CUST.addCustomJS();
-      if (heatMap.source() === MMGR.FILE_SOURCE) {
+      if (MMGR.getSource() === MMGR.ZIP_SOURCE) {
         firstTime = true;
         if (SUM.chmElement) {
           PANE.emptyPaneLocation(PANE.findPaneLocation(SUM.chmElement));
@@ -409,12 +481,144 @@
     };
   })();
 
-  /**********************************************************************************
-   * FUNCTION - onLoadCHM: This function performs "on load" processing for the NG_CHM
-   * Viewer.  It will load either the file mode viewer, standard viewer, or widgetized
-   * viewer.
-   **********************************************************************************/
+    /*
+     * Set the 'flick' control and data layer
+     */
+    let flickInitialized = false;
+    function onMapReady(heatMap) {
+      if (!flickInitialized) {
+        configurePageHeader(heatMap);
+        const dl = heatMap.getDataLayers();
+        const numLayers = Object.keys(dl).length;
+        if (numLayers > 1) {
+          const dls = new Array(numLayers);
+          const orderedKeys = new Array(numLayers);
+          for (let key in dl) {
+            const dlNext = +key.substring(2, key.length); // Requires data layer ids to be dl1, dl2, etc.
+            orderedKeys[dlNext - 1] = key;
+            let displayName = dl[key].name;
+            if (displayName.length > 20) {
+              displayName = displayName.substring(0, 17) + "...";
+            }
+            dls[dlNext - 1] =
+              '<option value="' + key + '">' + displayName + "</option>";
+          }
+          const panelConfig = heatMap.getPanelConfiguration();
+          const flickInfo =
+            panelConfig && panelConfig.flickInfo ? panelConfig.flickInfo : {};
+          const layer = FLICK.enableFlicks(
+            orderedKeys,
+            dls.join(""),
+            flickInfo,
+          );
+          heatMap.setCurrentDL(layer);
+        } else {
+          heatMap.setCurrentDL("dl1");
+          FLICK.disableFlicks();
+        }
+        flickInitialized = true;
+
+        // Check viewer version if not embedded.
+        if (!srcInfo.embedded) {
+          checkViewerVersion();
+        }
+      }
+    }
+
+  // Compare the version of this NG-CHM viewer to the one recent available.
+  // Notify the user if they're using a standalone viewer and it is out of date.
+  //
+  function checkViewerVersion() {
+    const debug = false;
+    const req = new XMLHttpRequest();
+    const baseVersion = COMPAT.version.replace(/-.*$/, "");
+    req.open("GET", COMPAT.versionCheckUrl + baseVersion, true);
+    req.onreadystatechange = function () {
+      if (req.readyState == req.DONE) {
+        if (req.status != 200) {
+          //Log failure, otherwise, do nothing.
+          console.log("Failed to get software version: " + req.status);
+        } else {
+          const latestVersion = req.response;
+          if (debug)
+            console.log("Compare versions", {
+              latestVersion,
+              thisVersion: COMPAT.version,
+              newer: newer(latestVersion, baseVersion),
+            });
+          if (
+            newer(latestVersion, baseVersion) &&
+            typeof NgChm.galaxy === "undefined" &&
+            !srcInfo.embedded
+          ) {
+            viewerAppVersionExpiredNotification(COMPAT.version, latestVersion);
+          }
+        }
+      }
+    };
+    req.send();
+
+    // v1 and v2 are version numbers consisting of integers separated by periods.
+    // This function returns true if v1 is greater than v2.
+    function newer(v1, v2) {
+      // Split each into fields and convert each field to integer.
+      v1 = v1.split(".").map((v) => v | 0);
+      v2 = v2.split(".").map((v) => v | 0);
+      for (let i = 0; ; i++) {
+        if (i == v1.length && i == v2.length) return false; // Reached end of both with no differences.
+        if (i == v2.length) return true; // Exhausted v2 (we treat 2.21.0 > 2.21)
+        if (i == v1.length) return false; // Exhausted v1.
+        if (v1[i] > v2[i]) return true;
+        if (v1[i] < v2[i]) return false;
+      }
+    }
+  }
+
+  // Configure elements of the page header and top bar that depend on the
+  // loaded NGCHM.
+  function configurePageHeader(heatMap) {
+    // Set document title if not embedded.
+    if (!srcInfo.embedded) {
+      // Don't set document title in case we're not in an iFrame
+      // (like in the builder for example).
+      document.title = heatMap.getMapInformation().name;
+    }
+
+    // Populate the header's nameDiv.
+    const nameDiv = document.getElementById("mapName");
+    nameDiv.innerHTML = heatMap.getMapInformation().name;
+  }
+
+  // FUNCTION onLoadCHM: Initialize the NG_CHM display.
+  //
+  // srcInfo.embedded is true iff this is an embedded NG-CHM.
+  //
+  // If this is an embedded NG-CHM, the other entries in srcInfo
+  // will have been set by NgChm.API.embedCHM.
+  //
+  // Otherwise, we will need to determine them.
+  //
+  // If srcInfo.options.sourceType==api:
+  // - srcInfo.options.repository is the API endpoint of a shaidy server.
+  // - srcInfo.mapIds is an array of shaidy map ids to load.
+  // - srcInfo.mapNames is an array of named maps to load.
+  // - Uses the WEB loader in API_SOURCE mode.
+  //
+  // If srcInfo.options.sourceType==web:
+  // - srcInfo.options.repository is a URL to a directory on the web
+  // - srcInfo.mapIds is an array of subfolder names containing unzipped NG-CHMs.
+  // - Uses the WEB loader in WEB_SOURCE mode.
+  //
+  // If srcInfo.options.sourceType==zip:
+  // - spec is an embedded blob, or
+  //   spec is a URL to an ngchm file, or
+  //   options.repository/spec is an ngchm of the web page's server.
+  // - Uses the ZIP loader in ZIP_SOURCE mode.
+  //
+  // Otherwise:
+  // - error.
   UIMGR.onLoadCHM = function () {
+
     // Flush summary cache before possibly replacing current CHM with a new map.
     SUM.summaryHeatMapCache = {};
 
@@ -423,46 +627,35 @@
 
     // See if we are running in file mode AND not from "widgetized" code - launcHed locally rather than from a web server (
     if (debugEmbed) {
-      console.log ("onLoadCHM: checking srcInfo:", {
-        srcInfo,
-      });
+      console.log ("onLoadCHM: checking srcInfo:", { srcInfo, });
     }
 
-    if (UTIL.mapId === "" && UTIL.mapNameRef === "" && !srcInfo.embedded) {
-      //In local mode, need user to select the zip file with data (required by browser security)
-      var chmFileItem = document.getElementById("fileButton");
-      document.getElementById("menuFileOpen").style.display = "";
-      document.getElementById("detail_buttons").style.display = "none";
-      chmFileItem.style.display = "";
-      chmFileItem.addEventListener("change", loadFileModeCHM, false);
-      UTIL.showSplashExample();
-    } else {
-      UTIL.showLoader("Loading NG-CHM from server...");
-      //Run from a web server.
-      var mapName = UTIL.mapId;
-      var dataSource = MMGR.WEB_SOURCE;
-      if (srcInfo.embedded && srcInfo.options.widgetMode !== "web") {
-        mapName = MMGR.embeddedMapName;
-        dataSource = MMGR.FILE_SOURCE;
-        var embedButton = document.getElementById("NGCHMEmbedButton");
-        if (embedButton !== null) {
-          document.getElementById("NGCHMEmbed").style.display = "none";
-        } else {
-          loadLocalModeCHM(sizeBuilderView);
-        }
+    // Maps can be specified in the following ways
+    // Specified as a shaidy server map:
+    // - ?map=id - Use web worker MMGR.API_SOURCE
+    // - ?name=name - Use web worker MMGR.API_SOURCE
+    // Specified as an embedded map via NgChm.API.embedCHM():
+    // - srcInfo.options.sourceType has been set to "web" MMGR.WEB_SOURCE
+    // - other embedded maps MMGR.ZIP_SOURCE (blob)
+    // Not specified via any of the above:
+    // - file mode - user gets a "Load NgChm" button MMGR.ZIP_SOURCE (file)
+
+    if (srcInfo.embedded) {
+      if (srcInfo.options.expandable) {
+        // Hide the embedded NG-CHM div and do not load
+        // the NG-CHMs until the user expands the div.
+        document.getElementById("NGCHMEmbed").style.display = "none";
       } else {
-        if (MMGR.embeddedMapName !== null) {
-          mapName = MMGR.embeddedMapName;
-          dataSource = MMGR.LOCAL_SOURCE;
-        }
-        resetCHM();
-        initDisplayVars();
-        MMGR.createHeatMap(dataSource, mapName, [
-          UIMGR.configurePanelInterface,
-          SUM.processSummaryMapUpdate,
-          DET.processDetailMapUpdate
-        ]);
+        // Load the non-expandable embedded NG-CHM immediately.
+        loadNGCHM();
       }
+    } else if (mapsSpecifiedOnURL()) {
+      // Load NG-CHMs specified on the URL immediately.
+      loadNGCHM();
+    } else {
+      // Not embedded and no maps specified on the URL.
+      // Show the open file button so the user can load a zipFile.
+      showOpenFileButton();
     }
     document
       .getElementById("summary_canvas")
@@ -474,42 +667,167 @@
     initializeKeyNavigation();
   };
 
+  // Check URL for maps to load.
+  // If found:
+  // - sets srcInfo
+  // - returns true
+  // Otherwise:
+  // - returns false.
+  // Currently can only specify sourceType=="api".
+  function mapsSpecifiedOnURL () {
+    const repo = UTIL.getURLParameter("repo");
+    if (repo) {
+      srcInfo.spec = UTIL.mapId;
+      srcInfo.options.sourceType = MMGR.WEB_SOURCE;
+      srcInfo.options.repository = repo;
+      return true;
+    }
+    const api = UTIL.getURLParameter("api");
+    srcInfo.options.repository = api || CFG.api;
+    if (UTIL.mapId.length + UTIL.mapNameRef.length > 0) {
+      srcInfo.spec = UTIL.mapId ? UTIL.mapId : "";
+      if (UTIL.mapNameRef) {
+        if (UTIL.mapId) srcInfo.spec += ',';
+        srcInfo.spec += UTIL.mapNameRef;
+      }
+      srcInfo.options.sourceType = MMGR.API_SOURCE;
+      return true;
+    }
+    return false;
+  }
+
+  function loadWebMaps () {
+    UTIL.showLoader("Loading NG-CHM from server...");
+    MMGR.loadWebMaps (srcInfo, updateCallbacks, () => {
+      resetCHM();
+      initDisplayVars();
+      UIMGR.configurePanelInterface();
+    });
+  }
+
+  // API.embedNGCHM (in NGCHM_Embed.js) allows the NG-CHM to be specified in 4 ways:
+  // srcType === "blob":     spec = info.srcSpec
+  // srcType === "base64":   spec = API.b64toBlob(info.srcSpec)
+  // srcType === "fileName": spec = info.srcSpec
+  // srcType === "url":      spec = info.srcSpec
+  //
+  // Historically:
+  // - These are all for sourceType="zip" (old widgetMode=='file').
+  // - info.srcType was not passed to API.embedCHM, so for backwards
+  //   compatibility we need to decipher what was intended by the form of spec.
+  //
+  // - srcType=="blob" and srcType=="base64" are the same by the time we get them:
+  //   spec is a blob.
+  //
+  // - For srcType=="url", spec is a complete URL to an ngchm zipFile.
+  //
+  // - The GuiBuilder calls API.embedCHM directly (not via API.embedNGCHM) and uses
+  //   options.repository/spec as the path to the ngchm zipFile.  spec is neither a
+  //   blob nor a url.
+  //
+  // Extending to other sourceTypes:
+  // - If spec is a blob, sourceType must be "zip".
+  // - If spec is a URL, sourceType must be "zip" or "web":
+  //   - "zip": spec is a URL to an ngchm zipFile.
+  //   - "web" : spec is a URL to a web directory containing an expanded ngchm.
+  // - If spec is neither of the above, sourceType can be any of the following:
+  //   - "zip": ${options.repository}/${spec} points to an ngchm zipFile.
+  //   - "web" : spec is a comma separated list.
+  //     - For each item in the list, ${options.repository}/${item} points to
+  //       a web directory containing an expanded ngchm.
+  //   - "api": spec is a comma separated list.
+  //     - options.repository is a URL to a shaidy server API endpoint.
+  //     - Each item in the list is either a mapId or a mapName to load:
+  //       - If it contains at least one slash ("/"), it is a mapName.
+  //       - If it contains no slashes, it is a mapId.
+  //
   /**********************************************************************************
-   * FUNCTION - loadLocalModeCHM: This function is called when running in local file mode and
-   * with the heat map embedded in a "widgetized" web page.
+   * FUNCTION - loadNGCHM: This function is called to load the map(s) specified in
+   * srcInfo.
    **********************************************************************************/
-  function loadLocalModeCHM() {
+  function loadNGCHM() {
     if (debugEmbed) {
-      console.log ("loadLocalModeCHM: ", { srcInfo });
+      console.log ("loadNGCHM: ", {
+        srcType: srcInfo.options.sourceType,
+        srcSpec: srcInfo.spec.substring(0,100)
+      });
     }
-    //Special case for embedded version where a blob is passed in.
-    if (MMGR.embeddedMapName instanceof Blob) {
-      loadBlobModeCHM();
+    // Check if srcInfo.spec is a blob.
+    if (srcInfo.spec instanceof Blob) {
+      if (srcInfo.options.sourceType != MMGR.ZIP_SOURCE) {
+        throw `blob NG-CHMs must be opened as zip files`;
+      }
+      loadZipFileFromBlob();
       return;
     }
-    if (UTIL.isValidURL(MMGR.embeddedMapName)) {
-      loadCHMFromURL();
-      return;
+    // Otherwise, see if it is a URL.
+    if (UTIL.isValidURL(srcInfo.spec)) {
+      switch (srcInfo.options.sourceType) {
+        case MMGR.ZIP_SOURCE:
+          loadZipFileFromURL();
+          return;
+        case MMGR.WEB_SOURCE:
+          const lastSlash = srcInfo.spec.lastIndexOf('/');
+          if (lastSlash < 0) {
+            throw `malformed web URL ${srcInfo.spec}`;
+          }
+          srcInfo.options.repository = srcInfo.spec.substring(0, lastSlash);
+          srcInfo.mapIds = srcInfo.spec.substring(lastSlash+1).split(',');
+          srcInfo.mapNames = [];
+          loadWebMaps();
+          return;
+        default:
+          throw `URL must be for sourceType "zip" or "web", not ${srcInfo.options.sourceType}`;
+      }
     }
-    //Else, fetch the .ngchm file
-    var req = new XMLHttpRequest();
-    req.open("GET", MMGR.localRepository + "/" + MMGR.embeddedMapName);
+    // Not a blob and not a URL.
+    switch (srcInfo.options.sourceType) {
+      case MMGR.ZIP_SOURCE:
+        if (srcInfo.spec) {
+          loadZipFileFromURL2();
+        } else {
+          showOpenFileButton();
+        }
+        return;
+      case MMGR.WEB_SOURCE:
+        srcInfo.mapIds = srcInfo.spec.split(',');
+        srcInfo.mapNames = [];
+        loadWebMaps();
+        return;
+      case MMGR.API_SOURCE:
+        srcInfo.mapIds = [];
+        srcInfo.mapNames = [];
+        for (const item of srcInfo.spec.split(',')) {
+          (item.includes('/') ? srcInfo.mapNames : srcInfo.mapIds).push (item);
+        }
+        loadWebMaps();
+        return;
+      default:
+        throw `Unknown sourceType ${srcInfo.options.sourceType} for default embedded NG-CHM spec`;
+    }
+  }
+
+  function loadZipFileFromURL2() {
+    // Otherwise, fetch the .ngchm file
+    UTIL.showLoader("Loading NG-CHM zip file from a URL...");
+    const req = new XMLHttpRequest();
+    req.open("GET", srcInfo.options.repository + "/" + srcInfo.spec);
     req.responseType = "blob";
     req.onreadystatechange = function () {
       if (req.readyState == req.DONE) {
         if (req.status != 200) {
-          console.log("Failed in call to get NGCHM from server: " + req.status);
+          console.warn("Failed in call to get NGCHM from server: " + req.status);
           UTIL.showLoader("Failed to get NGCHM from server");
         } else {
-          var chmBlob = new Blob([req.response], { type: "application/zip" }); // req.response;
-          var chmFile = new File([chmBlob], MMGR.embeddedMapName);
-          resetCHM();
-          var split = chmFile.name.split(".");
+          console.log ("Got response in loadZipFileFromURL2()");
+          const chmBlob = new Blob([req.response], { type: "application/zip" }); // req.response;
+          const chmFile = new File([chmBlob], srcInfo.spec);
+          const split = chmFile.name.split(".");
           if (split[split.length - 1].toLowerCase() !== "ngchm") {
             // check if the file is a .ngchm file
             UHM.invalidFileFormat();
           } else {
-            displayFileModeCHM(chmFile);
+            displayZipFileCHM(chmFile);
           }
         }
       }
@@ -518,48 +836,57 @@
   }
 
   /**********************************************************************************
-   * FUNCTION - loadCHMFromURL: Works kind of like local mode but works when javascript
+   * FUNCTION - loadZipFileFromURL: Works kind of like local mode but works when javascript
    * passes in the ngchm as a blob.
+   * - so why is it called loadZipFileFromURL????
    **********************************************************************************/
-  function loadCHMFromURL() {
-    var xhr = new XMLHttpRequest();
-    xhr.open("GET", MMGR.embeddedMapName, true);
+  function loadZipFileFromURL() {
+    UTIL.showLoader("Loading NG-CHM zip file from a URL...");
+    const xhr = new XMLHttpRequest();
+    xhr.open("GET", srcInfo.spec, true);
     xhr.setRequestHeader("Access-Control-Allow-Origin", "*");
     xhr.responseType = "blob";
     xhr.onload = function (e) {
       if (this.status == 200) {
-        var myBlob = this.response;
-        resetCHM();
-        displayFileModeCHM(myBlob);
+        const myBlob = this.response;
+        console.log ("Got blob in loadZipFileFromURL()");
+        displayZipFileCHM(myBlob);
       }
     };
     xhr.send();
   }
 
   /**********************************************************************************
-   * FUNCTION - loadCHMFromBlob: Works kind of like local mode but works when javascript
-   * passes in the ngchm as a blob.
+   * FUNCTION - loadZipFileFromBlob: Converts a blob (of a zipFile) into a file and
+   * opens it as a zipFile.
    **********************************************************************************/
-  function loadBlobModeCHM() {
-    var chmFile = new File([MMGR.embeddedMapName], "ngchm");
-    resetCHM();
-    displayFileModeCHM(chmFile);
+  function loadZipFileFromBlob() {
+    UTIL.showLoader("Loading NG-CHM from a blob...");
+    const chmFile = new File([srcInfo.spec], "ngchm");
+    displayZipFileCHM(chmFile);
   }
 
-  /**********************************************************************************
-   * FUNCTION - loadFileModeCHM: This function is called when running in stand-alone
-   * file mode and  user selects the chm data .zip file.
-   **********************************************************************************/
-  function loadFileModeCHM() {
-    UTIL.showLoader("Loading NG-CHM from file...");
-    var chmFile = document.getElementById("chmFile").files[0];
-    var split = chmFile.name.split(".");
-    if (split[split.length - 1].toLowerCase() !== "ngchm") {
-      // check if the file is a .ngchm file
-      UHM.invalidFileFormat();
-    } else {
-      displayFileModeCHM(chmFile);
-      openFileToggle();
+  // Show the open file button so that the user can select the ngchm file to load.
+  //
+  function showOpenFileButton() {
+    const chmFileItem = document.getElementById("fileButton");
+    document.getElementById("menuFileOpen").style.display = "";
+    document.getElementById("detail_buttons").style.display = "none";
+    chmFileItem.style.display = "";
+    chmFileItem.addEventListener("change", onFileSelected, false);
+    UTIL.showSplashExample();
+    return;
+
+    function onFileSelected() {
+      const chmFile = document.getElementById("chmFile").files[0];
+      const split = chmFile.name.split(".");
+      if (split[split.length - 1].toLowerCase() !== "ngchm") {
+        // check if the file is a .ngchm file
+        UHM.invalidFileFormat();
+      } else {
+        openFileToggle();
+        displayZipFileCHM(chmFile);
+      }
     }
   }
 
@@ -567,25 +894,29 @@
     const fileButton = document.getElementById("fileButton");
     const detailButtons = document.getElementById("detail_buttons");
     if (fileButton.style.display === "none") {
+      // File button is hidden: reload the page (which will reveal the button).
       location.reload();
     } else {
+      // File button is visible: hide the fileButton and show the map name / search
+      // controls.
       fileButton.style.display = "none";
       detailButtons.style.display = "";
     }
   }
 
   /**********************************************************************************
-   * FUNCTION - displayFileModeCHM: This function performs functions shared by the
-   * stand-alone and widgetized "file" versions of the application.
+   * FUNCTION displayZipFileCHM: Display an NG-CHM stored in a zip (.ngchm) file.
    **********************************************************************************/
-  function displayFileModeCHM(chmFile) {
-    resetCHM();
-    initDisplayVars();
-    MMGR.createHeatMap(
-      MMGR.FILE_SOURCE,
-      "",
-      [UIMGR.configurePanelInterface, SUM.processSummaryMapUpdate, DET.processDetailMapUpdate],
-      chmFile
+  function displayZipFileCHM(chmFile) {
+    UTIL.showLoader("Loading NG-CHM from zip file...");
+    MMGR.loadZipMaps(
+      chmFile,
+      updateCallbacks,
+      () => {
+        resetCHM();
+        initDisplayVars();
+        UIMGR.configurePanelInterface ();
+      }
     );
   }
 
@@ -632,28 +963,63 @@
     }
   }
 
-  /**********************************************************************************
-   * FUNCTION - embedCHM: This function is a special pre-processing function for the
-   * widgetized version of the NG-CHM Viewer.  It will take the map name provided
-   * by the user (embedded in an unaffiliated web page) and pass that on to the
-   * on load processing for the viewer.  repository (default .) is the path to the
-   * directory containing the specified map.
-   **********************************************************************************/
+  // Export functions related to embedding NG-CHMs.
+  //
+  // The functions are exported to NgChm.API (and for backward compatibility
+  // to NgChm.UTIL).
+  //
+  // NgChm.API.embedCHM (spec, options)
+  // - The NG-CHM widget has already been embedded into the page.
+  // - This function initializes and displays the NG-CHM.
+  // - The NG-CHM to display and its properties are determined by
+  //   the spec and options parameters.
+  //
+  // NgChm.API.showEmbedded (baseDiv, iframeStyle, customJS)
+  // - This function expands an expandable embedded NG-CHM.
+  //
+  // NgChm.API.showEmbed -- obsolete.  Kept for backward compatibility.
+  //
   NgChm.exportToNS("NgChm.API", { embedCHM, showEmbed, showEmbedded });
-  // FIXME: BMB: Why do both showEmbed and showEmbedded exist and how are they different?
-  // To preserve compatibility with old API:
   Object.assign(UTIL, { embedCHM, showEmbed, showEmbedded });
 
-  function embedCHM(map, repository) {
+  // Show an embedded NG-CHM.
+  //
+  const defaultEmbedOpts = {
+    sourceType: MMGR.ZIP_SOURCE,
+    repository: ".",
+    expandable: false,
+  };
+  function embedCHM(spec, o = {}) {
+    if (typeof o == "string") {
+      // Maintain compatibility with previous interface, at least for now.
+      console.warn (`Passing a repository string as the second parameter to NgChm.API.embedCHM is deprecated.
+      If you are using ngchmEmbed-min.js (recommended), upgrade to a recent version.
+      If you are calling NgChm.API.embedCHM directly, you now need to pass an options object with the repository field set.
+      For example, NgChm.API.embedCHM(filename, { repository: "${o}" }).
+      `);
+      o = { repository: o };
+    }
+    const options = Object.assign({}, defaultEmbedOpts, o);
+    options.expandable = document.getElementById("NGCHMEmbedButton") != null;
+    if (debugEmbed) {
+      console.log("embedCHM: ", { spec, o, options });
+    }
+
+    // Set source details (used by onLoadCHM).
     srcInfo.embedded = true;
-    srcInfo.options.widgetMode = 'file';
-    MMGR.embeddedMapName = map;
-    MMGR.localRepository = repository || ".";
-    //Reset dendros for local/widget load
+    srcInfo.spec = spec;
+    srcInfo.options = options;
+
+    // UIMGR.onLoadCHM is not called for embedded NG-CHMS.
+    // Call it now.
+    //
+    // Reset dendros for local/widget load
     SUM.colDendro = null;
     SUM.rowDendro = null;
     UIMGR.onLoadCHM();
   }
+
+  var embedLoaded = false;  // Used to determine if we have already loaded an expandable embedded NGCHM.
 
   /**********************************************************************************
    * FUNCTION - showEmbed: This function shows the embedded heat map when the
@@ -685,9 +1051,9 @@
     embeddedMap.style.flexDirection = "column";
     embeddedWrapper.style.display = "none";
     embeddedCollapse.style.display = "";
-    if (UTIL.embedLoaded === false) {
-      UTIL.embedLoaded = true;
-      loadLocalModeCHM(false);
+    if (!embedLoaded) {
+      embedLoaded = true;
+      loadNGCHM();
       if (customJS !== "") {
         setTimeout(function () {
           CUST.addExtraCustomJS(customJS);
@@ -720,9 +1086,9 @@
     embeddedMap.style.flexDirection = "column";
     embeddedWrapper.style.display = "none";
     embeddedCollapse.style.display = "";
-    if (UTIL.embedLoaded === false) {
-      UTIL.embedLoaded = true;
-      loadLocalModeCHM(false);
+    if (!embedLoaded) {
+      embedLoaded = true;
+      loadNGCHM();
       if (customJS !== "") {
         setTimeout(function () {
           CUST.addExtraCustomJS(customJS);
@@ -853,7 +1219,7 @@
       },
       function () {
         UHM.messageBoxCancel();
-        MMGR.zipAppDownload();
+        downloadFileApplication();
       }
     );
     UHM.setMessageBoxButton(
@@ -942,6 +1308,12 @@
     msgBox.classList.add("save-heat-map");
     UHM.setMessageBoxHeader("Save Heat Map");
 
+    if (MMGR.getSource() == MMGR.WEB_SOURCE) {
+      UHM.setMessageBoxText("<br>Saving an NG-CHM loaded from a web folder is not supported at this time.<br>");
+      addCancelSaveButton();
+      UHM.displayMessageBox();
+      return;
+    }
     // Find a reason, if any, we can't save to the server.
     const whyNot = checkSavingPermitted();
 
@@ -972,27 +1344,27 @@
     // Helper function.
     // Return null iff saving permitted, otherwise reason.
     function checkSavingPermitted() {
-      if (!heatMap.getUnAppliedChanges()) {
+      if (!MMGR.hasUnsavedChanges()) {
         return "there are no changes at this time";
       }
       // FIXME: BMB.  Improve Galaxy detection.
       if (typeof NgChm.galaxy !== "undefined") {
         return "changes cannot be saved in the Galaxy history";
       }
-      if (heatMap.isReadOnly()) {
-        return "the NG-CHM is marked READ-ONLY";
+      if (MMGR.hasReadOnlyChanges()) {
+        return "at least one NG-CHM with changes is marked READ-ONLY";
       }
       // Final check. Does the fileSource permit saving?
-      switch (heatMap.source()) {
-        case MMGR.WEB_SOURCE:
+      switch (MMGR.getSource()) {
+        case MMGR.API_SOURCE:
           return null;
-        case MMGR.LOCAL_SOURCE:
+        case MMGR.WEB_SOURCE:
           return "the NG-CHM server is read only";
-        case MMGR.FILE_SOURCE:
+        case MMGR.ZIP_SOURCE:
           return "browsers cannot automatically overwrite files";
         default:
           // This should never happen.
-          console.error ("Unknown type of NG-CHM server: " + heatMap.source());
+          console.error ("Unknown type of NG-CHM server: " + MMGR.getSource());
           return "the type of the NG-CHM server is not recognized";
       }
     }
@@ -1866,7 +2238,7 @@
       ]);
       if (req.args.length > 0) {
         if (req.args[0] != "--help") {
-          if (req.args[0].substr(0,2) == "--") {
+          if (req.args[0].substring(0,2) == "--") {
             res.output.error (`redraw: unexpected option: ${req.args[0]}`);
           } else {
             res.output.error (`redraw: unexpected subcommand/parameter: ${req.args[0]}`);

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -408,11 +408,10 @@
    * Viewer.  It will load either the file mode viewer, standard viewer, or widgetized
    * viewer.
    **********************************************************************************/
-  UIMGR.onLoadCHM = function (sizeBuilderView) {
+  UIMGR.onLoadCHM = function () {
     // Flush summary cache before possibly replacing current CHM with a new map.
     SUM.summaryHeatMapCache = {};
 
-    UTIL.isBuilderView = sizeBuilderView;
     //Run startup checks that enable startup warnings button.
     setDragPanels();
 
@@ -467,14 +466,14 @@
    * FUNCTION - loadLocalModeCHM: This function is called when running in local file mode and
    * with the heat map embedded in a "widgetized" web page.
    **********************************************************************************/
-  function loadLocalModeCHM(sizeBuilderView) {
+  function loadLocalModeCHM() {
     //Special case for embedded version where a blob is passed in.
     if (MMGR.embeddedMapName instanceof Blob) {
-      loadBlobModeCHM(sizeBuilderView);
+      loadBlobModeCHM();
       return;
     }
     if (UTIL.isValidURL(MMGR.embeddedMapName) === true) {
-      loadCHMFromURL(sizeBuilderView);
+      loadCHMFromURL();
       return;
     }
     //Else, fetch the .ngchm file
@@ -495,7 +494,7 @@
             // check if the file is a .ngchm file
             UHM.invalidFileFormat();
           } else {
-            displayFileModeCHM(chmFile, sizeBuilderView);
+            displayFileModeCHM(chmFile);
           }
         }
       }
@@ -507,7 +506,7 @@
    * FUNCTION - loadCHMFromURL: Works kind of like local mode but works when javascript
    * passes in the ngchm as a blob.
    **********************************************************************************/
-  function loadCHMFromURL(sizeBuilderView) {
+  function loadCHMFromURL() {
     var xhr = new XMLHttpRequest();
     xhr.open("GET", MMGR.embeddedMapName, true);
     xhr.setRequestHeader("Access-Control-Allow-Origin", "*");
@@ -516,7 +515,7 @@
       if (this.status == 200) {
         var myBlob = this.response;
         resetCHM();
-        displayFileModeCHM(myBlob, sizeBuilderView);
+        displayFileModeCHM(myBlob);
       }
     };
     xhr.send();
@@ -526,10 +525,10 @@
    * FUNCTION - loadCHMFromBlob: Works kind of like local mode but works when javascript
    * passes in the ngchm as a blob.
    **********************************************************************************/
-  function loadBlobModeCHM(sizeBuilderView) {
+  function loadBlobModeCHM() {
     var chmFile = new File([MMGR.embeddedMapName], "ngchm");
     resetCHM();
-    displayFileModeCHM(chmFile, sizeBuilderView);
+    displayFileModeCHM(chmFile);
   }
 
   /**********************************************************************************
@@ -564,7 +563,7 @@
    * FUNCTION - displayFileModeCHM: This function performs functions shared by the
    * stand-alone and widgetized "file" versions of the application.
    **********************************************************************************/
-  function displayFileModeCHM(chmFile, sizeBuilderView) {
+  function displayFileModeCHM(chmFile) {
     resetCHM();
     initDisplayVars();
     MMGR.createHeatMap(
@@ -573,27 +572,6 @@
       [UIMGR.configurePanelInterface, SUM.processSummaryMapUpdate, DET.processDetailMapUpdate],
       chmFile
     );
-    if (typeof sizeBuilderView !== "undefined" && sizeBuilderView) {
-      UTIL.showDetailPane = false;
-      PANE.showPaneHeader = false;
-      MMGR.getHeatMap().addEventListener(builderViewSizing);
-    }
-  }
-
-  /**********************************************************************************
-   * FUNCTION - builderViewSizing: This function handles the resizing of the summary
-   * panel for the builder in cases where ONLY the summary panel is being drawn.
-   **********************************************************************************/
-  function builderViewSizing(event) {
-    if (typeof event !== "undefined" && event !== HEAT.Event_INITIALIZED) {
-      return;
-    }
-
-    const header = document.getElementById("mdaServiceHeader");
-    if (!header.classList.contains("hide")) {
-      header.classList.add("hide");
-      window.onresize();
-    }
   }
 
   /**********************************************************************************
@@ -651,15 +629,13 @@
   // To preserve compatibility with old API:
   Object.assign(UTIL, { embedCHM, showEmbed, showEmbedded });
 
-  function embedCHM(map, repository, sizeBuilderView) {
+  function embedCHM(map, repository) {
     MMGR.embeddedMapName = map;
     MMGR.localRepository = repository || ".";
     //Reset dendros for local/widget load
     SUM.colDendro = null;
     SUM.rowDendro = null;
-    //	DET.colDendro = null;
-    //	DET.rowDendro = null;
-    UIMGR.onLoadCHM(sizeBuilderView);
+    UIMGR.onLoadCHM();
   }
 
   /**********************************************************************************

--- a/NGCHM/WebContent/javascript/custom/custom.js
+++ b/NGCHM/WebContent/javascript/custom/custom.js
@@ -16,7 +16,7 @@ if (false) {
 // Add a continuous 'Mutation Load' covariate bar if there are at least two
 // covariates with 'mutation' in their name.
 // - Assumes mutations in such bars have the value 'MUT'.
-const mutationCovars = linkouts.execCommand(["covar", "get-list", "column"]).filter(name => /mutation/.test(name));
+var mutationCovars = linkouts.execCommand(["covar", "get-list", "column"]).filter(name => /mutation/.test(name));
 if (mutationCovars.length > 1) {
   const covarName = "Mutation Load";
   linkouts.execCommand(["covar", "create", "column", covarName, "continuous"]);

--- a/NGCHM/build_ngchmApp.xml
+++ b/NGCHM/build_ngchmApp.xml
@@ -101,7 +101,6 @@
 	<java classname="${src.dir}NGCHM_Widgetizer" failonerror="true">
 	    <arg value="${web.dir}"/>
 	    <arg value="ngchmWidget-min.js"/>
-	    <arg value="file"/>
 	    <classpath>
 	        <pathelement path="build/classes"/>
 	    </classpath>

--- a/NGCHM/src/mda/ngchm/util/NGCHM_Widgetizer.java
+++ b/NGCHM/src/mda/ngchm/util/NGCHM_Widgetizer.java
@@ -108,14 +108,13 @@ public class NGCHM_Widgetizer {
     System.out.println("BEGIN NGCHM Widgetizer  " + new Date());
     try {
       if (args.length < 2) {
-        System.out.println("Usage: NGCHM_Widgetizer <web directory> <output file> <mode>");
+        System.out.println("Usage: NGCHM_Widgetizer <web directory> <output file>");
         System.exit(1);
       }
 
       StringBuffer cssLines = new StringBuffer();
       BufferedReader br = new BufferedReader(new FileReader(args[0] + "/chm.html"));
       BufferedWriter bw = new BufferedWriter(new FileWriter(args[1]));
-      String mode = args[2];
       String htmlString = "";
 
       String line = br.readLine();
@@ -240,7 +239,6 @@ public class NGCHM_Widgetizer {
         e.printStackTrace();
       }
       // Inject widget scripts.
-      bw.write("var ngChmWidgetMode = '" + mode + "';\n");
       copyToFile(args[0] + "javascript/ngchm-min.js", bw);
       bw.write("document.body.addEventListener('click', NgChm.UHM.closeMenu,true);\n");
 


### PR DESCRIPTION
This pull request enhances MatrixManager.js with the ability to load multiple maps.  It does NOT provide any UI elements for the casual user to access any of those maps except the first to load.  That capability will be expanded in subsequent pull requests.

This pull request also allows embedded NG-CHMs to load maps from web sources as well as zip files.  This will allow faster loading of large maps if you're not aiming to let the user save the page for off-line use.

Internally, the heat map sources have been changed to API_SOURCE (a shaidy server),  WEB_SOURCE (an unzipped NG-CHM in a web directory), or ZIP_SOURCE (a zip file, blob, etc.)

The HeatMap.source method has been replaced by the MMGR.getSource function.