### PR TITLE
Add initial ability to switch between different maps

### DIFF
--- a/NGCHM/WebContent/chm.html
+++ b/NGCHM/WebContent/chm.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<title>NG-CHM</title>
+		<title>NG-CHM Viewer</title>
 		<meta charset="utf-8"/>
 
 		<link rel="shortcut icon" type="image/png" href="images/ngChmIcon.png">

--- a/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapDisplay.js
@@ -2797,6 +2797,7 @@
         let height = parseInt(dendroCanvas.style.height, 10) | 0;
         height =
           mapItem.colDendro.summaryDendrogram.callbacks.calcDetailDendrogramSize(
+            mapItem.heatMap,
             "column",
             height,
             totalDetHeight,
@@ -2840,6 +2841,7 @@
 
         width =
           mapItem.rowDendro.summaryDendrogram.callbacks.calcDetailDendrogramSize(
+            mapItem.heatMap,
             "row",
             width,
             totalDetWidth,

--- a/NGCHM/WebContent/javascript/DetailHeatMapManager.js
+++ b/NGCHM/WebContent/javascript/DetailHeatMapManager.js
@@ -27,7 +27,7 @@
     pane: null,
     chm: null,
     heatMap: null,
-    version: "P",
+    version: "S",
     panelNbr: 1,
     mode: "NORMAL",
     prevMode: "NORMAL",
@@ -360,7 +360,7 @@
    *********************************************************************************************/
   DMM.switchToPrimary = function (mapItem) {
     // Cannot switch to primary if not the same heatMap as SUMMARY heatMap.
-    if (mapItem && mapItem.heatMap != SUM.heatMap) return;
+    if (mapItem && mapItem.heatMap !== SUM.heatMap) return;
     const chm = mapItem ? mapItem.chm : null;
     DVW.primaryMap = null;
     for (let i = 0; i < DVW.detailMaps.length; i++) {
@@ -421,7 +421,7 @@
   // FUNCTION detailMapsForHeatMap - return an array of the detail map views
   // for the specified heatMap.
   function detailMapsForHeatMap (heatMap) {
-    return DVW.detailMaps.filter(mapItem => mapItem.heatMap == heatMap);
+    return DVW.detailMaps.filter(mapItem => mapItem.heatMap === heatMap);
   }
 
   /*********************************************************************************************
@@ -557,7 +557,7 @@
       mapItem.saveCol = startCol;
       DET.callDetailDrawFunction("RIBBONV", mapItem);
     }
-    mapItem.updateSelection(mapItem);
+    mapItem.updateSelection();
     SUM.drawSelectionMarks();
   }
 

--- a/NGCHM/WebContent/javascript/HeatMapClass.js
+++ b/NGCHM/WebContent/javascript/HeatMapClass.js
@@ -545,6 +545,7 @@
   // Used to get HeatMapLevel object.
   class HeatMap {
     constructor (heatMapName, updateCallbacks, getTileLoader, onready) {
+      this.nonce = UTIL.getNewNonce(); // Unique identifier for this heatMap.
       this.initialized = false; // True once the minimum components have loaded.
       this.version = 0; // Update to indicate need to save or redraw.
       this.savedVersion = 0; // Last version that was saved.

--- a/NGCHM/WebContent/javascript/Linkout.js
+++ b/NGCHM/WebContent/javascript/Linkout.js
@@ -1331,7 +1331,7 @@ var linkoutsVersion = "undefined";
 
     function sendDataToBuilder() {
       const debug = false;
-      const nonce = PIM.getNewNonce();
+      const nonce = UTIL.getNewNonce();
       const url = new URL(util.value.replace(/[/]*[A-Za-z0-9-.]*.html*$/, ""));
       const builder = window.open(
         url.href + "/Upload_Matrix.html?adv=Y&nonce=" + nonce,

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -819,6 +819,11 @@
       return heatMap;
     };
 
+    // Set the current heat map.
+    MMGR.setHeatMap = function setHeatMap(hm) {
+      heatMap = hm;
+    };
+
     // Return all heat maps.
     MMGR.getAllHeatMaps = function getAllHeatMaps() {
       return allHeatMaps;

--- a/NGCHM/WebContent/javascript/MatrixManager.js
+++ b/NGCHM/WebContent/javascript/MatrixManager.js
@@ -8,6 +8,7 @@
   // Once the maps have been loaded,
   // - MMGR.getAllHeatMaps() returns all maps.
   // - MMGR.getHeatMap() returns the current map.
+  // - MMGR.getHeatMapByNonce() returns the map with the specified nonce.
 
   // Define Namespace for NgChm MatrixManager
   const MMGR = NgChm.createNS("NgChm.MMGR");
@@ -829,10 +830,20 @@
       return allHeatMaps;
     };
 
+    // Return the heat map with the specified nonce.
+    MMGR.getHeatMapByNonce = function getHeatMapByNonce (nonce) {
+      for (const heatMap of allHeatMaps) {
+        if (heatMap.nonce === nonce) {
+          return heatMap;
+        }
+      }
+      return null;
+    };
+
     // Return true iff any heatmap has unsaved changes.
     MMGR.hasUnsavedChanges = function () {
-      for (const heatmap of allHeatMaps) {
-        if (heatmap.getUnAppliedChanges()) {
+      for (const heatMap of allHeatMaps) {
+        if (heatMap.getUnAppliedChanges()) {
           return true;
         }
       }
@@ -841,8 +852,8 @@
 
     // Return true iff any read-only heatmap has unsaved changes.
     MMGR.hasReadOnlyChanges = function () {
-      for (const heatmap of allHeatMaps) {
-        if (heatMap.isReadOnly() && heatmap.getUnAppliedChanges()) {
+      for (const heatMap of allHeatMaps) {
+        if (heatMap.isReadOnly() && heatMap.getUnAppliedChanges()) {
           return true;
         }
       }
@@ -851,15 +862,15 @@
 
     // Clear unsaved changes flag on all heat maps.
     MMGR.clearUnsavedChanges = function () {
-      for (const heatmap of allHeatMaps) {
-        heatmap.setUnAppliedChanges(false);
+      for (const heatMap of allHeatMaps) {
+        heatMap.setUnAppliedChanges(false);
       }
     };
 
     // Return true if any heatmap was updated on load.
     MMGR.mapUpdatedOnLoad = function () {
-      for (const heatmap of allHeatMaps) {
-        if (heatmap.mapUpdatedOnLoad) {
+      for (const heatMap of allHeatMaps) {
+        if (heatMap.mapUpdatedOnLoad) {
           return true;
         }
       }
@@ -895,7 +906,7 @@
     function saveMaps (callback) {
       return function onMapsLoaded (maps) {
         allHeatMaps = maps;
-        heatMap = allHeatMaps[0];
+        MMGR.setHeatMap(allHeatMaps[0]);
         callback();
       };
     }

--- a/NGCHM/WebContent/javascript/NGCHM_Util.js
+++ b/NGCHM/WebContent/javascript/NGCHM_Util.js
@@ -36,6 +36,15 @@
     return str.substr(0, 1).toUpperCase() + str.substr(1);
   };
 
+  // Create a new, unique nonce.
+  UTIL.getNewNonce = function getNewNonce() {
+    const ta = new Uint8Array(16);
+    window.crypto.getRandomValues(ta);
+    return Array.from(ta)
+      .map((x) => x.toString(16))
+      .join("");
+  };
+
   // UTIL.passiveCompat is a function that accepts an options
   // object for addEventListener and depending on the browser's
   // support for the passive flag returns either:

--- a/NGCHM/WebContent/javascript/PluginInstanceManager.js
+++ b/NGCHM/WebContent/javascript/PluginInstanceManager.js
@@ -82,22 +82,12 @@
     initializePlugin(nonce, options);
   };
 
-  // Create a new, unique nonce.
-  PIM.getNewNonce = getNewNonce;
-  function getNewNonce() {
-    const ta = new Uint8Array(16);
-    window.crypto.getRandomValues(ta);
-    return Array.from(ta)
-      .map((x) => x.toString(16))
-      .join("");
-  }
-
   // Create a new instance of the specified plugin and return the
   // iframe associated with the new instance.  The caller is
   // responsible for inserting the iframe into the correct place
   // in the DOM.
   PIM.createPluginInstance = function createPluginInstance(kind, plugin) {
-    const nonce = getNewNonce();
+    const nonce = UTIL.getNewNonce();
     const isBlob = /^blob:/.test(plugin.src);
     const url = isBlob
       ? plugin.src

--- a/NGCHM/WebContent/javascript/SearchManager.js
+++ b/NGCHM/WebContent/javascript/SearchManager.js
@@ -89,6 +89,7 @@
   // label search entry is available.
   //
   SearchInterface.prototype.reset = function resetSearchInterface(heatMap) {
+    SRCHSTATE.clearAllSearchResults();
     // Record current heatMap.
     this.heatMap = heatMap;
     // Remove any existing options after the first (Labels).
@@ -543,7 +544,7 @@
   /**********************************************************************************
    * FUNCTION SRCH.configSearchInterface: Initialize/reset the search interface
    * for the specified heatMap.  It is called from the UI-Manager after the
-   * heatMap has initialized.
+   * heatMap has initialized, or whenever a new heatMap is selected.
    *
    * Specifically, it:
    * - resets the search interface.
@@ -638,14 +639,6 @@
         DVW.primaryMap.canvas.focus();
       }
     }
-  };
-
-  /**********************************************************************************
-   * FUNCTION - clearAllSearchResults: This function initializes/resets all
-   * search-related state variables.
-   **********************************************************************************/
-  SRCH.clearAllSearchResults = function () {
-    SRCHSTATE.clearAllSearchResults();
   };
 
   /**********************************************************************************

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -6,7 +6,6 @@
 
   const MAPREP = NgChm.importNS("NgChm.MAPREP");
   const HEAT = NgChm.importNS("NgChm.HEAT");
-  const MMGR = NgChm.importNS("NgChm.MMGR");
   const CMM = NgChm.importNS("NgChm.CMM");
   const SUMDDR = NgChm.importNS("NgChm.SUMDDR");
   const UTIL = NgChm.importNS("NgChm.UTIL");
@@ -15,11 +14,14 @@
   const PANE = NgChm.importNS("NgChm.Pane");
   const SRCHSTATE = NgChm.importNS("NgChm.SRCHSTATE");
 
+  const debug = UTIL.getDebugFlag("sum");
+
   // Flags.
   SUM.flagDrawClassBarLabels = false; // Labels are only drawn in NGCHM_GUI_Builder
 
   //WebGl Canvas, Context, and Pixel Arrays
   SUM.chmElement = null; // div containing summary heatmap
+  SUM.heatMap = null; // HeatMap being displayed in SUM.chmElement.
   SUM.canvas = null; //Primary Heat Map Canvas
   SUM.rCCanvas = null; //Row Class Bar Canvas
   SUM.cCCanvas = null; //Column Class Bar Canvas
@@ -80,6 +82,18 @@
     SUM.cCCanvas = document.getElementById("col_class_canvas");
   };
 
+  // FUNCTION SUM.setHeatMap - Set the heatMap (to be) displayed in the
+  // summary panel.
+  SUM.setHeatMap = function setHeatMap(heatMap) {
+    SUM.heatMap = heatMap;
+    SUM.colDendro = null;
+    SUM.rowDendro = null;
+    SUM.summaryHeatMapCache = {};
+    SUM.colTopItemsWidth = 0;
+    SUM.rowTopItemsHeight = 0;
+    SUM.initSummaryData();
+  };
+
   // Callback that is notified every time there is an update to the heat map
   // initialize, new data, etc.  This callback draws the summary heat map.
   SUM.processSummaryMapUpdate = function (heatMap, event, tile) {
@@ -88,6 +102,9 @@
       return;
     }
     if (event === HEAT.Event_NEWDATA && tile.level === MAPREP.SUMMARY_LEVEL) {
+      if (debug) {
+        console.log("processSummaryMapUpdate", { heatMap, event, tile });
+      }
       if (!heatMap.initialized) {
         return;
       }
@@ -104,11 +121,10 @@
     //Ignore updates to other tile types.
   };
 
-  // Initialize heatmap summary data that is independent of there being
-  // a summary panel.  This function is called once the heatmap data
-  // has been loaded, but before creating any view panels.
-  SUM.initSummaryData = function (callbacks) {
-    const ddrCallbacks = {
+  const ddrCallbacks = {};
+  // FUNCTION SUM.initDdrCallbacks - Initialize dendrogram callbacks.
+  SUM.initDdrCallbacks = function (callbacks) {
+    Object.assign(ddrCallbacks, {
       clearSelectedRegion: function (axis) {
         callbacks.callDetailDrawFunction("NORMAL");
         if (DVW.primaryMap) {
@@ -188,46 +204,47 @@
         }
         return size;
       },
-    };
+    });
+  };
 
-    SUM.reinitSummaryData = function () {
-      const heatMap = MMGR.getHeatMap();
-      if (!SUM.colDendro) {
-        SUM.colDendro = new SUMDDR.SummaryColumnDendrogram(
-          heatMap,
-          ddrCallbacks,
-        );
-      }
-      if (!SUM.rowDendro) {
-        SUM.rowDendro = new SUMDDR.SummaryRowDendrogram(heatMap, ddrCallbacks);
-      }
-      SUM.colTopItems = heatMap.getTopItems("column", { count: 10 });
-      SUM.rowTopItems = heatMap.getTopItems("row", { count: 10 });
+  // Initialize heatmap summary data that is independent of there being
+  // a summary panel.  This function is called once the heatmap data
+  // has been loaded, but before creating any view panels.
+  SUM.initSummaryData = function () {
+    const heatMap = SUM.heatMap;
+    if (!SUM.colDendro) {
+      SUM.colDendro = new SUMDDR.SummaryColumnDendrogram(
+        heatMap,
+        ddrCallbacks,
+      );
+    }
+    if (!SUM.rowDendro) {
+      SUM.rowDendro = new SUMDDR.SummaryRowDendrogram(heatMap, ddrCallbacks);
+    }
+    SUM.colTopItems = heatMap.getTopItems("column", { count: 10 });
+    SUM.rowTopItems = heatMap.getTopItems("row", { count: 10 });
 
-      SUM.matrixWidth = heatMap.getNumColumns(MAPREP.SUMMARY_LEVEL);
-      SUM.matrixHeight = heatMap.getNumRows(MAPREP.SUMMARY_LEVEL);
+    SUM.matrixWidth = heatMap.getNumColumns(MAPREP.SUMMARY_LEVEL);
+    SUM.matrixHeight = heatMap.getNumRows(MAPREP.SUMMARY_LEVEL);
 
-      if (SUM.matrixWidth < SUM.minDimensionSize) {
-        SUM.widthScale = Math.max(
-          2,
-          Math.ceil(SUM.minDimensionSize / SUM.matrixWidth),
-        );
-      }
-      if (SUM.matrixHeight < SUM.minDimensionSize) {
-        SUM.heightScale = Math.max(
-          2,
-          Math.ceil(SUM.minDimensionSize / SUM.matrixHeight),
-        );
-      }
-      SUM.calcTotalSize();
-    };
-    SUM.reinitSummaryData();
+    if (SUM.matrixWidth < SUM.minDimensionSize) {
+      SUM.widthScale = Math.max(
+        2,
+        Math.ceil(SUM.minDimensionSize / SUM.matrixWidth),
+      );
+    }
+    if (SUM.matrixHeight < SUM.minDimensionSize) {
+      SUM.heightScale = Math.max(
+        2,
+        Math.ceil(SUM.minDimensionSize / SUM.matrixHeight),
+      );
+    }
+    SUM.calcTotalSize();
   };
 
   SUM.redrawSummaryPanel = function () {
     // Nothing to redraw if never initialized.
     if (!SUM.chmElement) return;
-    SUM.reinitSummaryData();
 
     //Classificaton bars get stretched on small maps, scale down the bars and padding.
     SUM.rowClassBarWidth = SUM.calculateSummaryTotalClassBarHeight("row");
@@ -275,7 +292,7 @@
   //mimimum width is also set for the summary chm so that the divider bar cannot be dragged
   //further to the left.
   SUM.setMinimumSummaryWidth = function (minSumWidth) {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     var sumPct = parseInt(heatMap.getMapInformation().summary_width);
     if (typeof NgChm.galaxy === "undefined") {
       // FIXME: BMB: Implement a better way of determining Galaxy mode.
@@ -303,7 +320,7 @@
 
   SUM.setSelectionDivSize = function (width, height) {
     // input params used for PDF Generator to resize canvas based on PDF sizes
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     var colSel = document.getElementById("summary_col_select_canvas");
     var rowSel = document.getElementById("summary_row_select_canvas");
     var colTI = document.getElementById("summary_col_top_items_canvas");
@@ -469,9 +486,10 @@
 
   //Create a summary heat map for the current data layer and display it.
   SUM.buildSummaryTexture = function () {
-    const debug = false;
-
-    const heatMap = MMGR.getHeatMap();
+    if (debug) {
+      console.log("buildSummaryTexture");
+    }
+    const heatMap = SUM.heatMap;
     const currentDl = heatMap.getCurrentDL();
     let renderBuffer;
     if (SUM.summaryHeatMapCache.hasOwnProperty(currentDl)) {
@@ -535,7 +553,7 @@
 
   // Redisplay the summary heat map for the current data layer.
   SUM.drawHeatMap = function () {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     const currentDl = heatMap.getCurrentDL();
     if (SUM.summaryHeatMapCache[currentDl] !== undefined) {
       drawHeatMapRenderBuffer(SUM.summaryHeatMapCache[currentDl]);
@@ -555,7 +573,10 @@
 
   // Renders the Summary Heat Map for the current data layer into the specified renderBuffer.
   function renderSummaryHeatMap(renderBuffer, widthScale, heightScale) {
-    const heatMap = MMGR.getHeatMap();
+    if (debug) {
+      console.log("renderSummaryHeatMap");
+    }
+    const heatMap = SUM.heatMap;
     const currentDl = heatMap.getCurrentDL();
     const colorMap = heatMap
       .getColorMapManager()
@@ -618,7 +639,7 @@
 
   //Draws Row Classification bars into the webGl texture array ("dataBuffer"). "names"/"colorSchemes" should be array of strings.
   SUM.buildRowClassTexture = function buildRowClassTexture() {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     SUM.texRc = buildRowCovariateRenderBuffer(SUM.widthScale, SUM.heightScale);
 
     DVW.removeLabels("missingSumRowClassBars");
@@ -646,7 +667,7 @@
 
   SUM.buildRowCovariateRenderBuffer = buildRowCovariateRenderBuffer;
   function buildRowCovariateRenderBuffer(widthScale, heightScale) {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
 
     const renderBuffer = DRAW.createRenderBuffer(
       SUM.rowClassBarWidth * widthScale,
@@ -706,7 +727,7 @@
 
   //Draws Column Classification bars into the webGl texture array ("dataBuffer"). "names"/"colorSchemes" should be array of strings.
   SUM.buildColClassTexture = function () {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     SUM.texCc = SUM.buildColCovariateRenderBuffer(
       SUM.widthScale,
       SUM.heightScale,
@@ -737,7 +758,7 @@
   };
 
   SUM.buildColCovariateRenderBuffer = function (widthScale, heightScale) {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     // SUM.totalWidth includes a factor of SUM.widthScale, so we need to get the width without that scaling.
     const baseWidth = SUM.totalWidth / SUM.widthScale;
     const renderBuffer = DRAW.createRenderBuffer(
@@ -846,7 +867,7 @@
     ctx.lineWidth = 1;
     ctx.strokeStyle = "#000000";
 
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
 
     // If no row or column cuts, draw the heat map border in black
     if (!heatMap.hasGaps()) {
@@ -935,7 +956,7 @@
     if (!SUM.chmElement) return;
     // Reset the canvas (drawing borders and sub-dendro selections)
     const ctx = SUM.resetBoxCanvas(SUM.boxCanvas);
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     const dataLayers = heatMap.getDataLayers();
     DVW.detailMaps.forEach((mapItem) => {
       // Draw the View Box using user-defined defined selection color
@@ -1112,7 +1133,7 @@
   };
 
   SUM.drawRowClassBarLabels = function () {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     SUM.removeRowClassBarLabels();
     var colCanvas = document.getElementById("summary_col_top_items_canvas");
     var rowCanvas = document.getElementById("summary_row_top_items_canvas");
@@ -1166,7 +1187,7 @@
   };
 
   SUM.drawColClassBarLabels = function () {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     SUM.removeColClassBarLabels();
     var classBarsConfig = heatMap.getColClassificationConfig();
     var classBarConfigOrder = heatMap.getColClassificationOrder();
@@ -1190,7 +1211,7 @@
     //find the first, middle, and last vertical positions for the bar legend being drawn
     var topPos = beginClasses + prevHeight;
     var midPos = topPos + (currentClassBar.height - 15) / 2 - 1;
-    var midVal = MMGR.getHeatMap().getLabelText(key, "ROW", true);
+    var midVal = SUM.heatMap.getLabelText(key, "ROW", true);
     //Create div and place mid legend value
     SUM.setLabelDivElement(key + "ColLabel", midVal, midPos, leftPos, false);
   };
@@ -1227,7 +1248,7 @@
   };
 
   SUM.drawColClassBarLegends = function () {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     var classBarsConfig = heatMap.getColClassificationConfig();
     var classBarConfigOrder = heatMap.getColClassificationOrder();
     var classBarsData = heatMap.getColClassificationData();
@@ -1422,7 +1443,7 @@
 
   //THIS FUNCTION NOT CURRENTLY FOR THE SUMMARY PANEL CALLED BUT MAY BE ADDED BACK IN IN THE FUTURE
   SUM.drawRowClassBarLegends = function () {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     var classBarsConfig = heatMap.getRowClassificationConfig();
     var classBarConfigOrder = heatMap.getRowClassificationOrder();
     var classBarsData = heatMap.getRowClassificationData();
@@ -1592,7 +1613,7 @@
   //Hidden bars will have height zero.  The order of entries is fixed but
   //not specified.
   SUM.getSummaryCovariateBarHeights = function (axis) {
-    return MMGR.getHeatMap()
+    return SUM.heatMap
       .getScaledVisibleCovariates(axis, 1.0)
       .map((bar) => SUM.getScaledHeight(bar.height, axis));
   };
@@ -1876,7 +1897,7 @@
 
   // Draw the selection marks on the specified axis.
   SUM.drawAxisSelectionMarks = function (axis) {
-    const heatMap = MMGR.getHeatMap();
+    const heatMap = SUM.heatMap;
     const isRow = MAPREP.isRow(axis);
     const selection = SRCHSTATE.getAxisSearchResults(isRow ? "Row" : "Column");
     const canvas = document.getElementById(
@@ -2049,7 +2070,7 @@
 
         // Helper function. Determine maximum width of top items on the specified axis.
         function calcTopItemsMaxWidth(axis) {
-          const shownLabels = MMGR.getHeatMap().shownLabels(axis);
+          const shownLabels = SUM.heatMap.shownLabels(axis);
           const topItems = getTopItemLabelIndices(axis);
           let maxWidth = 0;
           topItems.forEach((ti) => {
@@ -2076,7 +2097,7 @@
         return;
       }
 
-      const heatMap = MMGR.getHeatMap();
+      const heatMap = SUM.heatMap;
 
       if (SUM.colTopItems || SUM.rowTopItems) {
         // create a reference top item div to space the elements properly. removed at end
@@ -2309,7 +2330,7 @@
       // function above).
       function placeTopItemLabels(canvas, topItemPosns, axis, otherAxisPosn) {
         const isRow = MAPREP.isRow(axis);
-        const shownLabels = MMGR.getHeatMap().shownLabels(axis);
+        const shownLabels = SUM.heatMap.shownLabels(axis);
         topItemPosns.forEach((tip) => {
           const item = document.createElement("Div");
           item.classList.add("topItems");
@@ -2342,7 +2363,7 @@
     // Return an array of the label indices of the top items on the specified axis.
     function getTopItemLabelIndices(axis) {
       const topItems = MAPREP.isRow(axis) ? SUM.rowTopItems : SUM.colTopItems;
-      const mapLabels = MMGR.getHeatMap().actualLabels(axis);
+      const mapLabels = SUM.heatMap.actualLabels(axis);
       // Trim top items, filter out empty items, uniqify.
       const uniqTopItems = topItems
         .map((l) => l.trim())

--- a/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapDisplay.js
@@ -98,7 +98,7 @@
   // initialize, new data, etc.  This callback draws the summary heat map.
   SUM.processSummaryMapUpdate = function (heatMap, event, tile) {
     // Ignore updates to any maps other than the one we are showing.
-    if (heatMap !== MMGR.getHeatMap()) {
+    if (heatMap !== SUM.heatMap) {
       return;
     }
     if (event === HEAT.Event_NEWDATA && tile.level === MAPREP.SUMMARY_LEVEL) {
@@ -226,6 +226,10 @@
   // for the specified heatMap and axis.
   SUM.getSummaryDendrogram = function (heatMap, axis) {
     const ddrs = summaryDendrograms.get(heatMap);
+    if (!ddrs) {
+      console.error("No summary dendrograms for heatMap", { heatMap, axis });
+      return null;
+    }
     return MAPREP.isRow(axis) ? ddrs.row : ddrs.column;
   };
 

--- a/NGCHM/WebContent/javascript/SummaryHeatMapManager.js
+++ b/NGCHM/WebContent/javascript/SummaryHeatMapManager.js
@@ -21,6 +21,7 @@
   SMM.onMouseUpSelRowCanvas = function (evt) {
     evt.preventDefault();
     evt.stopPropagation();
+    if (!DVW.primaryMap) return;
     //When doing a shift drag, this block will actually do the selection on mouse up.
     var sumOffsetX = evt.touches ? evt.layerX : evt.offsetX;
     var sumOffsetY = evt.touches ? evt.layerY : evt.offsetY;
@@ -43,6 +44,7 @@
   SMM.onMouseUpSelColCanvas = function (evt) {
     evt.preventDefault();
     evt.stopPropagation();
+    if (!DVW.primaryMap) return;
     //When doing a shift drag, this block will actually do the selection on mouse up.
     var sumOffsetX = evt.touches ? evt.layerX : evt.offsetX;
     var sumOffsetY = evt.touches ? evt.layerY : evt.offsetY;
@@ -106,8 +108,8 @@
     SUM.canvas.style.cursor = "default";
     //Gotta redraw everything because of event cascade occurring when mousing out of the layers that contain the canvas
     // (container and summary_chm) we set the right position mousing up on the canvas above, but move events are still coming in.
-    if (DVW.detailMaps.length > 0) {
-      // only 'redraw everything' if there are detail maps showing
+    if (DVW.primaryMap) {
+      // only 'redraw everything' if there is a primary detail map.
       DVW.primaryMap.updateSelection();
     }
   };
@@ -163,14 +165,16 @@
         var startCol = Math.max(Math.min(clickStartCol, clickEndCol) + 1, 1);
         var endRow = Math.max(clickStartRow, clickEndRow);
         var endCol = Math.max(clickStartCol, clickEndCol);
-        DVW.primaryMap.selectedIsDendrogram = false;
-        DMM.setSubRibbonView(
-          DVW.primaryMap,
-          startRow,
-          endRow,
-          startCol,
-          endCol,
-        );
+        if (DVW.primaryMap) {
+          DVW.primaryMap.selectedIsDendrogram = false;
+          DMM.setSubRibbonView(
+            DVW.primaryMap,
+            startRow,
+            endRow,
+            startCol,
+            endCol,
+          );
+        }
       } else {
         var xPos = SUM.getCanvasX(sumOffsetX);
         var yPos = SUM.getCanvasY(sumOffsetY);

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -394,7 +394,7 @@
             }
           });
           // Try multiple common types for embedded data.
-          const txt = dt.getData("Application/json") || dt.getData("Application/json") || dt.getData("text/json");
+          const txt = dt.getData("application/json") || dt.getData("Application/json") || dt.getData("text/json");
           if (txt) handleDropData(txt);
           dropTarget.classList.remove("visible");
         } else if (eventName === "dragenter") {

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -562,6 +562,7 @@
       UIMGR.initializeSummaryWindows(heatMap);
       SUM.setHeatMap(heatMap);
       initializeLayersInterface(heatMap);
+      DMM.setPrimaryForHeatmap(heatMap);
       CUST.addCustomJS();
       if (firstTime) {
         UIMGR.configurePanelInterface(heatMap);
@@ -696,6 +697,7 @@
     }
     configureDragDropHandler();
     initializeDdrCallbacks();
+    SUM.createSummaryDendrograms(allHeatMaps);
     configurePageHeader(allHeatMaps);
     return;
     // Helper function.

--- a/NGCHM/WebContent/javascript/UI-Manager.js
+++ b/NGCHM/WebContent/javascript/UI-Manager.js
@@ -566,7 +566,7 @@
     // Call initially and whenever a heatMap is selected from the maps drop down.
     function selectHeatMap (heatMap, firstTime) {
       if (!srcInfo.embedded) {
-        document.title = `NG-CHM Viewer: ${heatMap.name}`;
+        document.title = `NG-CHM Viewer: ${heatMap.mapName}`;
       }
       MMGR.setHeatMap(heatMap);
       SRCH.configSearchInterface(heatMap);


### PR DESCRIPTION
This PR gives the user an initial ability to switch between NG-CHMs when multiple maps are loaded.

When the user switches maps:
- The summary panel, if visible, should switch to the new map
- The layers control should switch to the layers of the new map
- Existing detail views should remain unchanged
- If there was a primary detail view, it should cease being primary
- If there are detail views of the new map, one should become primary
- The summary panel, if visible, should show view outlines for only the detail views for the map

If a new detail view is opened, it should open on the currently selected NG-CHM.

The functionality we discussed in the meeting to visually distinguish different NG-CHMs will be contained in subsequent PR.

Modifications to other parts of the system (e.g. preferences manager, pdf generator, ...) to deal with changing the selected map will be contained in subsequent PRs. Their behavior in this PR is not defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Switch between multiple heat maps via a header dropdown; per-map dendrograms and primary detail map handling.
  - Enhanced layer controls: auto-setup with dropdown/flicks; flicks disabled when only one layer.
  - Drag-and-drop JSON to load linkout specifications.
- Bug Fixes
  - Prevent selection updates when no primary detail map is present.
  - Clear previous search results when resetting for a new heat map.
- Style
  - Browser tab title updated to “NG-CHM Viewer”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->