### PR TITLE
Update dependency docker base images and bump ver. to 2.27.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Requires Docker 17.06 CE or later
 #
 # Stage -1: Build ant
-FROM openjdk:11-jdk AS ant
+FROM eclipse-temurin:11-jdk AS ant
 
 RUN apt-get update && apt-get install -y ant
 
@@ -70,7 +70,7 @@ RUN mkdir -p ${BMAPGEN} &&\
     ant -f NGCHM/build_guibuildermapgen.xml -Dmapgen.path=${BMAPGEN}/GUIBuilderMapGen.jar
 
 # Final stage: copy artifacts from previous stages into a minimal layer
-FROM multiarch/true:x86_64
+FROM busybox:stable
 
 VOLUME /NGCHM
 

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -65,7 +65,7 @@
   // CURRENT VERSION NUMBER
   // WARNING: The line starting with 'CM.version = ' is used by .github/workflows/create-build-tag.yml for creating build tags
   // If making changes to the string 'CM.version = ', make corresponding changes to the 'start_string' in that action.
-  CM.version = "2.27.0"; // Please increment rightmost digit for each interim version
+  CM.version = "2.27.2"; // Please increment rightmost digit for each interim version
   CM.versionCheckUrl =
     "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
   CM.viewerAppUrl =


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker runtime base image updated to a more lightweight and minimal variant
  * Version updated to 2.27.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->