### PR TITLE
Preparations for user map selection

### DIFF
--- a/NGCHM/WebContent/javascript/CovariateCommands.js
+++ b/NGCHM/WebContent/javascript/CovariateCommands.js
@@ -81,14 +81,14 @@
         }
       } else {
         if (["", "NA", "NAN"].includes(req.value.toUpperCase())) {
-          if (req.command != 'set') {
+          if (req.subcommand != 'set') {
             throw `cannot perform arithmetic using missing value`;
           }
           req.value = "NA";
         } else {
           const value = Number(req.value);
           if (isNaN(value)) {
-            if (req.command == 'set') {
+            if (req.subcommand == 'set') {
               throw `value must be empty/NA/NAN (missing) or a number, not ${req.value}`
             } else {
               throw `value must be a number, not ${req.value}`
@@ -620,7 +620,7 @@
   UTIL.registerCommand ("covar", covarCommand, helper);
 
   function covarCommand(req, res, next) {
-    req.heatMap = MMGR.getHeatMap();
+    if (!req.heatMap) req.heatMap = MMGR.getHeatMap();
     EXEC.doSubCommand (covarCommands, helper, req, res, next);
   }
 

--- a/NGCHM/WebContent/javascript/CovariateCommands.js
+++ b/NGCHM/WebContent/javascript/CovariateCommands.js
@@ -25,6 +25,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       function (req, res) {
         const output = res.output;
         for (const axis of ["row", "column"]) {
@@ -45,9 +47,15 @@
   const setOptions = new Map();
   setOptions.set ("--all", { field: "--all", args: 0 });
 
+  function helpAllOption (req, res, next) {
+    res.output.write(`--all : modify all of the covariate's values.`);
+    next();
+  }
+
   // Used by set, add, and scale commands.
   const calcRoute = [
-    EXEC.genGetOptions (EXEC.axisOptions, setOptions),
+    EXEC.genGetOptions (EXEC.mapOptions, EXEC.axisOptions, setOptions),
+    EXEC.getHeatMap,
     function (req, res, next) {
       if (req["--row"] && req["--column"]) {
         throw `specify either --row or --column, not both.`;
@@ -135,6 +143,7 @@
       },
       EXEC.showOptions([
         EXEC.helpMapOptions,
+        helpAllOption,
         EXEC.helpAxisOptions,
       ]),
     ],
@@ -153,6 +162,8 @@
       },
       EXEC.showOptions([
         EXEC.helpMapOptions,
+        helpAllOption,
+        EXEC.helpAxisOptions,
       ]),
     ],
     route: calcRoute
@@ -169,6 +180,8 @@
       },
       EXEC.showOptions([
         EXEC.helpMapOptions,
+        helpAllOption,
+        EXEC.helpAxisOptions,
       ]),
     ],
     route: calcRoute
@@ -186,6 +199,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       EXEC.reqAxis,
       EXEC.genRequired("name"),
       EXEC.reqDataType,
@@ -214,6 +229,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       EXEC.reqAxis,
       EXEC.reqCovariate,
       reqIndex,
@@ -252,6 +269,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       EXEC.reqAxis,
       function (req, res) {
         const covBars = req.heatMap.getAxisCovariateConfig(req.axis);
@@ -276,6 +295,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       EXEC.reqAxis,
       EXEC.reqCovariate,
       function (req, res) {
@@ -324,6 +345,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       EXEC.reqAxis,
       EXEC.reqCovariate,
       reqNewBreakPt,
@@ -384,6 +407,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       EXEC.reqAxis,
       EXEC.reqCovariate,
       function (req, res, next) {
@@ -410,6 +435,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       EXEC.reqAxis,
       EXEC.reqCovariate,
       reqExistingIndex,
@@ -479,7 +506,7 @@
   });
 
   covarCommands.set("change-missing", {
-    synopsis: "axis name color",
+    synopsis: "[--map name] axis name color",
     helpRoute: [
       function (req, res, next) {
         res.output.write(`Change the missing color of the covariate with the specified axis and name.`);
@@ -490,6 +517,8 @@
       ]),
     ],
     route: [
+      EXEC.genGetOptions (EXEC.mapOptions),
+      EXEC.getHeatMap,
       EXEC.reqAxis,
       EXEC.reqCovariate,
       EXEC.reqColor,

--- a/NGCHM/WebContent/javascript/CovariateCommands.js
+++ b/NGCHM/WebContent/javascript/CovariateCommands.js
@@ -34,9 +34,7 @@
           output.write();
           output.indent();
           const covBars = req.heatMap.getAxisCovariateConfig(axis);
-          for (let key in covBars) {
-            output.write(key);
-          }
+          Object.keys(covBars).forEach((key) => output.write(key));
           output.unindent();
           output.write();
         }
@@ -274,11 +272,7 @@
       EXEC.reqAxis,
       function (req, res) {
         const covBars = req.heatMap.getAxisCovariateConfig(req.axis);
-        const keys = [];
-        for (let key in covBars) {
-          keys.push(key);
-        }
-        res.value = keys;
+        res.value = [...Object.keys(covBars)];
       }
     ]
   });

--- a/NGCHM/WebContent/javascript/CovariateCommands.js
+++ b/NGCHM/WebContent/javascript/CovariateCommands.js
@@ -253,7 +253,7 @@
         order.splice(oldIndex, 1);
         const insertIndex = Math.min(req.index, order.length);
         order.splice(insertIndex, 0, req.covariateName);
-        req.heatMap.setAxisCovariateOrder(req.axis);
+        req.heatMap.setAxisCovariateOrder(req.axis, order);
         res.output.write(`Reordered ${req.axis} covariates`);
       }
     ]

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -72,7 +72,6 @@
         DVW.detailMaps[i].updateSelection();
       }
     }
-    MMGR.getHeatMap().setUnAppliedChanges(true);
   };
 
   /*********************************************************************************************

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -157,7 +157,7 @@
     // In any case, data for the drawing window's level should also arrive soon
     // and the heat map would be redrawn then.
     DVW.detailMaps.forEach((mapItem) => {
-      if (heatMap == mapItem.heatMap) {
+      if (heatMap === mapItem.heatMap) {
         const aw = mapItem.detailHeatMapAccessWindow;
         if (!aw || aw.isTileInWindow(tile)) {
           mapItem.detailHeatMapValidator[tile.layer] = "";

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -80,9 +80,9 @@
    * that is notified every time there is an update to the heat map initialize, new data, etc.
    * This callback draws the summary heat map.
    *********************************************************************************************/
-  DET.processDetailMapUpdate = function (event, tile) {
+  DET.processDetailMapUpdate = function (heatMap, event, tile) {
     if (event === HEAT.Event_NEWDATA) {
-      DET.flushDrawingCache(tile);
+      DET.flushDrawingCache(heatMap, tile);
     }
   };
 
@@ -147,7 +147,7 @@
    * the new tile to be redrawn the next time it is displayed.  The currently displayed primary
    * heat map will be redrawn after a short delay if it might be affected by the tile.
    *********************************************************************************************/
-  DET.flushDrawingCache = function (tile) {
+  DET.flushDrawingCache = function (heatMap, tile) {
     // The cached heat map for the tile's layer will be
     // invalidated if the tile's level matches the level
     // of the cached heat map.
@@ -158,11 +158,13 @@
     // In any case, data for the drawing window's level should also arrive soon
     // and the heat map would be redrawn then.
     DVW.detailMaps.forEach((mapItem) => {
-      const aw = mapItem.detailHeatMapAccessWindow;
-      if (!aw || aw.isTileInWindow(tile)) {
-        mapItem.detailHeatMapValidator[tile.layer] = "";
-        // Redraw 'now', without resizing, if the tile is for the currently displayed layer.
-        DET.setDrawDetailTimeout(mapItem, DET.redrawUpdateTimeout, true);
+      if (heatMap == mapItem.heatMap) {
+        const aw = mapItem.detailHeatMapAccessWindow;
+        if (!aw || aw.isTileInWindow(tile)) {
+          mapItem.detailHeatMapValidator[tile.layer] = "";
+          // Redraw 'now', without resizing, if the tile is for the currently displayed layer.
+          DET.setDrawDetailTimeout(mapItem, DET.redrawUpdateTimeout, true);
+        }
       }
     });
   };

--- a/NGCHM/WebContent/javascript/HeatMapClass.js
+++ b/NGCHM/WebContent/javascript/HeatMapClass.js
@@ -970,6 +970,16 @@
       }
     };
 
+    // Persist the axis covariate order and mark the heatmap as changed.
+    HeatMap.prototype.setAxisCovariateOrder = function (axis) {
+      if (MAPREP.isRow(axis)) {
+        this.setRowClassificationOrder ();
+      } else {
+        this.setColClassificationOrder ();
+      }
+      this.setUnAppliedChanges(true);
+    };
+
     HeatMap.prototype.getMapInformation = function () {
       return this.mapConfig.data_configuration.map_information;
     };

--- a/NGCHM/WebContent/javascript/HeatMapClass.js
+++ b/NGCHM/WebContent/javascript/HeatMapClass.js
@@ -1436,14 +1436,15 @@
       // Send event to all listeners.
       sendAllListeners: function sendAllListeners(event, tile) {
         // Send the event to all listeners.
-        this.eventListeners.forEach((callback) => callback(event, tile));
+        const heatMap = this;
+        this.eventListeners.forEach((callback) => callback(heatMap, event, tile));
         if (event === HEAT.Event_NEWDATA) {
           // Also broadcast NEWDATA events to all levels for which tile.level is an alternate.
           const { layer, level: mylevel, row, col, data } = tile;
           const alts = this.getAllAlternateLevels(mylevel);
           while (alts.length > 0) {
             const altTile = { layer, level: alts.shift(), row, col, data };
-            this.eventListeners.forEach((callback) => callback(event, altTile));
+            this.eventListeners.forEach((callback) => callback(heatMap, event, altTile));
           }
         }
       }

--- a/NGCHM/WebContent/javascript/HeatMapClass.js
+++ b/NGCHM/WebContent/javascript/HeatMapClass.js
@@ -971,12 +971,12 @@
     };
 
     // Persist the axis covariate order and mark the heatmap as changed.
-    HeatMap.prototype.setAxisCovariateOrder = function (axis) {
-      if (MAPREP.isRow(axis)) {
-        this.setRowClassificationOrder ();
-      } else {
-        this.setColClassificationOrder ();
+    HeatMap.prototype.setAxisCovariateOrder = function (axis, order) {
+      if (!Array.isArray(order)) {
+        console.error("setAxisCovariateOrder requires an order array", { axis, order });
+        return;
       }
+      this.getAxisConfig(axis).classifications_order = order.slice();
       this.setUnAppliedChanges(true);
     };
 

--- a/NGCHM/WebContent/javascript/SearchManager.js
+++ b/NGCHM/WebContent/javascript/SearchManager.js
@@ -7,7 +7,6 @@
 
   const SRCHSTATE = NgChm.importNS("NgChm.SRCHSTATE");
   const MAPREP = NgChm.importNS("NgChm.MAPREP");
-  const MMGR = NgChm.importNS("NgChm.MMGR");
   const UTIL = NgChm.importNS("NgChm.UTIL");
   const SUM = NgChm.importNS("NgChm.SUM");
   const DVW = NgChm.importNS("NgChm.DVW");
@@ -89,7 +88,9 @@
   // METHOD SearchInterface.reset - Reset the searchOn options so that only
   // label search entry is available.
   //
-  SearchInterface.prototype.reset = function resetSearchInterface() {
+  SearchInterface.prototype.reset = function resetSearchInterface(heatMap) {
+    // Record current heatMap.
+    this.heatMap = heatMap;
     // Remove any existing options after the first (Labels).
     for (let i = this.ui.searchOn.options.length - 1; i >= 1; i--) {
       this.ui.searchOn.remove(i);
@@ -533,9 +534,9 @@
   // Instantiate the search interface.
   const searchInterface = new SearchInterface();
 
-  SRCH.heatMapListener = function heatMapListener (event) {
-    if (event == HEAT.Event_PLUGINS) {
-      SRCH.configSearchInterface (MMGR.getHeatMap());
+  SRCH.heatMapListener = function heatMapListener (heatMap, event) {
+    if (searchInterface.heatMap == heatMap && event == HEAT.Event_PLUGINS) {
+      SRCH.configSearchInterface (heatMap);
     }
   };
 
@@ -550,7 +551,7 @@
    *
    **********************************************************************************/
   SRCH.configSearchInterface = function (heatMap) {
-    searchInterface.reset();
+    searchInterface.reset(heatMap);
     addCovariateOptions("col");
     addCovariateOptions("row");
     for (const searchOption of heatMap.getSearchOptions()) {
@@ -686,7 +687,7 @@
    * the search and manages the appearance of the covariate search text box.
    **********************************************************************************/
   function covarSearch(searchInterface, searchFor, postFn) {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = searchInterface.heatMap;
     const classDataValues = heatMap.getAxisCovariateData(searchFor.axis)[searchFor.key].values;
     const currentClassBar = heatMap.getAxisCovariateConfig(searchFor.axis)[searchFor.key];
     let validSearch = true;
@@ -825,9 +826,8 @@
     // Helper function.
     // Find matches against labels on the specified axis.
     function searchLabels(axis) {
-      const heatMap = MMGR.getHeatMap();
       // Searches are case independent, so we map everything to upper case.
-      const labels = heatMap.actualLabels(axis).map(label => label.toUpperCase());
+      const labels = searchInterface.heatMap.actualLabels(axis).map(label => label.toUpperCase());
       for (const searchItem of searchItems) {
         if (searchItem == "." || searchItem == "*") {
           // if this is a search item that's going to return everything, skip it.

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -82,9 +82,9 @@
 
   // Callback that is notified every time there is an update to the heat map
   // initialize, new data, etc.  This callback draws the summary heat map.
-  SUM.processSummaryMapUpdate = function (event, tile) {
+  SUM.processSummaryMapUpdate = function (heatMap, event, tile) {
     if (event === HEAT.Event_NEWDATA && tile.level === MAPREP.SUMMARY_LEVEL) {
-      if (!MMGR.getHeatMap().initialized) {
+      if (!heatMap.initialized) {
         return;
       }
       //Summary tile - wait a bit to see if we get another tile quickly, then draw

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -94,6 +94,8 @@
       }
       SUM.flushDrawingCache(tile);
       SUM.eventTimer = setTimeout(SUM.buildSummaryTexture, 200);
+    } else if (event === HEAT.Event_PLUGINS && heatMap === MMGR.getHeatMap()) {
+      SUM.redrawSummaryPanel();
     }
     //Ignore updates to other tile types.
   };

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -83,6 +83,10 @@
   // Callback that is notified every time there is an update to the heat map
   // initialize, new data, etc.  This callback draws the summary heat map.
   SUM.processSummaryMapUpdate = function (heatMap, event, tile) {
+    // Ignore updates to any maps other than the one we are showing.
+    if (heatMap !== MMGR.getHeatMap()) {
+      return;
+    }
     if (event === HEAT.Event_NEWDATA && tile.level === MAPREP.SUMMARY_LEVEL) {
       if (!heatMap.initialized) {
         return;
@@ -94,7 +98,7 @@
       }
       SUM.flushDrawingCache(tile);
       SUM.eventTimer = setTimeout(SUM.buildSummaryTexture, 200);
-    } else if (event === HEAT.Event_PLUGINS && heatMap === MMGR.getHeatMap()) {
+    } else if (event === HEAT.Event_PLUGINS) {
       SUM.redrawSummaryPanel();
     }
     //Ignore updates to other tile types.

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -367,9 +367,8 @@
     const debug = false;
     var firstTime = true;
 
-    UIMGR.configurePanelInterface = function configurePanelInterface() {
+    UIMGR.configurePanelInterface = function configurePanelInterface(heatMap) {
 
-      const heatMap = MMGR.getHeatMap();
       onMapReady (heatMap);
       UIMGR.initializeSummaryWindows(heatMap);
 
@@ -699,11 +698,34 @@
 
   function loadWebMaps () {
     UTIL.showLoader("Loading NG-CHM from server...");
-    MMGR.loadWebMaps (srcInfo, updateCallbacks, () => {
-      resetCHM();
-      initDisplayVars();
-      UIMGR.configurePanelInterface();
-    });
+    MMGR.loadWebMaps (srcInfo, updateCallbacks, allMapsLoaded);
+  }
+
+  function allMapsLoaded () {
+    const heatMap = MMGR.getHeatMap();
+    resetCHM();
+    initDisplayVars();
+    UIMGR.configurePanelInterface(heatMap);
+    return;
+    // Helper function : Reload CHM SelectionManager parameters after loading heatMaps.
+    function resetCHM() {
+      SRCH.clearAllSearchResults();
+      DVW.scrollTime = null;
+      SUM.colDendro = null;
+      SUM.rowDendro = null;
+    }
+    // Helper function : Reinitialize summary and detail display values after loading heatMaps.
+    function initDisplayVars() {
+      DRAW.widthScale = 1; // scalar used to stretch small maps (less than 250) to be proper size
+      DRAW.heightScale = 1;
+      SUM.summaryHeatMapCache = {};
+      SUM.colTopItemsWidth = 0;
+      SUM.rowTopItemsHeight = 0;
+      DMM.nextMapNumber = 1;
+      DEV.setMouseDown(false);
+      UTIL.removeElementsByClass("DynamicLabel");
+      SRCH.clearAllCurrentSearchItems();
+    }
   }
 
   // API.embedNGCHM (in NGCHM_Embed.js) allows the NG-CHM to be specified in 4 ways:
@@ -910,44 +932,7 @@
    **********************************************************************************/
   function displayZipFileCHM(chmFile) {
     UTIL.showLoader("Loading NG-CHM from zip file...");
-    MMGR.loadZipMaps(
-      chmFile,
-      updateCallbacks,
-      () => {
-        resetCHM();
-        initDisplayVars();
-        UIMGR.configurePanelInterface ();
-      }
-    );
-  }
-
-  /**********************************************************************************
-   * FUNCTION - resetCHM: This function will reload CHM SelectionManager parameters
-   * when loading a file mode heatmap.  Specifically for handling the case where switching
-   * from one file-mode heatmap to another
-   **********************************************************************************/
-  function resetCHM() {
-    SRCH.clearAllSearchResults();
-    DVW.scrollTime = null;
-    SUM.colDendro = null;
-    SUM.rowDendro = null;
-  }
-
-  /**********************************************************************************
-   * FUNCTION - initDisplayVars: This function reinitializes summary and detail
-   * display values whenever a file-mode map is opened.  This is done primarily
-   * to reset screens when a second, third, etc. map is opened.
-   **********************************************************************************/
-  function initDisplayVars() {
-    DRAW.widthScale = 1; // scalar used to stretch small maps (less than 250) to be proper size
-    DRAW.heightScale = 1;
-    SUM.summaryHeatMapCache = {};
-    SUM.colTopItemsWidth = 0;
-    SUM.rowTopItemsHeight = 0;
-    DMM.nextMapNumber = 1;
-    DEV.setMouseDown(false);
-    UTIL.removeElementsByClass("DynamicLabel");
-    SRCH.clearAllCurrentSearchItems();
+    MMGR.loadZipMaps(chmFile, updateCallbacks, allMapsLoaded);
   }
 
   /**********************************************************************************

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -365,7 +365,6 @@
   //
   (function () {
     const debug = false;
-    var firstTime = true;
 
     UIMGR.configurePanelInterface = function configurePanelInterface(heatMap) {
 
@@ -380,24 +379,9 @@
       SRCH.configSearchInterface(heatMap);
 
       CUST.addCustomJS();
-      if (MMGR.getSource() === MMGR.ZIP_SOURCE) {
-        firstTime = true;
-        if (SUM.chmElement) {
-          PANE.emptyPaneLocation(PANE.findPaneLocation(SUM.chmElement));
-        }
-        if (DVW.detailMaps.length > 0) {
-          for (let i = 0; i < DVW.detailMaps.length; i++) {
-            PANE.emptyPaneLocation(PANE.findPaneLocation(DVW.detailMaps[i].chm));
-          }
-        }
-      }
+
       // Split the initial pane horizontally and insert the
       // summary and detail NGCHMs into the children.
-      if (firstTime) {
-        firstTime = false;
-      } else {
-        return;
-      }
       UTIL.showLoader("Configuring interface...");
       //
       // Define the DROP TARGET and set the drop event handler(s).

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -34,6 +34,7 @@
   const CMDD = NgChm.importNS("NgChm.CMDD");
   const TOUR = NgChm.importNS("NgChm.TOUR");
   const EXEC = NgChm.importNS("NgChm.EXEC");
+  const UPM = NgChm.importNS("NgChm.UPM");
 
   const debugEmbed = UTIL.getDebugFlag("ui-embed");
   const srcInfo = {
@@ -1741,6 +1742,17 @@
   document.getElementById("menuFileOpen").onclick = () => {
     openFileToggle();
   };
+
+  // Two ways to open the Preferences Manager.
+  {
+    document.getElementById("colorMenu_btn").onclick = openPreferencesManager;
+    document.getElementById("menuGear").onclick = openPreferencesManager;
+    // Helper function.
+    function openPreferencesManager() {
+      const heatMap = MMGR.getHeatMap();
+      UPM.openPreferencesManager(heatMap);
+    }
+  }
 
   function clearSelectedDendrogram(mapItem) {
     if (mapItem.selectedIsDendrogram) {

--- a/NGCHM/WebContent/javascript/UserPreferenceManager.js
+++ b/NGCHM/WebContent/javascript/UserPreferenceManager.js
@@ -216,10 +216,6 @@
 
   // Define a click handler for each of the Preferences Manager UI elements.
   (function () {
-    // Two ways to open the Preferences Manager.
-    KAE("colorMenu_btn").onclick = () => openPreferencesManager();
-    KAE("menuGear").onclick = () => openPreferencesManager();
-
     // Two ways to close the Preferences Manager.
     KAE("redX_btn").onclick = () => closePreferencesManager();
     KAE("prefClose_btn").onclick = () => closePreferencesManager();
@@ -261,14 +257,14 @@
    *  - getNewBreakThresholds
    =================================================================================*/
 
-  /* FUNCTION openPreferencesManager - Open the User Preferences Manager for the current
-   * heatmap.
+  /* FUNCTION UPM.openPreferencesManager - Open the User Preferences Manager for the
+   * specified heatmap.
    *
    * This function is called if
    * - the Edit Preferences "gear" button is pressed on the main application screen, or
    * - the Modify Map Preferences menu option is selected from the hamburger menu.
    */
-  function openPreferencesManager() {
+  UPM.openPreferencesManager = function openPreferencesManager(heatMap) {
     UHM.closeMenu();
     UHM.hlpC();
 
@@ -281,7 +277,7 @@
     }
 
     // Set the heatMap we are editing.
-    UPM.heatMap = MMGR.getHeatMap();
+    UPM.heatMap = heatMap;
 
     // Disable the apply and reset buttons until a change is made.
     applyButton.disabled = true;
@@ -289,7 +285,7 @@
 
     // Execute common code to display the contents of the Preferences Manager.
     editPreferences(null);
-  }
+  };
 
   /**********************************************************************************
    * FUNCTION closePreferencesManager: Close the Preferences Manager Window.


### PR DESCRIPTION
The PR consists of several small changes we need to make before allowing the user to select the NG-CHM they want to view.

The aim is to get them out of the way before those PRs.

Specifically, this PR contains commits that:

- Fixed several commands to make them behave as documented
- Removed the unused firstTime test in UIMGR.configurePanelInterface
- Added a function to perform the necessary actions after all maps have loaded
- Moved the event listeners for opening the preferences manager to UI-Manager.js
- Stopped marking heat maps as changed just because selections are redrawn
- Added the heatMap to which they apply to the events sent to HeatMapListeners
- Made numerous additional fixes/tweaks in response to Code Rabbit comments

To see how I can make changes after this month, I made this PR using my fork of the repository and a test PR I created there to interact with CodeRabbit (at least initially). I plan to discard it, but for now you can see CodeRabbit's comments at [https://github.com/bmbroom/NG-CHM/pull/2](https://github.com/bmbroom/NG-CHM/pull/2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Preferences Manager accessible from color menu and gear, scoped to the current heat map.
  * Covariate reordering supports moving items to the end.
  * Added “--all” option in covariate commands.

* Improvements
  * Deterministic covariate listing based on display order.
  * More robust missing value handling and value parsing.
  * Clearer tracking of unapplied changes after edits.
  * Search and UI initialization scoped to the active heat map.

* Bug Fixes
  * Prevents redraws and updates from unrelated heat maps.
  * Removes unintended global change flags.

* Documentation
  * Help text updated to reflect new options and map scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->