### PR TITLE
Update dependency docker base images and bump ver. to 2.27.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN mkdir -p ${BMAPGEN} &&\
     ant -f NGCHM/build_guibuildermapgen.xml -Dmapgen.path=${BMAPGEN}/GUIBuilderMapGen.jar
 
 # Final stage: copy artifacts from previous stages into a minimal layer
-FROM scratch
+FROM busybox:stable
 
 VOLUME /NGCHM
 

--- a/NGCHM/WebContent/javascript/CompatibilityManager.js
+++ b/NGCHM/WebContent/javascript/CompatibilityManager.js
@@ -65,7 +65,7 @@
   // CURRENT VERSION NUMBER
   // WARNING: The line starting with 'CM.version = ' is used by .github/workflows/create-build-tag.yml for creating build tags
   // If making changes to the string 'CM.version = ', make corresponding changes to the 'start_string' in that action.
-  CM.version = "2.27.1"; // Please increment rightmost digit for each interim version
+  CM.version = "2.27.2"; // Please increment rightmost digit for each interim version
   CM.versionCheckUrl =
     "https://bioinformatics.mdanderson.org/versioncheck/NGCHM/";
   CM.viewerAppUrl =


### PR DESCRIPTION
Base the volume container on busybox:stable.  We found "scratch" can not be used for this.